### PR TITLE
[rhel7] add initial support (qcow2, vhd, azure-rhui)

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 type repository struct {
-	Name       string `json:"name,omitempty"`
-	BaseURL    string `json:"baseurl,omitempty"`
-	Metalink   string `json:"metalink,omitempty"`
-	MirrorList string `json:"mirrorlist,omitempty"`
-	GPGKey     string `json:"gpgkey,omitempty"`
-	CheckGPG   bool   `json:"check_gpg,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	BaseURL     string   `json:"baseurl,omitempty"`
+	Metalink    string   `json:"metalink,omitempty"`
+	MirrorList  string   `json:"mirrorlist,omitempty"`
+	GPGKey      string   `json:"gpgkey,omitempty"`
+	CheckGPG    bool     `json:"check_gpg,omitempty"`
+	PackageSets []string `json:"package_sets,omitempty"`
 }
 
 type ostreeOptions struct {
@@ -126,12 +127,13 @@ func main() {
 			repoName = fmt.Sprintf("repo-%d", i)
 		}
 		repos[i] = rpmmd.RepoConfig{
-			Name:       repoName,
-			BaseURL:    repo.BaseURL,
-			Metalink:   repo.Metalink,
-			MirrorList: repo.MirrorList,
-			GPGKey:     repo.GPGKey,
-			CheckGPG:   repo.CheckGPG,
+			Name:        repoName,
+			BaseURL:     repo.BaseURL,
+			Metalink:    repo.Metalink,
+			MirrorList:  repo.MirrorList,
+			GPGKey:      repo.GPGKey,
+			CheckGPG:    repo.CheckGPG,
+			PackageSets: repo.PackageSets,
 		}
 	}
 

--- a/internal/distro/fedora/pipelines.go
+++ b/internal/distro/fedora/pipelines.go
@@ -619,7 +619,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -44,6 +44,7 @@ type ImageConfig struct {
 	WAAgentConfig      *osbuild2.WAAgentConfStageOptions
 	Grub2Config        *osbuild2.GRUB2Config
 	DNFAutomaticConfig *osbuild2.DNFAutomaticConfigStageOptions
+	YumConfig          *osbuild2.YumConfigStageOptions
 	YUMRepos           []*osbuild2.YumReposStageOptions
 	Firewall           *osbuild2.FirewallStageOptions
 	UdevRules          *osbuild2.UdevRulesStageOptions
@@ -131,6 +132,9 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.DNFAutomaticConfig == nil {
 			finalConfig.DNFAutomaticConfig = parentConfig.DNFAutomaticConfig
+		}
+		if finalConfig.YumConfig == nil {
+			finalConfig.YumConfig = parentConfig.YumConfig
 		}
 		if finalConfig.YUMRepos == nil {
 			finalConfig.YUMRepos = parentConfig.YUMRepos

--- a/internal/distro/rhel7/azure.go
+++ b/internal/distro/rhel7/azure.go
@@ -1,0 +1,452 @@
+package rhel7
+
+import (
+	"math/rand"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			// Defaults
+			"@Core",
+			"langpacks-en",
+
+			// From the lorax kickstart
+			"chrony",
+			"cloud-init",
+			"cloud-utils-growpart",
+			"gdisk",
+			"net-tools",
+			"python3",
+			"selinux-policy-targeted",
+			"WALinuxAgent",
+
+			// removed from defaults but required to boot in azure
+			"dhcp-client",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"rng-tools",
+		},
+	}.Append(bootPackageSet(t))
+}
+
+func azureRhuiCommonPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@base",
+			"@core",
+			"authconfig",
+			"bpftool",
+			"bzip2",
+			"chrony",
+			"cloud-init",
+			"cloud-utils-growpart",
+			"dracut-config-generic",
+			"dracut-norescue",
+			"efibootmgr",
+			"firewalld",
+			"gdisk",
+			"grub2-efi-x64",
+			"grub2-pc",
+			"grub2",
+			"hyperv-daemons",
+			"kernel",
+			"lvm2",
+			"redhat-release-eula",
+			"redhat-support-tool",
+			"rh-dotnetcore11",
+			"rhn-setup",
+			"rhui-azure-rhel7",
+			"rsync",
+			"shim-x64",
+			"tar",
+			"tcpdump",
+			"WALinuxAgent",
+			"yum-rhn-plugin",
+			"yum-utils",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"mariadb-libs",
+			"NetworkManager-config-server",
+			"postfix",
+		},
+	}.Append(bootPackageSet(t))
+}
+
+var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
+	distro.X86_64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Size: 68719476736,
+		Partitions: []disk.Partition{
+			{
+				Size: 524288000,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 524288000,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size:     2097152,
+				Bootable: true,
+				Type:     disk.BIOSBootPartitionGUID,
+				UUID:     disk.BIOSBootPartitionUUID,
+			},
+			{
+				Type: disk.LVMPartitionGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.LVMVolumeGroup{
+					Name:        "rootvg",
+					Description: "built with lvm2 and osbuild",
+					LogicalVolumes: []disk.LVMLogicalVolume{
+						{
+							Size: 1 * 1024 * 1024 * 1024,
+							Name: "homelv",
+							Payload: &disk.Filesystem{
+								Type:         "xfs",
+								Label:        "home",
+								Mountpoint:   "/home",
+								FSTabOptions: "defaults",
+								FSTabFreq:    0,
+								FSTabPassNo:  0,
+							},
+						},
+						{
+							Size: 2 * 1024 * 1024 * 1024,
+							Name: "rootlv",
+							Payload: &disk.Filesystem{
+								Type:         "xfs",
+								Label:        "root",
+								Mountpoint:   "/",
+								FSTabOptions: "defaults",
+								FSTabFreq:    0,
+								FSTabPassNo:  0,
+							},
+						},
+						{
+							Size: 2 * 1024 * 1024 * 1024,
+							Name: "tmplv",
+							Payload: &disk.Filesystem{
+								Type:         "xfs",
+								Label:        "tmp",
+								Mountpoint:   "/tmp",
+								FSTabOptions: "defaults",
+								FSTabFreq:    0,
+								FSTabPassNo:  0,
+							},
+						},
+						{
+							Size: 10 * 1024 * 1024 * 1024,
+							Name: "usrlv",
+							Payload: &disk.Filesystem{
+								Type:         "xfs",
+								Label:        "usr",
+								Mountpoint:   "/usr",
+								FSTabOptions: "defaults",
+								FSTabFreq:    0,
+								FSTabPassNo:  0,
+							},
+						},
+						{
+							Size: 10 * 1024 * 1024 * 1024, // firedrill: 8 GB
+							Name: "varlv",
+							Payload: &disk.Filesystem{
+								Type:         "xfs",
+								Label:        "var",
+								Mountpoint:   "/var",
+								FSTabOptions: "defaults",
+								FSTabFreq:    0,
+								FSTabPassNo:  0,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func vhdPipelines(compress bool) pipelinesFunc {
+	return func(t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetSpecs map[string][]rpmmd.PackageSpec, rng *rand.Rand) ([]osbuild.Pipeline, error) {
+		pipelines := make([]osbuild.Pipeline, 0)
+		pipelines = append(pipelines, *buildPipeline(repos, packageSetSpecs[buildPkgsKey], t.arch.distro.runner))
+
+		partitionTable, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
+		if err != nil {
+			return nil, err
+		}
+
+		treePipeline, err := osPipeline(t, repos, packageSetSpecs[osPkgsKey], customizations, options, partitionTable)
+		if err != nil {
+			return nil, err
+		}
+		pipelines = append(pipelines, *treePipeline)
+
+		diskfile := "disk.img"
+		kernelVer := rpmmd.GetVerStrFromPackageSpecListPanic(packageSetSpecs[osPkgsKey], customizations.GetKernel().Name)
+		imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, partitionTable, t.arch, kernelVer)
+		pipelines = append(pipelines, *imagePipeline)
+		if err != nil {
+			return nil, err
+		}
+
+		var qemufile string
+		if compress {
+			qemufile = "disk.vhd"
+		} else {
+			qemufile = t.filename
+		}
+
+		qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, qemufile, osbuild.QEMUFormatVPC, osbuild.VPCOptions{ForceSize: common.BoolToPtr(false)})
+		pipelines = append(pipelines, *qemuPipeline)
+
+		if compress {
+			lastPipeline := pipelines[len(pipelines)-1]
+			pipelines = append(pipelines, *xzArchivePipeline(lastPipeline.Name, qemufile, t.Filename()))
+		}
+
+		return pipelines, nil
+	}
+}
+
+var vhdImgType = imageType{
+	name:     "vhd",
+	filename: "disk.vhd",
+	mimeType: "application/x-vhd",
+	packageSets: map[string]packageSetFunc{
+		buildPkgsKey: distroBuildPackageSet,
+		osPkgsKey:    vhdCommonPackageSet,
+	},
+	packageSetChains: map[string][]string{
+		osPkgsKey: {osPkgsKey, blueprintPkgsKey},
+	},
+	defaultImageConfig: &distro.ImageConfig{
+		EnabledServices: []string{
+			"sshd",
+			"waagent",
+		},
+		DefaultTarget: "multi-user.target",
+	},
+	kernelOptions:       "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y",
+	bootable:            true,
+	defaultSize:         4 * GigaByte,
+	pipelines:           vhdPipelines(false),
+	buildPipelines:      []string{"build"},
+	payloadPipelines:    []string{"os", "image", "vpc"},
+	exports:             []string{"vpc"},
+	basePartitionTables: defaultBasePartitionTables,
+}
+
+var azureRhuiImgType = imageType{
+	name:     "azure-rhui",
+	filename: "disk.vhd.xz",
+	mimeType: "application/xz",
+	packageSets: map[string]packageSetFunc{
+		buildPkgsKey: distroBuildPackageSet,
+		osPkgsKey:    azureRhuiCommonPackageSet,
+	},
+	packageSetChains: map[string][]string{
+		osPkgsKey: {osPkgsKey, blueprintPkgsKey},
+	},
+	defaultImageConfig: &distro.ImageConfig{
+		Timezone: "Etc/UTC",
+		Locale:   "en_US.UTF-8",
+		GPGKeyFiles: []string{
+			"/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release",
+			"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+		},
+		Authconfig: &osbuild.AuthconfigStageOptions{},
+		Sysconfig: []*osbuild.SysconfigStageOptions{
+			{
+				Kernel: &osbuild.SysconfigKernelOptions{
+					UpdateDefault: true,
+					DefaultKernel: "kernel-core",
+				},
+				Network: &osbuild.SysconfigNetworkOptions{
+					Networking: true,
+					NoZeroConf: true,
+				},
+			},
+		},
+		EnabledServices: []string{
+			"cloud-config",
+			"cloud-final",
+			"cloud-init-local",
+			"cloud-init",
+			"firewalld",
+			"NetworkManager",
+			"sshd",
+			"waagent",
+		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				ClientAliveInterval: common.IntToPtr(180),
+			},
+		},
+		Modprobe: []*osbuild.ModprobeStageOptions{
+			{
+				Filename: "blacklist-nouveau.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+					osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
+				},
+			},
+			{
+				Filename: "blacklist-floppy.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+				},
+			},
+		},
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "06_logging_override.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Output: &osbuild.CloudInitConfigOutput{
+						All: common.StringToPtr("| tee -a /var/log/cloud-init-output.log"),
+					},
+				},
+			},
+			{
+				Filename: "10-azure-kvp.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Reporting: &osbuild.CloudInitConfigReporting{
+						Logging: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "log",
+						},
+						Telemetry: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "hyperv",
+						},
+					},
+				},
+			},
+			{
+				Filename: "91-azure_datasource.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Datasource: &osbuild.CloudInitConfigDatasource{
+						Azure: &osbuild.CloudInitConfigDatasourceAzure{
+							ApplyNetworkConfig: false,
+						},
+					},
+					DatasourceList: []string{
+						"Azure",
+					},
+				},
+			},
+		},
+		PwQuality: &osbuild.PwqualityConfStageOptions{
+			Config: osbuild.PwqualityConfConfig{
+				Minlen:   common.IntToPtr(6),
+				Minclass: common.IntToPtr(3),
+				Dcredit:  common.IntToPtr(0),
+				Ucredit:  common.IntToPtr(0),
+				Lcredit:  common.IntToPtr(0),
+				Ocredit:  common.IntToPtr(0),
+			},
+		},
+		WAAgentConfig: &osbuild.WAAgentConfStageOptions{
+			Config: osbuild.WAAgentConfig{
+				RDFormat:     common.BoolToPtr(false),
+				RDEnableSwap: common.BoolToPtr(false),
+			},
+		},
+		RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
+			distro.RHSMConfigNoSubscription: {
+				YumPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
+					SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+				SubMan: &osbuild.RHSMStageOptionsSubMan{
+					Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
+						AutoRegistration: common.BoolToPtr(true),
+					},
+					Rhsm: &osbuild.SubManConfigRHSMSection{
+						ManageRepos: common.BoolToPtr(false),
+					},
+				},
+			},
+			distro.RHSMConfigWithSubscription: {
+				SubMan: &osbuild.RHSMStageOptionsSubMan{
+					Rhsmcertd: &osbuild.SubManConfigRHSMCERTDSection{
+						AutoRegistration: common.BoolToPtr(true),
+					},
+					// do not disable the redhat.repo management if the user
+					// explicitly request the system to be subscribed
+				},
+			},
+		},
+		Grub2Config: &osbuild.GRUB2Config{
+			TerminalInput:  []string{"serial", "console"},
+			TerminalOutput: []string{"serial", "console"},
+			Serial:         "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+			Timeout:        10,
+		},
+		UdevRules: &osbuild.UdevRulesStageOptions{
+			Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+			Rules: osbuild.UdevRules{
+				osbuild.UdevRuleComment{
+					Comment: []string{
+						"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+						"This interface is transparently bonded to the synthetic interface,",
+						"so NetworkManager should just ignore any SRIOV interfaces.",
+					},
+				},
+				osbuild.NewUdevRule(
+					[]osbuild.UdevKV{
+						{K: "SUBSYSTEM", O: "==", V: "net"},
+						{K: "DRIVERS", O: "==", V: "hv_pci"},
+						{K: "ACTION", O: "==", V: "add"},
+						{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
+					},
+				),
+			},
+		},
+		YumConfig: &osbuild.YumConfigStageOptions{
+			Config: &osbuild.YumConfigConfig{
+				HttpCaching: common.StringToPtr("packages"),
+			},
+			Plugins: &osbuild.YumConfigPlugins{
+				Langpacks: &osbuild.YumConfigPluginsLangpacks{
+					Locales: []string{"en_US.UTF-8"},
+				},
+			},
+		},
+		DefaultTarget: "multi-user.target",
+	},
+	kernelOptions:       vhdImgType.kernelOptions,
+	bootable:            true,
+	defaultSize:         68719476736,
+	pipelines:           vhdPipelines(true),
+	buildPipelines:      []string{"build"},
+	payloadPipelines:    []string{"os", "image", "vpc", "archive"},
+	exports:             []string{"archive"},
+	basePartitionTables: azureRhuiBasePartitionTables,
+}

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -493,6 +493,8 @@ func newDistro(distroName string) distro.Distro {
 
 	x86_64.addImageTypes(
 		qcow2ImgType,
+		vhdImgType,
+		azureRhuiImgType,
 	)
 
 	rd.addArches(

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -1,0 +1,503 @@
+package rhel7
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+const (
+	// package set names
+
+	// build package set name
+	buildPkgsKey = "build"
+
+	// main/common os image package set name
+	osPkgsKey = "packages"
+
+	// blueprint package set name
+	blueprintPkgsKey = "blueprint"
+)
+
+var mountpointAllowList = []string{
+	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home", "/tmp",
+}
+
+// RHEL-based OS image configuration defaults
+var defaultDistroImageConfig = &distro.ImageConfig{
+	Timezone: "America/New_York",
+	Locale:   "en_US.UTF-8",
+	GPGKeyFiles: []string{
+		"/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+	},
+	Sysconfig: []*osbuild.SysconfigStageOptions{
+		{
+			Kernel: &osbuild.SysconfigKernelOptions{
+				UpdateDefault: true,
+				DefaultKernel: "kernel",
+			},
+			Network: &osbuild.SysconfigNetworkOptions{
+				Networking: true,
+				NoZeroConf: true,
+			},
+		},
+	},
+}
+
+// distribution objects without the arches > image types
+var distroMap = map[string]distribution{
+	"rhel-7": {
+		name:               "rhel-7",
+		product:            "Red Hat Enterprise Linux",
+		osVersion:          "7.9",
+		nick:               "Maipo",
+		releaseVersion:     "7",
+		modulePlatformID:   "platform:el7",
+		vendor:             "redhat",
+		runner:             "org.osbuild.rhel7",
+		defaultImageConfig: defaultDistroImageConfig,
+	},
+}
+
+// --- Distribution ---
+type distribution struct {
+	name               string
+	product            string
+	nick               string
+	osVersion          string
+	releaseVersion     string
+	modulePlatformID   string
+	vendor             string
+	runner             string
+	arches             map[string]distro.Arch
+	defaultImageConfig *distro.ImageConfig
+}
+
+func (d *distribution) Name() string {
+	return d.name
+}
+
+func (d *distribution) Releasever() string {
+	return d.releaseVersion
+}
+
+func (d *distribution) ModulePlatformID() string {
+	return d.modulePlatformID
+}
+
+func (d *distribution) OSTreeRef() string {
+	return "" // not supported
+}
+
+func (d *distribution) ListArches() []string {
+	archNames := make([]string, 0, len(d.arches))
+	for name := range d.arches {
+		archNames = append(archNames, name)
+	}
+	sort.Strings(archNames)
+	return archNames
+}
+
+func (d *distribution) GetArch(name string) (distro.Arch, error) {
+	arch, exists := d.arches[name]
+	if !exists {
+		return nil, errors.New("invalid architecture: " + name)
+	}
+	return arch, nil
+}
+
+func (d *distribution) addArches(arches ...architecture) {
+	if d.arches == nil {
+		d.arches = map[string]distro.Arch{}
+	}
+
+	// Do not make copies of architectures, as opposed to image types,
+	// because architecture definitions are not used by more than a single
+	// distro definition.
+	for idx := range arches {
+		d.arches[arches[idx].name] = &arches[idx]
+	}
+}
+
+func (d *distribution) isRHEL() bool {
+	return strings.HasPrefix(d.name, "rhel")
+}
+
+func (d *distribution) getDefaultImageConfig() *distro.ImageConfig {
+	return d.defaultImageConfig
+}
+
+// --- Architecture ---
+
+type architecture struct {
+	distro           *distribution
+	name             string
+	imageTypes       map[string]distro.ImageType
+	imageTypeAliases map[string]string
+	legacy           string
+	bootType         distro.BootType
+}
+
+func (a *architecture) Name() string {
+	return a.name
+}
+
+func (a *architecture) ListImageTypes() []string {
+	itNames := make([]string, 0, len(a.imageTypes))
+	for name := range a.imageTypes {
+		itNames = append(itNames, name)
+	}
+	sort.Strings(itNames)
+	return itNames
+}
+
+func (a *architecture) GetImageType(name string) (distro.ImageType, error) {
+	t, exists := a.imageTypes[name]
+	if !exists {
+		aliasForName, exists := a.imageTypeAliases[name]
+		if !exists {
+			return nil, errors.New("invalid image type: " + name)
+		}
+		t, exists = a.imageTypes[aliasForName]
+		if !exists {
+			panic(fmt.Sprintf("image type '%s' is an alias to a non-existing image type '%s'", name, aliasForName))
+		}
+	}
+	return t, nil
+}
+
+func (a *architecture) addImageTypes(imageTypes ...imageType) {
+	if a.imageTypes == nil {
+		a.imageTypes = map[string]distro.ImageType{}
+	}
+	for idx := range imageTypes {
+		it := imageTypes[idx]
+		it.arch = a
+		a.imageTypes[it.name] = &it
+		for _, alias := range it.nameAliases {
+			if a.imageTypeAliases == nil {
+				a.imageTypeAliases = map[string]string{}
+			}
+			if existingAliasFor, exists := a.imageTypeAliases[alias]; exists {
+				panic(fmt.Sprintf("image type alias '%s' for '%s' is already defined for another image type '%s'", alias, it.name, existingAliasFor))
+			}
+			a.imageTypeAliases[alias] = it.name
+		}
+	}
+}
+
+func (a *architecture) Distro() distro.Distro {
+	return a.distro
+}
+
+// --- Image Type ---
+type pipelinesFunc func(t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetSpecs map[string][]rpmmd.PackageSpec, rng *rand.Rand) ([]osbuild.Pipeline, error)
+
+type packageSetFunc func(t *imageType) rpmmd.PackageSet
+
+type imageType struct {
+	arch               *architecture
+	name               string
+	nameAliases        []string
+	filename           string
+	mimeType           string
+	packageSets        map[string]packageSetFunc
+	packageSetChains   map[string][]string
+	defaultImageConfig *distro.ImageConfig
+	kernelOptions      string
+	defaultSize        uint64
+	buildPipelines     []string
+	payloadPipelines   []string
+	exports            []string
+	pipelines          pipelinesFunc
+
+	// bootable image
+	bootable bool
+	// If set to a value, it is preferred over the architecture value
+	bootType distro.BootType
+	// List of valid arches for the image type
+	basePartitionTables distro.BasePartitionTableMap
+}
+
+func (t *imageType) Name() string {
+	return t.name
+}
+
+func (t *imageType) Arch() distro.Arch {
+	return t.arch
+}
+
+func (t *imageType) Filename() string {
+	return t.filename
+}
+
+func (t *imageType) MIMEType() string {
+	return t.mimeType
+}
+
+func (t *imageType) OSTreeRef() string {
+	// Not supported
+	return ""
+}
+
+func (t *imageType) Size(size uint64) uint64 {
+	const MegaByte = 1024 * 1024
+	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
+	if t.name == "vhd" && size%MegaByte != 0 {
+		size = (size/MegaByte + 1) * MegaByte
+	}
+	if size == 0 {
+		size = t.defaultSize
+	}
+	return size
+}
+
+func (t *imageType) getPackages(name string) rpmmd.PackageSet {
+	getter := t.packageSets[name]
+	if getter == nil {
+		return rpmmd.PackageSet{}
+	}
+
+	return getter(t)
+}
+
+func (t *imageType) PackageSets(bp blueprint.Blueprint, repos []rpmmd.RepoConfig) map[string][]rpmmd.PackageSet {
+	// merge package sets that appear in the image type with the package sets
+	// of the same name from the distro and arch
+	mergedSets := make(map[string]rpmmd.PackageSet)
+
+	imageSets := t.packageSets
+
+	for name := range imageSets {
+		mergedSets[name] = t.getPackages(name)
+	}
+
+	if _, hasPackages := imageSets[osPkgsKey]; !hasPackages {
+		// should this be possible??
+		mergedSets[osPkgsKey] = rpmmd.PackageSet{}
+	}
+
+	// every image type must define a 'build' package set
+	if _, hasBuild := imageSets[buildPkgsKey]; !hasBuild {
+		panic(fmt.Sprintf("'%s' image type has no '%s' package set defined", t.name, buildPkgsKey))
+	}
+
+	// blueprint packages
+	bpPackages := bp.GetPackages()
+	timezone, _ := bp.Customizations.GetTimezoneSettings()
+	if timezone != nil {
+		bpPackages = append(bpPackages, "chrony")
+	}
+
+	// if we have file system customization that will need to a new mount point
+	// the layout is converted to LVM so we need to corresponding packages
+	archName := t.arch.Name()
+	pt := t.basePartitionTables[archName]
+	haveNewMountpoint := false
+
+	if fs := bp.Customizations.GetFilesystems(); fs != nil {
+		for i := 0; !haveNewMountpoint && i < len(fs); i++ {
+			haveNewMountpoint = !pt.ContainsMountpoint(fs[i].Mountpoint)
+		}
+	}
+
+	if haveNewMountpoint {
+		bpPackages = append(bpPackages, "lvm2")
+	}
+
+	// depsolve bp packages separately
+	// bp packages aren't restricted by exclude lists
+	mergedSets[blueprintPkgsKey] = rpmmd.PackageSet{Include: bpPackages}
+	kernel := bp.Customizations.GetKernel().Name
+
+	// add bp kernel to main OS package set to avoid duplicate kernels
+	mergedSets[osPkgsKey] = mergedSets[osPkgsKey].Append(rpmmd.PackageSet{Include: []string{kernel}})
+
+	return distro.MakePackageSetChains(t, mergedSets, repos)
+}
+
+func (t *imageType) BuildPipelines() []string {
+	return t.buildPipelines
+}
+
+func (t *imageType) PayloadPipelines() []string {
+	return t.payloadPipelines
+}
+
+func (t *imageType) PayloadPackageSets() []string {
+	return []string{blueprintPkgsKey}
+}
+
+func (t *imageType) PackageSetsChains() map[string][]string {
+	return t.packageSetChains
+}
+
+func (t *imageType) Exports() []string {
+	if len(t.exports) == 0 {
+		panic(fmt.Sprintf("programming error: no exports for '%s'", t.name))
+	}
+	return t.exports
+}
+
+// getBootType returns the BootType which should be used for this particular
+// combination of architecture and image type.
+func (t *imageType) getBootType() distro.BootType {
+	bootType := t.arch.bootType
+	if t.bootType != distro.UnsetBootType {
+		bootType = t.bootType
+	}
+	return bootType
+}
+
+func (t *imageType) getPartitionTable(
+	mountpoints []blueprint.FilesystemCustomization,
+	options distro.ImageOptions,
+	rng *rand.Rand,
+) (*disk.PartitionTable, error) {
+	archName := t.arch.Name()
+
+	basePartitionTable, exists := t.basePartitionTables[archName]
+
+	if !exists {
+		return nil, fmt.Errorf("unknown arch: " + archName)
+	}
+
+	imageSize := t.Size(options.Size)
+
+	return disk.NewPartitionTable(&basePartitionTable, mountpoints, imageSize, true, rng)
+}
+
+func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
+	// ensure that image always returns non-nil default config
+	imageConfig := t.defaultImageConfig
+	if imageConfig == nil {
+		imageConfig = &distro.ImageConfig{}
+	}
+	return imageConfig.InheritFrom(t.arch.distro.getDefaultImageConfig())
+
+}
+
+func (t *imageType) PartitionType() string {
+	archName := t.arch.Name()
+	basePartitionTable, exists := t.basePartitionTables[archName]
+	if !exists {
+		return ""
+	}
+
+	return basePartitionTable.Type
+}
+
+func (t *imageType) Manifest(customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSpecSets map[string][]rpmmd.PackageSpec,
+	seed int64) (distro.Manifest, error) {
+
+	if err := t.checkOptions(customizations, options); err != nil {
+		return distro.Manifest{}, err
+	}
+
+	source := rand.NewSource(seed)
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	pipelines, err := t.pipelines(t, customizations, options, repos, packageSpecSets, rng)
+	if err != nil {
+		return distro.Manifest{}, err
+	}
+
+	// flatten spec sets for sources
+	allPackageSpecs := make([]rpmmd.PackageSpec, 0)
+	for _, specs := range packageSpecSets {
+		allPackageSpecs = append(allPackageSpecs, specs...)
+	}
+
+	return json.Marshal(
+		osbuild.Manifest{
+			Version:   "2",
+			Pipelines: pipelines,
+			Sources:   osbuild.GenSources(allPackageSpecs, nil, nil),
+		},
+	)
+}
+
+func isMountpointAllowed(mountpoint string) bool {
+	for _, allowed := range mountpointAllowList {
+		match, _ := path.Match(allowed, mountpoint)
+		if match {
+			return true
+		}
+		// ensure that only clean mountpoints
+		// are valid
+		if strings.Contains(mountpoint, "//") {
+			return false
+		}
+		match = strings.HasPrefix(mountpoint, allowed+"/")
+		if allowed != "/" && match {
+			return true
+		}
+	}
+	return false
+}
+
+// checkOptions checks the validity and compatibility of options and customizations for the image type.
+func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions) error {
+
+	mountpoints := customizations.GetFilesystems()
+
+	invalidMountpoints := []string{}
+	for _, m := range mountpoints {
+		if !isMountpointAllowed(m.Mountpoint) {
+			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
+		}
+	}
+
+	if len(invalidMountpoints) > 0 {
+		return fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
+	}
+
+	return nil
+}
+
+// New creates a new distro object, defining the supported architectures and image types
+func New() distro.Distro {
+	return newDistro("rhel-7")
+}
+
+func NewHostDistro(name, modulePlatformID, ostreeRef string) distro.Distro {
+	return newDistro("rhel-7")
+}
+
+func newDistro(distroName string) distro.Distro {
+
+	rd := distroMap[distroName]
+
+	// Architecture definitions
+	x86_64 := architecture{
+		name:     distro.X86_64ArchName,
+		distro:   &rd,
+		legacy:   "i386-pc",
+		bootType: distro.HybridBootType,
+	}
+
+	x86_64.addImageTypes(
+		qcow2ImgType,
+	)
+
+	rd.addArches(
+		x86_64,
+	)
+
+	return &rd
+}

--- a/internal/distro/rhel7/distro_test.go
+++ b/internal/distro/rhel7/distro_test.go
@@ -47,6 +47,22 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
+			name: "vhd",
+			args: args{"vhd"},
+			want: wantResult{
+				filename: "disk.vhd",
+				mimeType: "application/x-vhd",
+			},
+		},
+		{
+			name: "azure-rhui",
+			args: args{"azure-rhui"},
+			want: wantResult{
+				filename: "disk.vhd.xz",
+				mimeType: "application/xz",
+			},
+		},
+		{
 			name: "invalid-output-type",
 			args: args{"foobar"},
 			want: wantResult{wantErr: true},
@@ -128,6 +144,8 @@ func TestImageType_Name(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
+				"vhd",
+				"azure-rhui",
 			},
 		},
 	}
@@ -185,6 +203,8 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
+				"vhd",
+				"azure-rhui",
 			},
 		},
 	}

--- a/internal/distro/rhel7/distro_test.go
+++ b/internal/distro/rhel7/distro_test.go
@@ -1,0 +1,445 @@
+package rhel7_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel7"
+)
+
+type rhelFamilyDistro struct {
+	name   string
+	distro distro.Distro
+}
+
+var rhelFamilyDistros = []rhelFamilyDistro{
+	{
+		name:   "rhel",
+		distro: rhel7.New(),
+	},
+}
+
+func TestFilenameFromType(t *testing.T) {
+	type args struct {
+		outputFormat string
+	}
+	type wantResult struct {
+		filename string
+		mimeType string
+		wantErr  bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want wantResult
+	}{
+		{
+			name: "qcow2",
+			args: args{"qcow2"},
+			want: wantResult{
+				filename: "disk.qcow2",
+				mimeType: "application/x-qemu-disk",
+			},
+		},
+		{
+			name: "invalid-output-type",
+			args: args{"foobar"},
+			want: wantResult{wantErr: true},
+		},
+	}
+	for _, dist := range rhelFamilyDistros {
+		t.Run(dist.name, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					dist := dist.distro
+					arch, _ := dist.GetArch("x86_64")
+					imgType, err := arch.GetImageType(tt.args.outputFormat)
+					if (err != nil) != tt.want.wantErr {
+						t.Errorf("Arch.GetImageType() error = %v, wantErr %v", err, tt.want.wantErr)
+						return
+					}
+					if !tt.want.wantErr {
+						gotFilename := imgType.Filename()
+						gotMIMEType := imgType.MIMEType()
+						if gotFilename != tt.want.filename {
+							t.Errorf("ImageType.Filename()  got = %v, want %v", gotFilename, tt.want.filename)
+						}
+						if gotMIMEType != tt.want.mimeType {
+							t.Errorf("ImageType.MIMEType() got1 = %v, want %v", gotMIMEType, tt.want.mimeType)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestImageType_BuildPackages(t *testing.T) {
+	x8664BuildPackages := []string{
+		"dnf",
+		"dosfstools",
+		"e2fsprogs",
+		"grub2-efi-x64",
+		"grub2-pc",
+		"policycoreutils",
+		"shim-x64",
+		"systemd",
+		"tar",
+		"qemu-img",
+		"xz",
+	}
+	buildPackages := map[string][]string{
+		"x86_64": x8664BuildPackages,
+	}
+	for _, dist := range rhelFamilyDistros {
+		t.Run(dist.name, func(t *testing.T) {
+			d := dist.distro
+			for _, archLabel := range d.ListArches() {
+				archStruct, err := d.GetArch(archLabel)
+				if assert.NoErrorf(t, err, "d.GetArch(%v) returned err = %v; expected nil", archLabel, err) {
+					continue
+				}
+				for _, itLabel := range archStruct.ListImageTypes() {
+					itStruct, err := archStruct.GetImageType(itLabel)
+					if assert.NoErrorf(t, err, "d.GetArch(%v) returned err = %v; expected nil", archLabel, err) {
+						continue
+					}
+					buildPkgs := itStruct.PackageSets(blueprint.Blueprint{}, nil)["build"]
+					assert.NotNil(t, buildPkgs)
+					assert.Len(t, buildPkgs, 1)
+					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)
+				}
+			}
+		})
+	}
+}
+
+func TestImageType_Name(t *testing.T) {
+	imgMap := []struct {
+		arch     string
+		imgNames []string
+	}{
+		{
+			arch: "x86_64",
+			imgNames: []string{
+				"qcow2",
+			},
+		},
+	}
+
+	for _, dist := range rhelFamilyDistros {
+		t.Run(dist.name, func(t *testing.T) {
+			for _, mapping := range imgMap {
+				arch, err := dist.distro.GetArch(mapping.arch)
+				if assert.NoError(t, err) {
+					for _, imgName := range mapping.imgNames {
+						imgType, err := arch.GetImageType(imgName)
+						if assert.NoError(t, err) {
+							assert.Equalf(t, imgName, imgType.Name(), "arch: %s", mapping.arch)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// Check that Manifest() function returns an error for unsupported
+// configurations.
+func TestDistro_ManifestError(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Kernel: &blueprint.KernelCustomization{
+				Append: "debug",
+			},
+		},
+	}
+
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			imgOpts := distro.ImageOptions{
+				Size: imgType.Size(0),
+			}
+			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
+			_, err := imgType.Manifest(bp.Customizations, imgOpts, nil, testPackageSpecSets, 0)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestArchitecture_ListImageTypes(t *testing.T) {
+	imgMap := []struct {
+		arch                     string
+		imgNames                 []string
+		rhelAdditionalImageTypes []string
+	}{
+		{
+			arch: "x86_64",
+			imgNames: []string{
+				"qcow2",
+			},
+		},
+	}
+
+	for _, dist := range rhelFamilyDistros {
+		t.Run(dist.name, func(t *testing.T) {
+			for _, mapping := range imgMap {
+				arch, err := dist.distro.GetArch(mapping.arch)
+				require.NoError(t, err)
+				imageTypes := arch.ListImageTypes()
+
+				var expectedImageTypes []string
+				expectedImageTypes = append(expectedImageTypes, mapping.imgNames...)
+				if dist.name == "rhel" {
+					expectedImageTypes = append(expectedImageTypes, mapping.rhelAdditionalImageTypes...)
+				}
+
+				require.ElementsMatch(t, expectedImageTypes, imageTypes)
+			}
+		})
+	}
+}
+
+func TestRhel7_ListArches(t *testing.T) {
+	arches := rhel7.New().ListArches()
+	assert.Equal(t, []string{"x86_64"}, arches)
+}
+
+func TestRhel7_GetArch(t *testing.T) {
+	arches := []struct {
+		name                  string
+		errorExpected         bool
+		errorExpectedInCentos bool
+	}{
+		{
+			name: "x86_64",
+		},
+		{
+			name:          "foo-arch",
+			errorExpected: true,
+		},
+	}
+
+	for _, dist := range rhelFamilyDistros {
+		t.Run(dist.name, func(t *testing.T) {
+			for _, a := range arches {
+				actualArch, err := dist.distro.GetArch(a.name)
+				if a.errorExpected || (a.errorExpectedInCentos && dist.name == "centos") {
+					assert.Nil(t, actualArch)
+					assert.Error(t, err)
+				} else {
+					assert.Equal(t, a.name, actualArch.Name())
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRhel7_Name(t *testing.T) {
+	distro := rhel7.New()
+	assert.Equal(t, "rhel-7", distro.Name())
+}
+
+func TestRhel7_ModulePlatformID(t *testing.T) {
+	distro := rhel7.New()
+	assert.Equal(t, "platform:el7", distro.ModulePlatformID())
+}
+
+func TestRhel7_KernelOption(t *testing.T) {
+	distro_test_common.TestDistro_KernelOption(t, rhel7.New())
+}
+
+func TestDistro_CustomFileSystemManifestError(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/boot",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/boot\"]")
+		}
+	}
+}
+
+func TestDistro_TestRootMountPoint(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, 0)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/log",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/log/audit",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, 0)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b/c",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var/a/b/c/d",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, 0)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "//",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var//",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/var//log/audit/",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
+		}
+	}
+}
+
+func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/variable",
+				},
+				{
+					MinSize:    1024,
+					Mountpoint: "/variable/log/audit",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, 0)
+			assert.EqualError(t, err, "The following custom mountpoints are not supported [\"/variable\" \"/variable/log/audit\"]")
+		}
+	}
+}
+
+func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
+	r7distro := rhel7.New()
+	bp := blueprint.Blueprint{
+		Customizations: &blueprint.Customizations{
+			Filesystem: []blueprint.FilesystemCustomization{
+				{
+					MinSize:    1024,
+					Mountpoint: "/usr",
+				},
+			},
+		},
+	}
+	for _, archName := range r7distro.ListArches() {
+		arch, _ := r7distro.GetArch(archName)
+		for _, imgTypeName := range arch.ListImageTypes() {
+			imgType, _ := arch.GetImageType(imgTypeName)
+			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
+			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, 0)
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/internal/distro/rhel7/package_sets.go
+++ b/internal/distro/rhel7/package_sets.go
@@ -1,0 +1,124 @@
+package rhel7
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+// BUILD PACKAGE SETS
+
+// distro-wide build package set
+func distroBuildPackageSet(t *imageType) rpmmd.PackageSet {
+	ps := rpmmd.PackageSet{
+		Include: []string{
+			"dosfstools",
+			"e2fsprogs",
+			"gdisk",
+			"lvm2",
+			"parted",
+			"policycoreutils",
+			"python3",
+			"python3-iniparse",
+			"python3-PyYAML",
+			"qemu-img",
+			"rpm",
+			"selinux-policy-targeted",
+			"systemd",
+			"tar",
+			"util-linux",
+			"xfsprogs",
+			"xz",
+		},
+	}
+
+	switch t.arch.Name() {
+
+	case distro.X86_64ArchName:
+		ps = ps.Append(x8664BuildPackageSet(t))
+	}
+
+	return ps
+}
+
+// x86_64 build package set
+func x8664BuildPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"grub2-pc",
+		},
+	}
+}
+
+// BOOT PACKAGE SETS
+
+func bootPackageSet(t *imageType) rpmmd.PackageSet {
+	if !t.bootable {
+		return rpmmd.PackageSet{}
+	}
+
+	var addLegacyBootPkg bool
+	var addUEFIBootPkg bool
+
+	switch bt := t.getBootType(); bt {
+	case distro.LegacyBootType:
+		addLegacyBootPkg = true
+	case distro.UEFIBootType:
+		addUEFIBootPkg = true
+	case distro.HybridBootType:
+		addLegacyBootPkg = true
+		addUEFIBootPkg = true
+	default:
+		panic(fmt.Sprintf("unsupported boot type: %q", bt))
+	}
+
+	ps := rpmmd.PackageSet{}
+
+	switch t.arch.Name() {
+	case distro.X86_64ArchName:
+		if addLegacyBootPkg {
+			ps = ps.Append(x8664LegacyBootPackageSet(t))
+		}
+		if addUEFIBootPkg {
+			ps = ps.Append(x8664UEFIBootPackageSet(t))
+		}
+
+	default:
+		panic(fmt.Sprintf("unsupported boot arch: %s", t.arch.Name()))
+	}
+
+	return ps
+}
+
+// x86_64 Legacy arch-specific boot package set
+func x8664LegacyBootPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"dracut-config-generic",
+			"grub2-pc",
+		},
+	}
+}
+
+// x86_64 UEFI arch-specific boot package set
+func x8664UEFIBootPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"dracut-config-generic",
+			"efibootmgr",
+			"grub2-efi-x64",
+			"shim-x64",
+		},
+	}
+}
+
+// packages that are only in some (sub)-distributions
+func distroSpecificPackageSet(t *imageType) rpmmd.PackageSet {
+	if t.arch.distro.isRHEL() {
+		return rpmmd.PackageSet{
+			Include: []string{"insights-client"},
+		}
+	}
+	return rpmmd.PackageSet{}
+}

--- a/internal/distro/rhel7/partition_tables.go
+++ b/internal/distro/rhel7/partition_tables.go
@@ -1,0 +1,66 @@
+package rhel7
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+)
+
+// shared constants
+const GigaByte = 1024 * 1024 * 1024
+
+// ////////// Partition table //////////
+
+var defaultBasePartitionTables = distro.BasePartitionTableMap{
+	distro.X86_64ArchName: disk.PartitionTable{
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []disk.Partition{
+			{
+				Size:     1048576, // 1MB
+				Bootable: true,
+				Type:     disk.BIOSBootPartitionGUID,
+				UUID:     disk.BIOSBootPartitionUUID,
+			},
+			{
+				Size: 209715200, // 200 MB
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 524288000, // 500 MB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 2147483648, // 2GiB
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+}

--- a/internal/distro/rhel7/pipelines.go
+++ b/internal/distro/rhel7/pipelines.go
@@ -1,0 +1,340 @@
+package rhel7
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func buildPipeline(repos []rpmmd.RepoConfig, buildPackageSpecs []rpmmd.PackageSpec, runner string) *osbuild.Pipeline {
+	p := new(osbuild.Pipeline)
+	p.Name = "build"
+	p.Runner = runner
+	p.AddStage(osbuild.NewRPMStage(rpmStageOptions(repos), osbuild.NewRpmStageSourceFilesInputs(buildPackageSpecs)))
+	p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(true)))
+	return p
+}
+
+func prependKernelCmdlineStage(pipeline *osbuild.Pipeline, t *imageType, pt *disk.PartitionTable) *osbuild.Pipeline {
+	if t.arch.name == distro.S390xArchName {
+		rootFs := pt.FindMountable("/")
+		if rootFs == nil {
+			panic("s390x image must have a root filesystem, this is a programming error")
+		}
+		kernelStage := osbuild.NewKernelCmdlineStage(osbuild.NewKernelCmdlineStageOptions(rootFs.GetFSSpec().UUID, t.kernelOptions))
+		pipeline.Stages = append([]*osbuild.Stage{kernelStage}, pipeline.Stages...)
+	}
+	return pipeline
+}
+
+func osPipeline(t *imageType,
+	repos []rpmmd.RepoConfig,
+	packages []rpmmd.PackageSpec,
+	c *blueprint.Customizations,
+	options distro.ImageOptions,
+	pt *disk.PartitionTable) (*osbuild.Pipeline, error) {
+
+	imageConfig := t.getDefaultImageConfig()
+	p := new(osbuild.Pipeline)
+
+	p.Name = "os"
+	p.Build = "name:build"
+
+	rpmOptions := osbuild.NewRPMStageOptions(repos)
+	rpmOptions.GPGKeysFromTree = imageConfig.GPGKeyFiles
+	p.AddStage(osbuild.NewRPMStage(rpmOptions, osbuild.NewRpmStageSourceFilesInputs(packages)))
+
+	// Difference to RHEL8, 9 pipelines: no BLS stage
+
+	language, keyboard := c.GetPrimaryLocale()
+	if language != nil {
+		p.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: *language}))
+	} else {
+		p.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: imageConfig.Locale}))
+	}
+	if keyboard != nil {
+		p.AddStage(osbuild.NewKeymapStage(&osbuild.KeymapStageOptions{Keymap: *keyboard}))
+	} else if imageConfig.Keyboard != nil {
+		p.AddStage(osbuild.NewKeymapStage(imageConfig.Keyboard))
+	}
+
+	if hostname := c.GetHostname(); hostname != nil {
+		p.AddStage(osbuild.NewHostnameStage(&osbuild.HostnameStageOptions{Hostname: *hostname}))
+	}
+
+	timezone, ntpServers := c.GetTimezoneSettings()
+	if timezone != nil {
+		p.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: *timezone}))
+	} else {
+		p.AddStage(osbuild.NewTimezoneStage(&osbuild.TimezoneStageOptions{Zone: imageConfig.Timezone}))
+	}
+
+	if len(ntpServers) > 0 {
+		p.AddStage(osbuild.NewChronyStage(&osbuild.ChronyStageOptions{Timeservers: ntpServers}))
+	} else if imageConfig.TimeSynchronization != nil {
+		p.AddStage(osbuild.NewChronyStage(imageConfig.TimeSynchronization))
+	}
+
+	if groups := c.GetGroups(); len(groups) > 0 {
+		p.AddStage(osbuild.NewGroupsStage(osbuild.NewGroupsStageOptions(groups)))
+	}
+
+	if userOptions, err := osbuild.NewUsersStageOptions(c.GetUsers(), false); err != nil {
+		return nil, err
+	} else if userOptions != nil {
+		p.AddStage(osbuild.NewUsersStage(userOptions))
+	}
+
+	if services := c.GetServices(); services != nil || imageConfig.EnabledServices != nil ||
+		imageConfig.DisabledServices != nil || imageConfig.DefaultTarget != "" {
+		p.AddStage(osbuild.NewSystemdStage(systemdStageOptions(
+			imageConfig.EnabledServices,
+			imageConfig.DisabledServices,
+			services,
+			imageConfig.DefaultTarget,
+		)))
+	}
+
+	var fwStageOptions *osbuild.FirewallStageOptions
+	if firewallCustomization := c.GetFirewall(); firewallCustomization != nil {
+		fwStageOptions = firewallStageOptions(firewallCustomization)
+	}
+	if firewallConfig := imageConfig.Firewall; firewallConfig != nil {
+		// merge the user-provided firewall config with the default one
+		if fwStageOptions != nil {
+			fwStageOptions = &osbuild.FirewallStageOptions{
+				// Prefer the firewall ports and services settings provided
+				// via BP customization.
+				Ports:            fwStageOptions.Ports,
+				EnabledServices:  fwStageOptions.EnabledServices,
+				DisabledServices: fwStageOptions.DisabledServices,
+				// Default zone can not be set using BP customizations, therefore
+				// default to the one provided in the default image configuration.
+				DefaultZone: firewallConfig.DefaultZone,
+			}
+		} else {
+			fwStageOptions = firewallConfig
+		}
+	}
+	if fwStageOptions != nil {
+		p.AddStage(osbuild.NewFirewallStage(fwStageOptions))
+	}
+
+	for _, sysconfigConfig := range imageConfig.Sysconfig {
+		p.AddStage(osbuild.NewSysconfigStage(sysconfigConfig))
+	}
+
+	if t.arch.distro.isRHEL() {
+		if options.Subscription != nil {
+			commands := []string{
+				fmt.Sprintf("/usr/sbin/subscription-manager register --org=%s --activationkey=%s --serverurl %s --baseurl %s", options.Subscription.Organization, options.Subscription.ActivationKey, options.Subscription.ServerUrl, options.Subscription.BaseUrl),
+			}
+			if options.Subscription.Insights {
+				commands = append(commands, "/usr/bin/insights-client --register")
+			}
+			p.AddStage(osbuild.NewFirstBootStage(&osbuild.FirstBootStageOptions{
+				Commands:       commands,
+				WaitForNetwork: true,
+			}))
+
+			if rhsmConfig, exists := imageConfig.RHSMConfig[distro.RHSMConfigWithSubscription]; exists {
+				p.AddStage(osbuild.NewRHSMStage(rhsmConfig))
+			}
+		} else {
+			if rhsmConfig, exists := imageConfig.RHSMConfig[distro.RHSMConfigNoSubscription]; exists {
+				p.AddStage(osbuild.NewRHSMStage(rhsmConfig))
+			}
+		}
+	}
+
+	for _, systemdLogindConfig := range imageConfig.SystemdLogind {
+		p.AddStage(osbuild.NewSystemdLogindStage(systemdLogindConfig))
+	}
+
+	for _, cloudInitConfig := range imageConfig.CloudInit {
+		p.AddStage(osbuild.NewCloudInitStage(cloudInitConfig))
+	}
+
+	for _, modprobeConfig := range imageConfig.Modprobe {
+		p.AddStage(osbuild.NewModprobeStage(modprobeConfig))
+	}
+
+	for _, dracutConfConfig := range imageConfig.DracutConf {
+		p.AddStage(osbuild.NewDracutConfStage(dracutConfConfig))
+	}
+
+	for _, systemdUnitConfig := range imageConfig.SystemdUnit {
+		p.AddStage(osbuild.NewSystemdUnitStage(systemdUnitConfig))
+	}
+
+	if authselectConfig := imageConfig.Authselect; authselectConfig != nil {
+		p.AddStage(osbuild.NewAuthselectStage(authselectConfig))
+	}
+
+	if seLinuxConfig := imageConfig.SELinuxConfig; seLinuxConfig != nil {
+		p.AddStage(osbuild.NewSELinuxConfigStage(seLinuxConfig))
+	}
+
+	if tunedConfig := imageConfig.Tuned; tunedConfig != nil {
+		p.AddStage(osbuild.NewTunedStage(tunedConfig))
+	}
+
+	for _, tmpfilesdConfig := range imageConfig.Tmpfilesd {
+		p.AddStage(osbuild.NewTmpfilesdStage(tmpfilesdConfig))
+	}
+
+	for _, pamLimitsConfConfig := range imageConfig.PamLimitsConf {
+		p.AddStage(osbuild.NewPamLimitsConfStage(pamLimitsConfConfig))
+	}
+
+	for _, sysctldConfig := range imageConfig.Sysctld {
+		p.AddStage(osbuild.NewSysctldStage(sysctldConfig))
+	}
+
+	for _, dnfConfig := range imageConfig.DNFConfig {
+		p.AddStage(osbuild.NewDNFConfigStage(dnfConfig))
+	}
+
+	if sshdConfig := imageConfig.SshdConfig; sshdConfig != nil {
+		p.AddStage((osbuild.NewSshdConfigStage(sshdConfig)))
+	}
+
+	if authConfig := imageConfig.Authconfig; authConfig != nil {
+		p.AddStage(osbuild.NewAuthconfigStage(authConfig))
+	}
+
+	if pwQuality := imageConfig.PwQuality; pwQuality != nil {
+		p.AddStage(osbuild.NewPwqualityConfStage(pwQuality))
+	}
+
+	if waConfig := imageConfig.WAAgentConfig; waConfig != nil {
+		p.AddStage(osbuild.NewWAAgentConfStage(waConfig))
+	}
+
+	if yumConfig := imageConfig.YumConfig; yumConfig != nil {
+		p.AddStage(osbuild.NewYumConfigStage(yumConfig))
+	}
+
+	for _, yumRepo := range imageConfig.YUMRepos {
+		p.AddStage(osbuild.NewYumReposStage(yumRepo))
+	}
+
+	if udevRules := imageConfig.UdevRules; udevRules != nil {
+		p.AddStage(osbuild.NewUdevRulesStage(udevRules))
+	}
+
+	if pt != nil {
+
+		kernelOptions := osbuild.GenImageKernelOptions(pt)
+		if t.kernelOptions != "" {
+			kernelOptions = append(kernelOptions, t.kernelOptions)
+		}
+		if bpKernel := c.GetKernel(); bpKernel.Append != "" {
+			kernelOptions = append(kernelOptions, bpKernel.Append)
+		}
+
+		p.AddStage(osbuild.NewFSTabStage(osbuild.NewFSTabStageOptions(pt)))
+		kernelVer := rpmmd.GetVerStrFromPackageSpecListPanic(packages, c.GetKernel().Name)
+
+		var bootloader *osbuild.Stage
+		if t.arch.name == distro.S390xArchName {
+			p = prependKernelCmdlineStage(p, t, pt)
+			bootloader = osbuild.NewZiplStage(new(osbuild.ZiplStageOptions))
+		} else {
+			product := osbuild.GRUB2Product{
+				Name:    t.arch.distro.product,
+				Version: t.arch.distro.osVersion,
+				Nick:    t.arch.distro.nick,
+			}
+
+			ver, _ := rpmmd.GetVerStrFromPackageSpecList(packages, "dracut-config-rescue")
+			haveRescue := ver != ""
+
+			id := "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+			entries := osbuild.MakeGrub2MenuEntries(id, kernelVer, product, haveRescue)
+
+			var vendor string // whether to boot via uefi, and if so the vendor
+			var legacy string // whether to boot via legacy, and if so the platform
+
+			bt := t.getBootType()
+
+			if bt == distro.HybridBootType || bt == distro.LegacyBootType {
+				legacy = t.arch.legacy
+			}
+
+			if bt == distro.HybridBootType || bt == distro.UEFIBootType {
+				vendor = t.arch.distro.vendor
+			}
+
+			// we rely on stage option validation to detect invalid boot configurations
+			options := osbuild.NewGrub2LegacyStageOptions(
+				imageConfig.Grub2Config,
+				pt,
+				kernelOptions,
+				legacy,
+				vendor,
+				entries,
+			)
+			bootloader = osbuild.NewGrub2LegacyStage(options)
+		}
+
+		p.AddStage(bootloader)
+	}
+
+	p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
+
+	return p, nil
+}
+
+func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk.PartitionTable, arch *architecture, kernelVer string) *osbuild.Pipeline {
+	p := new(osbuild.Pipeline)
+	p.Name = "image"
+	p.Build = "name:build"
+
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSgdisk) {
+		p.AddStage(stage)
+	}
+
+	inputName := "root-tree"
+	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, inputPipelineName, outputFilename, pt)
+	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, inputPipelineName)
+	p.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
+
+	for _, stage := range osbuild.GenImageFinishStages(pt, outputFilename) {
+		p.AddStage(stage)
+	}
+
+	loopback := osbuild.NewLoopbackDevice(&osbuild.LoopbackDeviceOptions{Filename: outputFilename})
+	p.AddStage(bootloaderInstStage(outputFilename, pt, arch, kernelVer, copyDevices, copyMounts, loopback))
+	return p
+}
+
+func qemuPipeline(inputPipelineName, inputFilename, outputFilename string, format osbuild.QEMUFormat, formatOptions osbuild.QEMUFormatOptions) *osbuild.Pipeline {
+	p := new(osbuild.Pipeline)
+	p.Name = string(format)
+	p.Build = "name:build"
+
+	qemuStage := osbuild.NewQEMUStage(
+		osbuild.NewQEMUStageOptions(outputFilename, format, formatOptions),
+		osbuild.NewQemuStagePipelineFilesInputs(inputPipelineName, inputFilename),
+	)
+	p.AddStage(qemuStage)
+	return p
+}
+
+func xzArchivePipeline(inputPipelineName, inputFilename, outputFilename string) *osbuild.Pipeline {
+	p := new(osbuild.Pipeline)
+	p.Name = "archive"
+	p.Build = "name:build"
+
+	p.AddStage(osbuild.NewXzStage(
+		osbuild.NewXzStageOptions(outputFilename),
+		osbuild.NewFilesInputs(osbuild.NewFilesInputReferencesPipeline(inputPipelineName, inputFilename)),
+	))
+
+	return p
+}

--- a/internal/distro/rhel7/qcow2.go
+++ b/internal/distro/rhel7/qcow2.go
@@ -1,0 +1,152 @@
+package rhel7
+
+import (
+	"math/rand"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
+	ps := rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+			"kernel",
+			"nfs-utils",
+			"yum-utils",
+
+			"cloud-init",
+			//"ovirt-guest-agent-common",
+			"rhn-setup",
+			"yum-rhn-plugin",
+			"cloud-utils-growpart",
+			"dracut-config-generic",
+			"tar",
+			"tcpdump",
+			"rsync",
+		},
+		Exclude: []string{
+			"biosdevname",
+			"dracut-config-rescue",
+			"iprutils",
+			"NetworkManager-team",
+			"NetworkManager-tui",
+			"NetworkManager",
+			"plymouth",
+
+			"aic94xx-firmware",
+			"alsa-firmware",
+			"alsa-lib",
+			"alsa-tools-firmware",
+			"ivtv-firmware",
+			"iwl1000-firmware",
+			"iwl100-firmware",
+			"iwl105-firmware",
+			"iwl135-firmware",
+			"iwl2000-firmware",
+			"iwl2030-firmware",
+			"iwl3160-firmware",
+			"iwl3945-firmware",
+			"iwl4965-firmware",
+			"iwl5000-firmware",
+			"iwl5150-firmware",
+			"iwl6000-firmware",
+			"iwl6000g2a-firmware",
+			"iwl6000g2b-firmware",
+			"iwl6050-firmware",
+			"iwl7260-firmware",
+			"libertas-sd8686-firmware",
+			"libertas-sd8787-firmware",
+			"libertas-usb8388-firmware",
+		},
+	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
+
+	return ps
+}
+
+func qcow2Pipelines(t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetSpecs map[string][]rpmmd.PackageSpec, rng *rand.Rand) ([]osbuild.Pipeline, error) {
+	pipelines := make([]osbuild.Pipeline, 0)
+	pipelines = append(pipelines, *buildPipeline(repos, packageSetSpecs[buildPkgsKey], t.arch.distro.runner))
+
+	partitionTable, err := t.getPartitionTable(customizations.GetFilesystems(), options, rng)
+	if err != nil {
+		return nil, err
+	}
+
+	treePipeline, err := osPipeline(t, repos, packageSetSpecs[osPkgsKey], customizations, options, partitionTable)
+	if err != nil {
+		return nil, err
+	}
+	pipelines = append(pipelines, *treePipeline)
+
+	diskfile := "disk.img"
+	kernelVer := rpmmd.GetVerStrFromPackageSpecListPanic(packageSetSpecs[osPkgsKey], customizations.GetKernel().Name)
+	imagePipeline := liveImagePipeline(treePipeline.Name, diskfile, partitionTable, t.arch, kernelVer)
+	pipelines = append(pipelines, *imagePipeline)
+
+	qemuPipeline := qemuPipeline(imagePipeline.Name, diskfile, t.filename, osbuild.QEMUFormatQCOW2, osbuild.QCOW2Options{Compat: "0.10"})
+	pipelines = append(pipelines, *qemuPipeline)
+
+	return pipelines, nil
+}
+
+var qcow2ImgType = imageType{
+	name:          "qcow2",
+	filename:      "disk.qcow2",
+	mimeType:      "application/x-qemu-disk",
+	kernelOptions: "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+	packageSets: map[string]packageSetFunc{
+		buildPkgsKey: distroBuildPackageSet,
+		osPkgsKey:    qcow2CommonPackageSet,
+	},
+	defaultImageConfig: &distro.ImageConfig{
+		DefaultTarget: "multi-user.target",
+		Sysconfig: []*osbuild.SysconfigStageOptions{
+			{
+				Kernel: &osbuild.SysconfigKernelOptions{
+					UpdateDefault: true,
+					DefaultKernel: "kernel",
+				},
+				Network: &osbuild.SysconfigNetworkOptions{
+					Networking: true,
+					NoZeroConf: true,
+				},
+				NetworkScripts: &osbuild.NetworkScriptsOptions{
+					IfcfgFiles: map[string]osbuild.IfcfgFile{
+						"eth0": {
+							Device:    "eth0",
+							Bootproto: osbuild.IfcfgBootprotoDHCP,
+							OnBoot:    common.BoolToPtr(true),
+							Type:      osbuild.IfcfgTypeEthernet,
+							UserCtl:   common.BoolToPtr(true),
+							PeerDNS:   common.BoolToPtr(true),
+							IPv6Init:  common.BoolToPtr(false),
+						},
+					},
+				},
+			},
+		},
+		RHSMConfig: map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions{
+			distro.RHSMConfigNoSubscription: {
+				YumPlugins: &osbuild.RHSMStageOptionsDnfPlugins{
+					ProductID: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+					SubscriptionManager: &osbuild.RHSMStageOptionsDnfPlugin{
+						Enabled: false,
+					},
+				},
+			},
+		},
+	},
+	bootable:            true,
+	defaultSize:         10 * GigaByte,
+	pipelines:           qcow2Pipelines,
+	buildPipelines:      []string{"build"},
+	payloadPipelines:    []string{"os", "image", "qcow2"},
+	exports:             []string{"qcow2"},
+	basePartitionTables: defaultBasePartitionTables,
+}

--- a/internal/distro/rhel7/stage_options.go
+++ b/internal/distro/rhel7/stage_options.go
@@ -1,0 +1,80 @@
+package rhel7
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func bootloaderInstStage(filename string, pt *disk.PartitionTable, arch *architecture, kernelVer string, devices *osbuild.Devices, mounts *osbuild.Mounts, disk *osbuild.Device) *osbuild.Stage {
+	platform := arch.legacy
+	if platform != "" {
+		return osbuild.NewGrub2InstStage(osbuild.NewGrub2InstStageOption(filename, pt, platform))
+	}
+
+	if arch.name == distro.S390xArchName {
+		return osbuild.NewZiplInstStage(osbuild.NewZiplInstStageOptions(kernelVer, pt), disk, devices, mounts)
+	}
+
+	return nil
+}
+
+func rpmStageOptions(repos []rpmmd.RepoConfig) *osbuild.RPMStageOptions {
+	var gpgKeys []string
+	for _, repo := range repos {
+		if repo.GPGKey == "" {
+			continue
+		}
+		gpgKeys = append(gpgKeys, repo.GPGKey)
+	}
+
+	return &osbuild.RPMStageOptions{
+		GPGKeys: gpgKeys,
+	}
+}
+
+// selinuxStageOptions returns the options for the org.osbuild.selinux stage.
+// Setting the argument to 'true' relabels the '/usr/bin/cp' and '/usr/bin/tar'
+// binaries with 'install_exec_t'. This should be set in the build root.
+func selinuxStageOptions(labelcp bool) *osbuild.SELinuxStageOptions {
+	options := &osbuild.SELinuxStageOptions{
+		FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
+	}
+	if labelcp {
+		options.Labels = map[string]string{
+			"/usr/bin/cp":  "system_u:object_r:install_exec_t:s0",
+			"/usr/bin/tar": "system_u:object_r:install_exec_t:s0",
+		}
+	} else {
+		options.ForceAutorelabel = common.BoolToPtr(true)
+	}
+	return options
+}
+
+func firewallStageOptions(firewall *blueprint.FirewallCustomization) *osbuild.FirewallStageOptions {
+	options := osbuild.FirewallStageOptions{
+		Ports: firewall.Ports,
+	}
+
+	if firewall.Services != nil {
+		options.EnabledServices = firewall.Services.Enabled
+		options.DisabledServices = firewall.Services.Disabled
+	}
+
+	return &options
+}
+
+func systemdStageOptions(enabledServices, disabledServices []string, s *blueprint.ServicesCustomization, target string) *osbuild.SystemdStageOptions {
+	if s != nil {
+		enabledServices = append(enabledServices, s.Enabled...)
+		disabledServices = append(disabledServices, s.Disabled...)
+	}
+	return &osbuild.SystemdStageOptions{
+		EnabledServices:  enabledServices,
+		DisabledServices: disabledServices,
+		DefaultTarget:    target,
+	}
+}

--- a/internal/distro/rhel84/distro_backports.go
+++ b/internal/distro/rhel84/distro_backports.go
@@ -61,7 +61,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -1664,7 +1664,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distro/rhel86/pipelines.go
+++ b/internal/distro/rhel86/pipelines.go
@@ -1065,7 +1065,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -1060,7 +1060,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distro/rhel90beta/pipelines.go
+++ b/internal/distro/rhel90beta/pipelines.go
@@ -1051,7 +1051,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 	p.Name = "image"
 	p.Build = "name:build"
 
-	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename) {
+	for _, stage := range osbuild.GenImagePrepareStages(pt, outputFilename, osbuild.PTSfdisk) {
 		p.AddStage(stage)
 	}
 

--- a/internal/distroregistry/distroregistry.go
+++ b/internal/distroregistry/distroregistry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
+	"github.com/osbuild/osbuild-composer/internal/distro/rhel7"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel8"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel84"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel85"
@@ -22,6 +23,7 @@ var supportedDistros = []supportedDistro{
 	{fedora.NewF34, fedora.NewHostDistro},
 	{fedora.NewF35, fedora.NewHostDistro},
 	{fedora.NewF36, fedora.NewHostDistro},
+	{rhel7.New, rhel7.NewHostDistro},
 	{rhel8.New, rhel8.NewHostDistro},
 	{rhel84.New, rhel84.NewHostDistro},
 	{rhel85.New, rhel85.NewHostDistro},

--- a/internal/osbuild2/disk.go
+++ b/internal/osbuild2/disk.go
@@ -9,9 +9,9 @@ import (
 // sfdiskStageOptions creates the options and devices properties for an
 // org.osbuild.sfdisk stage based on a partition table description
 func sfdiskStageOptions(pt *disk.PartitionTable) *SfdiskStageOptions {
-	partitions := make([]Partition, len(pt.Partitions))
+	partitions := make([]SfdiskPartition, len(pt.Partitions))
 	for idx, p := range pt.Partitions {
-		partitions[idx] = Partition{
+		partitions[idx] = SfdiskPartition{
 			Bootable: p.Bootable,
 			Start:    pt.BytesToSectors(p.Start),
 			Size:     pt.BytesToSectors(p.Size),

--- a/internal/osbuild2/grub2_legacy_stage.go
+++ b/internal/osbuild2/grub2_legacy_stage.go
@@ -1,0 +1,227 @@
+package osbuild2
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/disk"
+)
+
+type GRUB2FSDesc struct {
+	Device string     `json:"device,omitempty"`
+	Label  string     `json:"label,omitempty"`
+	UUID   *uuid.UUID `json:"uuid,omitempty"`
+}
+
+func (d GRUB2FSDesc) validate() error {
+
+	have := make([]string, 0, 3)
+	if d.Device != "" {
+		have = append(have, "`device`")
+	}
+
+	if d.Label != "" {
+		have = append(have, "`label`")
+	}
+
+	if d.UUID != nil {
+		have = append(have, "`uuid`")
+	}
+
+	count := len(have)
+	if count == 0 {
+		return fmt.Errorf("need `device`, `label`, or `uuid`")
+	} else if count > 1 {
+		return fmt.Errorf("must only specify one of %s", strings.Join(have, ", "))
+	}
+
+	return nil
+}
+
+type GRUB2Product struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Nick    string `json:"nick,omitempty"`
+}
+
+func (p GRUB2Product) validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("need `Name`")
+	}
+	if p.Version == "" {
+		return fmt.Errorf("need `Version`")
+	}
+	return nil
+}
+
+type GRUB2MenuEntry struct {
+	Default *bool        `json:"default,omitempty"`
+	Id      string       `json:"id,omitempty"`
+	Kernel  string       `json:"kernel,omitempty"`
+	Product GRUB2Product `json:"product,omitempty"`
+}
+
+func (e GRUB2MenuEntry) validate() (err error) {
+	if e.Id == "" {
+		return fmt.Errorf("need `Id`")
+	}
+	if e.Kernel == "" {
+		return fmt.Errorf("need `Kernel`")
+	}
+	if err = e.Product.validate(); err != nil {
+		return fmt.Errorf("`Product` error: %w", err)
+	}
+	return nil
+}
+
+type GRUB2BIOS struct {
+	Platform string `json:"platform,"`
+}
+
+type GRUB2LegacyConfig struct {
+	GRUB2Config
+	CmdLine     string `json:"cmdline,omitempty"`
+	Distributor string `json:"distributor,omitempty"`
+}
+
+type GRUB2LegacyStageOptions struct {
+	// Required
+	RootFS  GRUB2FSDesc      `json:"rootfs"`
+	Entries []GRUB2MenuEntry `json:"entries"`
+
+	// One of
+	BIOS *GRUB2BIOS `json:"bios,omitempty"`
+	UEFI *GRUB2UEFI `json:"uefi,omitempty"`
+
+	// Optional
+	BootFS        *GRUB2FSDesc       `json:"bootfs,omitempty"`
+	WriteDefaults *bool              `json:"write_defaults,omitempty"`
+	Config        *GRUB2LegacyConfig `json:"config,omitempty"`
+}
+
+func (GRUB2LegacyStageOptions) isStageOptions() {}
+
+func MakeGrub2MenuEntries(id string, kernelVer string, product GRUB2Product, rescue bool) []GRUB2MenuEntry {
+	entries := []GRUB2MenuEntry{
+		{
+			Default: common.BoolToPtr(true),
+			Id:      id,
+			Product: product,
+			Kernel:  kernelVer,
+		},
+	}
+
+	if rescue {
+		entry := GRUB2MenuEntry{
+			Id:      id,
+			Product: product,
+			Kernel:  "0-rescue-ffffffffffffffffffffffffffffffff",
+		}
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func NewGrub2LegacyStageOptions(cfg *GRUB2Config,
+	pt *disk.PartitionTable,
+	kernelOptions []string,
+	legacy string,
+	uefi string,
+	entries []GRUB2MenuEntry) *GRUB2LegacyStageOptions {
+
+	rootFs := pt.FindMountable("/")
+	if rootFs == nil {
+		panic("root filesystem must be defined for grub2 stage, this is a programming error")
+	}
+
+	kopts := strings.Join(kernelOptions, " ")
+
+	rootFsUUID := uuid.MustParse(rootFs.GetFSSpec().UUID)
+	stageOptions := GRUB2LegacyStageOptions{
+		RootFS:  GRUB2FSDesc{UUID: &rootFsUUID},
+		Entries: entries,
+		Config: &GRUB2LegacyConfig{
+			CmdLine:     kopts,
+			Distributor: "$(sed 's, release .*$,,g' /etc/system-release)",
+		},
+	}
+
+	if cfg != nil {
+		stageOptions.Config.GRUB2Config = *cfg
+	}
+
+	bootFs := pt.FindMountable("/boot")
+	if bootFs != nil {
+		bootFsUUID := uuid.MustParse(bootFs.GetFSSpec().UUID)
+		stageOptions.BootFS = &GRUB2FSDesc{UUID: &bootFsUUID}
+	}
+
+	if legacy != "" {
+		stageOptions.BIOS = &GRUB2BIOS{
+			Platform: legacy,
+		}
+	}
+
+	if uefi != "" {
+		stageOptions.UEFI = &GRUB2UEFI{
+			Vendor: uefi,
+		}
+	}
+
+	return &stageOptions
+}
+
+func (o GRUB2LegacyStageOptions) validate() error {
+	// Check we have the required options
+	err := o.RootFS.validate()
+	if err != nil {
+		return fmt.Errorf("`rootfs` error: %w", err)
+	}
+
+	if o.BIOS == nil && o.UEFI == nil {
+		return fmt.Errorf("need `BIOS` or `UEFI`")
+	}
+
+	if o.BIOS != nil && o.BIOS.Platform == "" {
+		return fmt.Errorf("need `BIOS.Platform`")
+	}
+
+	if o.UEFI != nil && o.UEFI.Vendor == "" {
+		return fmt.Errorf("need `UEFI.Vendor`")
+	}
+
+	if len(o.Entries) == 0 {
+		return fmt.Errorf("at least one entry is required")
+	}
+
+	for i, entry := range o.Entries {
+		if err = entry.validate(); err != nil {
+			return fmt.Errorf("menu entry %d: %w", i, err)
+		}
+	}
+
+	// check optional arguments
+	if o.BootFS != nil {
+		err = o.BootFS.validate()
+		if err != nil {
+			return fmt.Errorf("`bootfs` error: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func NewGrub2LegacyStage(options *GRUB2LegacyStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(fmt.Errorf("grub2.legacy validation failed: %w", err))
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.grub2.legacy",
+		Options: options,
+	}
+}

--- a/internal/osbuild2/grub2_legacy_stage_test.go
+++ b/internal/osbuild2/grub2_legacy_stage_test.go
@@ -1,0 +1,34 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrub2LegacyStage_Validation(t *testing.T) {
+
+	options := GRUB2LegacyStageOptions{}
+
+	err := options.validate()
+	assert.Error(t, err)
+
+	options.RootFS.Device = "/dev/sda"
+	err = options.validate()
+	assert.Error(t, err)
+
+	prod := GRUB2Product{
+		Name:    "Fedora",
+		Nick:    "Foo",
+		Version: "1",
+	}
+	options.Entries = MakeGrub2MenuEntries("id", "kernel", prod, false)
+	err = options.validate()
+	assert.Error(t, err)
+
+	options.BIOS = &GRUB2BIOS{
+		Platform: "i386-pc",
+	}
+	err = options.validate()
+	assert.NoError(t, err)
+}

--- a/internal/osbuild2/qemu_stage.go
+++ b/internal/osbuild2/qemu_stage.go
@@ -85,6 +85,9 @@ func (o VDIOptions) formatType() QEMUFormat {
 type VPCOptions struct {
 	// The type of the format must be 'vpc'
 	Type QEMUFormat `json:"type"`
+
+	// VPC related options
+	ForceSize *bool `json:"force_size,omitempty"`
 }
 
 func (VPCOptions) isQEMUFormatOptions() {}

--- a/internal/osbuild2/qemu_stage_test.go
+++ b/internal/osbuild2/qemu_stage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -130,6 +131,20 @@ func TestNewQEMUStageOptions(t *testing.T) {
 				Filename: "image.vpc",
 				Format: VPCOptions{
 					Type: QEMUFormatVPC,
+				},
+			},
+		},
+		{
+			Filename: "image.vpc",
+			Format:   QEMUFormatVPC,
+			FormatOptions: VPCOptions{
+				ForceSize: common.BoolToPtr(false),
+			},
+			ExpectedOptions: &QEMUStageOptions{
+				Filename: "image.vpc",
+				Format: VPCOptions{
+					Type:      QEMUFormatVPC,
+					ForceSize: common.BoolToPtr(false),
 				},
 			},
 		},

--- a/internal/osbuild2/sfdisk_stage.go
+++ b/internal/osbuild2/sfdisk_stage.go
@@ -10,13 +10,13 @@ type SfdiskStageOptions struct {
 	UUID string `json:"uuid"`
 
 	// Partition layout
-	Partitions []Partition `json:"partitions,omitempty"`
+	Partitions []SfdiskPartition `json:"partitions,omitempty"`
 }
 
 func (SfdiskStageOptions) isStageOptions() {}
 
 // Description of a partition
-type Partition struct {
+type SfdiskPartition struct {
 	// Mark the partition as bootable (dos)
 	Bootable bool `json:"bootable,omitempty"`
 

--- a/internal/osbuild2/sfdisk_stage_test.go
+++ b/internal/osbuild2/sfdisk_stage_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNewSfdiskStage(t *testing.T) {
 
-	partition := Partition{
+	partition := SfdiskPartition{
 		Bootable: true,
 		Name:     "root",
 		Size:     2097152,
@@ -20,7 +20,7 @@ func TestNewSfdiskStage(t *testing.T) {
 	options := SfdiskStageOptions{
 		Label:      "gpt",
 		UUID:       "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Partitions: []Partition{partition},
+		Partitions: []SfdiskPartition{partition},
 	}
 
 	device := NewLoopbackDevice(&LoopbackDeviceOptions{Filename: "disk.raw"})

--- a/internal/osbuild2/sgdisk_stage.go
+++ b/internal/osbuild2/sgdisk_stage.go
@@ -1,0 +1,46 @@
+package osbuild2
+
+// Partition a target using sgdisk(8)
+
+import (
+	"github.com/google/uuid"
+)
+
+type SgdiskStageOptions struct {
+	// UUID for the disk image's partition table
+	UUID uuid.UUID `json:"uuid"`
+
+	// Partition layout
+	Partitions []SgdiskPartition `json:"partitions,omitempty"`
+}
+
+func (SgdiskStageOptions) isStageOptions() {}
+
+// Description of a partition
+type SgdiskPartition struct {
+	// Mark the partition as bootable (dos)
+	Bootable bool `json:"bootable,omitempty"`
+
+	// The partition name
+	Name string `json:"name,omitempty"`
+
+	// The size of the partition (sectors)
+	Size uint64 `json:"size,omitempty"`
+
+	// The start offset of the partition (sectors)
+	Start uint64 `json:"start,omitempty"`
+
+	// The partition type
+	Type string `json:"type,omitempty"`
+
+	// UUID of the partition
+	UUID *uuid.UUID `json:"uuid,omitempty"`
+}
+
+func NewSgdiskStage(options *SgdiskStageOptions, device *Device) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.sgdisk",
+		Options: options,
+		Devices: Devices{"device": *device},
+	}
+}

--- a/internal/osbuild2/sgdisk_stage_test.go
+++ b/internal/osbuild2/sgdisk_stage_test.go
@@ -1,0 +1,38 @@
+package osbuild2
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSgdiskStage(t *testing.T) {
+
+	uid := uuid.MustParse("68B2905B-DF3E-4FB3-80FA-49D1E773AA33")
+	partition := SgdiskPartition{
+		Bootable: true,
+		Name:     "root",
+		Size:     2097152,
+		Start:    0,
+		Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+		UUID:     &uid,
+	}
+
+	options := SgdiskStageOptions{
+		UUID:       uuid.MustParse("D209C89E-EA5E-4FBD-B161-B461CCE297E0"),
+		Partitions: []SgdiskPartition{partition},
+	}
+
+	device := NewLoopbackDevice(&LoopbackDeviceOptions{Filename: "disk.raw"})
+	devices := Devices{"device": *device}
+
+	expectedStage := &Stage{
+		Type:    "org.osbuild.sgdisk",
+		Options: &options,
+		Devices: devices,
+	}
+
+	actualStage := NewSgdiskStage(&options, device)
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
@@ -1,0 +1,11394 @@
+{
+  "compose-request": {
+    "distro": "rhel-7",
+    "arch": "x86_64",
+    "image-type": "azure-rhui",
+    "repositories": [
+      {
+        "name": "server",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530"
+      },
+      {
+        "name": "server-extras",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530"
+      },
+      {
+        "name": "server-optional",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-optional-r7.9-20220530"
+      },
+      {
+        "name": "server-dotnet",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530"
+      },
+      {
+        "name": "rhel-eng",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
+      },
+      {
+        "name": "azure-rhui-7",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+      }
+    ],
+    "filename": "disk.vhd",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.rhel7",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+                  },
+                  {
+                    "id": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+                  },
+                  {
+                    "id": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+                  },
+                  {
+                    "id": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+                  },
+                  {
+                    "id": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+                  },
+                  {
+                    "id": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+                  },
+                  {
+                    "id": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+                  },
+                  {
+                    "id": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+                  },
+                  {
+                    "id": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+                  },
+                  {
+                    "id": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+                  },
+                  {
+                    "id": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+                  },
+                  {
+                    "id": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+                  },
+                  {
+                    "id": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+                  },
+                  {
+                    "id": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+                  },
+                  {
+                    "id": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+                  },
+                  {
+                    "id": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  }
+                ]
+              }
+            },
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:315b1c75761f80eb7a2905319f8f6c16926ad9f04a3ebab2a3b205d36da82745"
+                  },
+                  {
+                    "id": "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655"
+                  },
+                  {
+                    "id": "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0"
+                  },
+                  {
+                    "id": "sha256:fca63e69026cd824dbe1d0ba051894e2bb63b3277d5a01c42fda7accc909b6a9"
+                  },
+                  {
+                    "id": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
+                  },
+                  {
+                    "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+                  },
+                  {
+                    "id": "sha256:b94ecd37a58dc42572a099e62c68d449e9c46e857031520d2734c04d4500b801"
+                  },
+                  {
+                    "id": "sha256:988b25517fadb0af5a9d96ebbaea08b8eaff964d987b93c4687a94af0c436a56"
+                  },
+                  {
+                    "id": "sha256:a08cd4a656134c5923c4ad980c0bb2b5027a7ad73f99ee268127b48f961f7478"
+                  },
+                  {
+                    "id": "sha256:512db073b9eaecb7d9f5b8cfd16fd1f7ca213ce98f9f77d3e859a2680601e8b5"
+                  },
+                  {
+                    "id": "sha256:a69a9c804aca28b14c8bc7ab65238ecf9a13ee5081b0172377edf007d0def5aa"
+                  },
+                  {
+                    "id": "sha256:86e6a979b9ddfa18c910cb38fa1f9d133761939c2a866a5f594f94124d6d0a43"
+                  },
+                  {
+                    "id": "sha256:57cf80287c438875891cbf68322b3ae37682fd2a3c54d7ff247630239dbb2fd2"
+                  },
+                  {
+                    "id": "sha256:05b11d41594ae949abd8f0f65f265dd815fb1ae2e8618bb3be63a7b7062be100"
+                  },
+                  {
+                    "id": "sha256:cf2b99d65041c66e7c71016facdfd1149131f4375b95509307d348472a008713"
+                  },
+                  {
+                    "id": "sha256:2a63a5dc60cbc1cd87af739663f4becd6e05b46bf7daf28e092142f9b140469b"
+                  },
+                  {
+                    "id": "sha256:448840196e3439f64d64ac56e71d5e2e1d83b7100aeca7ac2719d70e7913f5e6"
+                  },
+                  {
+                    "id": "sha256:972ceab21a6657b69dad156a8af938be7242524b52dec1759f7d69e5e555b277"
+                  },
+                  {
+                    "id": "sha256:2ecf5b8dbb340dd2d3e87909a48db4e2fe640b4d6fbe582ee313388bd1ed61cb"
+                  },
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:978c60b716fd39216dede943a6149f2673a6277b534f5310190dd765e5b0010c"
+                  },
+                  {
+                    "id": "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0"
+                  },
+                  {
+                    "id": "sha256:e70333dc0e327dd19cd56dd2ad8251ba42920b88ee38718ba99fa1d0f9b06913"
+                  },
+                  {
+                    "id": "sha256:005d3c65516a8021aac3e640d498a5fafe7f86eb7848009aed399a42730aa79f"
+                  },
+                  {
+                    "id": "sha256:2ec491fcbf33117f504cacfff9f2332fd89c260c56355c1d463e7ebc9b11f04e"
+                  },
+                  {
+                    "id": "sha256:8d9f342e8cfe60b59ac65145b7db24f5f4b7ef9de9f7af458c514955c2fd56e7"
+                  },
+                  {
+                    "id": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+                  },
+                  {
+                    "id": "sha256:e87571e303e233bbbaed2bfa760111850b8ad262772a73861e62721da31f04d7"
+                  },
+                  {
+                    "id": "sha256:5c72631f154e7cbfa12f04df7e3b2efcfd6f5c77a0fa7a30b684001a277cae0b"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:1b69e24543d83757d4f6b14167a3b8c777f214eb21caa309598a4177423f61de"
+                  },
+                  {
+                    "id": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+                  },
+                  {
+                    "id": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+                  },
+                  {
+                    "id": "sha256:f486a12e4b85857e9f9f66b665e4a65b094e287e31762d22d032cb7c94277ede"
+                  },
+                  {
+                    "id": "sha256:311477ee57b269f9693a70931066ef2852c030557fb3c61313308af71bf46b94"
+                  },
+                  {
+                    "id": "sha256:3d24d7a5ff7832751ccee0b6acbbef45cea0154ba4f038fc0cce045a30460ae3"
+                  },
+                  {
+                    "id": "sha256:0d3b093a48d64797df3a93d7dec2d26554efbece0ede5c6d4b90347ae4a9e1c4"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f"
+                  },
+                  {
+                    "id": "sha256:2e725765793b2f83faaec043d050f138b0c9e6c24d1fb7fe455e3743135d3c60"
+                  },
+                  {
+                    "id": "sha256:9b1dfc6830cce0e4292348f46adb357bb9177d9bc34f10ec4148addfd9fc10c2"
+                  },
+                  {
+                    "id": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+                  },
+                  {
+                    "id": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+                  },
+                  {
+                    "id": "sha256:a5e3bfb580c6f5e199ea5114bcdd10b395cd5f705c81aa021dc2238fc9de472a"
+                  },
+                  {
+                    "id": "sha256:848e44f6fccdd7be3de701153a87acfc6c50c93161d8d7e5f38e2b499b508fdb"
+                  },
+                  {
+                    "id": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+                  },
+                  {
+                    "id": "sha256:f09c7f9cbd9e60531ee2311cfd8ec6a76a6a7d7cebe2ba8d520e333176fbc650"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:c4703397f0a79f8f9f47549f3c535ef7c650bc169b5fbe67dfa5699f2ae91e18"
+                  },
+                  {
+                    "id": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+                  },
+                  {
+                    "id": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:645ae25a1ff4f52ed840eb5d93043596c3c84fa4c36e117678e57f10423586c8"
+                  },
+                  {
+                    "id": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+                  },
+                  {
+                    "id": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+                  },
+                  {
+                    "id": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+                  },
+                  {
+                    "id": "sha256:9b47cda1043733241a300ee9313c588f3a2f47b66b199bd625febdd3e454357f"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:f18f1203a701537f33df24e384493d038346d423475219d1d74c003cbe9cc264"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+                  },
+                  {
+                    "id": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+                  },
+                  {
+                    "id": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+                  },
+                  {
+                    "id": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+                  },
+                  {
+                    "id": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+                  },
+                  {
+                    "id": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+                  },
+                  {
+                    "id": "sha256:8292047f2f3599b9b32d87143cf717bdb39f65de65a618ebcb864ec19b7b4d7a"
+                  },
+                  {
+                    "id": "sha256:5f05c450273ead37b116bc141378fc2da9ac7096c2ecbd11bb4d41aed000fcfd"
+                  },
+                  {
+                    "id": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+                  },
+                  {
+                    "id": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+                  },
+                  {
+                    "id": "sha256:12b5567baa42fc4200d7a02264d8bae115c4a3ead6f04fb634d6f8243988e3e8"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+                  },
+                  {
+                    "id": "sha256:24d1e9b218aa1c0649bafabeb78234deee3ef0388c372cb621dee67e74a64370"
+                  },
+                  {
+                    "id": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+                  },
+                  {
+                    "id": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+                  },
+                  {
+                    "id": "sha256:a11590a762d0990e1c9d0b9f702af5c7925d50950ec8ad889e6e1f128d3c28c3"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+                  },
+                  {
+                    "id": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+                  },
+                  {
+                    "id": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+                  },
+                  {
+                    "id": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+                  },
+                  {
+                    "id": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+                  },
+                  {
+                    "id": "sha256:25f29adfb9ba39f408b7c268bd6e089e901593f1c36840ebb59e801afef0430c"
+                  },
+                  {
+                    "id": "sha256:9fa4df8bc1cf44c15afcbefc132af31a3cf10092efe11cf7f07995918b2d9f48"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:d029559bf7ec180b3c1d698cbc2d3f4d7988cc9f17ec40ae62e4da90c4816d35"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:14ea0df235cd8b92e60655961c88d3ea801e81bfab0f39f8356e934948b9185f"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+                  },
+                  {
+                    "id": "sha256:8ae96665d13a50a59f51837fa400670368c6c88fa02528132e889d28071b5348"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+                  },
+                  {
+                    "id": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+                  },
+                  {
+                    "id": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+                  },
+                  {
+                    "id": "sha256:ab255e1e536cbc9e8dc453892ac6f6dcd4b73b20740bb20b9c39fedcd4266107"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+                  },
+                  {
+                    "id": "sha256:0242b754ddce29e5a16f952a132c0181457f98312c4e1c5c31afa8e4358102ca"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+                  },
+                  {
+                    "id": "sha256:ad851567ad8d5c79b1f26a98c77f67e5630790c8cd08bc58583a34dac023cd4b"
+                  },
+                  {
+                    "id": "sha256:4d5368561d92f2a57a443e5f161b289c3862ec677906634c6bca536c3e0860b0"
+                  },
+                  {
+                    "id": "sha256:d4c4630f794b5538d8947a5317a69e7dabd7072c2de2f9e39e77cd6c992ac576"
+                  },
+                  {
+                    "id": "sha256:da015b114f953919b376173d378507d79bd79352960606fe2c941a53543da473"
+                  },
+                  {
+                    "id": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+                  },
+                  {
+                    "id": "sha256:9cbd12093d658f57664a1e385a5d38401b6c99e70f0b1cca029236ce950bf77d"
+                  },
+                  {
+                    "id": "sha256:2367c7a15f8067150791d2f485693249a0f65a970b1b3e7e1d5d82768173304b"
+                  },
+                  {
+                    "id": "sha256:88ca4efd493183e4def9ceaf63e5a07be6bbb1eea11b84dd66213d677e68d9bd"
+                  },
+                  {
+                    "id": "sha256:dcb552bcfe95d9f7d30cd11370a3bb1cc106eb1f56c57cbc8a92afa128bcdc7b"
+                  },
+                  {
+                    "id": "sha256:bd5524100101fc58617dd09216349a130ac7e44b9886e702b46c47d507b796f6"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+                  },
+                  {
+                    "id": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+                  },
+                  {
+                    "id": "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee"
+                  },
+                  {
+                    "id": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+                  },
+                  {
+                    "id": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+                  },
+                  {
+                    "id": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+                  },
+                  {
+                    "id": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+                  },
+                  {
+                    "id": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+                  },
+                  {
+                    "id": "sha256:d69952b6417c422f416fe3baddd49dec88a26cd826749961ee24b6721977a2ce"
+                  },
+                  {
+                    "id": "sha256:8303f7eb2f02a0d34fd34cb8c266c0eab46918411d6bb40d2462d7072da89107"
+                  },
+                  {
+                    "id": "sha256:12d3f2ca7449af3e3a3cff8be6b024cd1106987f49a7be16a84fa9bb39f2dde9"
+                  },
+                  {
+                    "id": "sha256:7d15ad33bec7d5bdc64074edaecff6019f590069b5375de7640c7df7e8e3776d"
+                  },
+                  {
+                    "id": "sha256:97dfbf353c370ee92b04a856a883255217528af0cfcbc9f234531efe71c043e6"
+                  },
+                  {
+                    "id": "sha256:11ac559bb43266411c847e259a1bb111ee67b4fdc09c3d9dbf6e91094f815e0f"
+                  },
+                  {
+                    "id": "sha256:12b098f5666193520fc84a092ce438a39f8c3ff53f7a7c4eee55e6515b49618c"
+                  },
+                  {
+                    "id": "sha256:f4e8763f1a42799dbcbada6f3c7f7f0943c89d9f5369bb750ea067a6e7a5ce4b"
+                  },
+                  {
+                    "id": "sha256:7e3edabd3ad60028285e194934644e087602c2440a672dc8c05996afb044ece4"
+                  },
+                  {
+                    "id": "sha256:aced7b9842dab221f2ca286c7532c9342e81fff0df3f09c4f265ec3fa83d4ece"
+                  },
+                  {
+                    "id": "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8"
+                  },
+                  {
+                    "id": "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244"
+                  },
+                  {
+                    "id": "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a"
+                  },
+                  {
+                    "id": "sha256:a37d2eeb9810427888dfe2eea1712441e0bb91e74f93d2166a8978a29f82ca98"
+                  },
+                  {
+                    "id": "sha256:d866a841fa8afa3b5f4210f172d4eb78aafaa13b0de26ccbea708779fb746b14"
+                  },
+                  {
+                    "id": "sha256:a3dc70cc6472c7eb9d1216acc144a6dceb48bdb69955f01b8585cd80ffdd538a"
+                  },
+                  {
+                    "id": "sha256:0b4110cf94f7f793dbabb7a1a616087455ab316ec74ad5204abb0fd2f211ee58"
+                  },
+                  {
+                    "id": "sha256:33fba59c069f63b29ac955363d97683c582178f5e314d594c452b8a630a59170"
+                  },
+                  {
+                    "id": "sha256:58ce6f65f4b61dfcb190deac65fca0cc210abfdae65b54a88ee5f61c61e3e47e"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+                  },
+                  {
+                    "id": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+                  },
+                  {
+                    "id": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+                  },
+                  {
+                    "id": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+                  },
+                  {
+                    "id": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+                  },
+                  {
+                    "id": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+                  },
+                  {
+                    "id": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:8c91e2e8241f222a2ca540011b58cfdf10b581ae9c6eacdf235bad5da31009f5"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:b59fc16e525b857da2333a7354eec6d1721588e3f7a6714088652a57a32d85ee"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:a85e9f5cbe6f217ed678b18abe2009ab96a0a448ac1140d2dacde37a7fb4f78f"
+                  },
+                  {
+                    "id": "sha256:ca24f6143d050170b1ac8558ebb34aaea23f271e558ce33cf895bd8267f43475"
+                  },
+                  {
+                    "id": "sha256:99c5dddb22433a4991da81bec61c535ce73ac78228ed4532e64761a77c31942f"
+                  },
+                  {
+                    "id": "sha256:683ee2641d3562d86c587971a43828110908202066520bd7027871de0b0487b3"
+                  },
+                  {
+                    "id": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+                  },
+                  {
+                    "id": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:e29916f4a360db8235f2130273d6bd60be00611cd8d626ec14f6e143f1e946c6"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:bb7b02048bc98c2f62e62ce67f36eb54cfcbf53f763ea0cd557053d20b2a2682"
+                  },
+                  {
+                    "id": "sha256:688dbfd142affe8b88385239fd072973abadd2223634322b0b84e201cdb3b046"
+                  },
+                  {
+                    "id": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+                  },
+                  {
+                    "id": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+                  },
+                  {
+                    "id": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:3d21b95e0248c86ffaff71a1df85fd7073ab09dc05874fd8a6940eab6edac6fd"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+                  },
+                  {
+                    "id": "sha256:9b8a185b88e6d414b5d744aabd5817950d112a8f351bff3c2a01b1ab2b766b1e"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+                  },
+                  {
+                    "id": "sha256:6ff39c0b322acbf413a853deeb745d2f68c7843c55f5352ea56cc5d94548ee9d"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:7567202eb027a1efb739092a6204307d735db326cf92a2c979201e36d841a284"
+                  },
+                  {
+                    "id": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+                  },
+                  {
+                    "id": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+                  },
+                  {
+                    "id": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+                  },
+                  {
+                    "id": "sha256:2e56f3449308538a955393ca85e4908d9022885fa34894cb365669b9d38de282"
+                  },
+                  {
+                    "id": "sha256:535aec9847767995152b43de3f8323e53c7c36decf894ca6e426742fb1507322"
+                  },
+                  {
+                    "id": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+                  },
+                  {
+                    "id": "sha256:aeb22ef9ac260054a3641602a021740b6d0985cbddc60bc00ce2b3279017ca1c"
+                  },
+                  {
+                    "id": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:096652bf46e6ed5a256632cb11ca56d660830e60f4fdca3b254bb5d4b1ba3d7c"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:10c1e258fd2bbc90f1ddf5082676ad9b0c748faa5f7968039e16ce9eace381e4"
+                  },
+                  {
+                    "id": "sha256:2345c8acf8cf82a953622d784b2200fd114a3b52fe92b3864929d305618424bc"
+                  },
+                  {
+                    "id": "sha256:11fc857bbb8e1ae64b236afcecf7d741b73d66a99d65e0014f1da0e45f3b3140"
+                  },
+                  {
+                    "id": "sha256:641326bddc57b01e75135caff060a9b94fb26f9a322df71a53a4138540148b09"
+                  },
+                  {
+                    "id": "sha256:b5a9f5afb8cc541d689a44146b51c3aca035068f9649393f7e8b0e981b22f8de"
+                  },
+                  {
+                    "id": "sha256:9719db8c12246ac32792b5cc42142e4c1fdc084eb47210623600202ae120b87e"
+                  },
+                  {
+                    "id": "sha256:e88107f8fa81c9322a1c04e3de4f8459cef9d3b30a8c7763c1c8e22abc70fb5b"
+                  },
+                  {
+                    "id": "sha256:52b0f84c76826cc370f665ae358e9525e2a374446fc680b3eada61520ab0c1e0"
+                  },
+                  {
+                    "id": "sha256:00bae5c24b3d71b20e66526b17f74457d0be31a17f005e3bf0abab0e61e19e97"
+                  },
+                  {
+                    "id": "sha256:da67098eeba3936506e2fcd15e5332d4afffe37e31b97f9170bea8ce9ceafd76"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:8054fbbaf33682c5c93c39f068bda45fd83df0eed913a6c3102c078c24f4f9d7"
+                  },
+                  {
+                    "id": "sha256:ef6fe84eab681d8549d44ab81ebb8c1ef2c147fa2b90df34cc1dab70b21df355"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:b46266a836d3630b3ee29954714e25e45e1a721a10516661c594490c45365e87"
+                  },
+                  {
+                    "id": "sha256:2edbe67c9f917f0f26c9caf326f59045209f40d474c1d586ad64b24babe04727"
+                  },
+                  {
+                    "id": "sha256:8287097d72794f1eb40ba7e4da1eaf7d010724f7bcbbd6b33381bb9a9e0bda93"
+                  },
+                  {
+                    "id": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+                  },
+                  {
+                    "id": "sha256:9ecef8165f4dae5f3e31ff14bc762c927a0cabed1342f1db9422f5599b6f26ee"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:93503e6622050a007698e4649903b26f7c76b207461c5e97c9215437a33b031f"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:a676654d1700d3fd065951eb022ca49800ae5f8f41d6828504e2e5b23293bab7"
+                  },
+                  {
+                    "id": "sha256:31c3efd8249034f7a5b00c5c87cface914234c10c3f55c95a81fb621466c3b0e"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+                  },
+                  {
+                    "id": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+                  },
+                  {
+                    "id": "sha256:52119268a72a5b22af74b0d71fcfd6c8b2ac6237c161b5eb628f345fa52704da"
+                  },
+                  {
+                    "id": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+                  },
+                  {
+                    "id": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+                  },
+                  {
+                    "id": "sha256:2a2f4b503c06c43f5a838109b40134e0663efeb92c00d6b725ef52f2ffedc6e7"
+                  },
+                  {
+                    "id": "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+                  },
+                  {
+                    "id": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+                  },
+                  {
+                    "id": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+                  },
+                  {
+                    "id": "sha256:b40290eeee6074620408362d136df5336e221399544480ebfba773fd90a08485"
+                  },
+                  {
+                    "id": "sha256:589adacd70beea80aabbd1ed217632f98a3ee4a327622a86aeb83fb05bd2de4d"
+                  },
+                  {
+                    "id": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+                  },
+                  {
+                    "id": "sha256:1afd06d4eafb5bb6d2e5098a498d5eccc9d06f5e5413ce35ce0fb08eccfd6175"
+                  },
+                  {
+                    "id": "sha256:95f881bf85e0867c2023d85d5b86b78835e6997a1078cdc52d727d2ac89e4ae7"
+                  },
+                  {
+                    "id": "sha256:12e5a19c594ccbce0507ce57297b8305033a07c474c9d4c176d70545e1a20b23"
+                  },
+                  {
+                    "id": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+                  },
+                  {
+                    "id": "sha256:f0fcbddda64a9b621d19f72adbc09e35dbeb3d258d55e2a5883c7734e26522d2"
+                  },
+                  {
+                    "id": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+                  },
+                  {
+                    "id": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+                  },
+                  {
+                    "id": "sha256:2540ffdba1bfc89714d18489247193d661ec5ac342159c3f5907e13981cf5a21"
+                  },
+                  {
+                    "id": "sha256:5aa53274792dcf7e419e57a7af5d17c9edad42a0caf6c71b007c2e1f86bd1dfb"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+                  },
+                  {
+                    "id": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+                  },
+                  {
+                    "id": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:de9f33935b91553ca6880aecde850fbdb92b81786e87c7e04329c4d896320d3c"
+                  },
+                  {
+                    "id": "sha256:f0573f0630208eb7e500ff5a58d0bbddf06a3c01fe19979012cfc96e0d650175"
+                  },
+                  {
+                    "id": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+                  },
+                  {
+                    "id": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+                  },
+                  {
+                    "id": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+                  },
+                  {
+                    "id": "sha256:a0fecb62ade3bbce7df090cc2364708de0da41fefeb6e06548f0532ca5d9b19c"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+                  },
+                  {
+                    "id": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+                  },
+                  {
+                    "id": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:bcc8c0dd7c9650d12b89f7ed0c037709d41dcd13310cfaf48d44323f87735e2b"
+                  },
+                  {
+                    "id": "sha256:08a7cd07930cc331c629d79dcfc919f44695cddbc60ae44b0af08d5618462484"
+                  },
+                  {
+                    "id": "sha256:791a9cbd72458f4f28a5e7d267ad415c51f9647a60c5645cb288cc4cd85381ea"
+                  },
+                  {
+                    "id": "sha256:71fa2eceea6cea25283dccee16f61cedef49f4262af360821ceebef808401090"
+                  },
+                  {
+                    "id": "sha256:15b698148ae0f924adf4e287e2de86c2289a3f2d46d9170ff21972ab0a73ba36"
+                  },
+                  {
+                    "id": "sha256:49176af8fa7ec5f144b33988ab7ac6b186793c0438e28d0b12f343e9addb8451"
+                  },
+                  {
+                    "id": "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64"
+                  },
+                  {
+                    "id": "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982"
+                  },
+                  {
+                    "id": "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45"
+                  },
+                  {
+                    "id": "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007"
+                  },
+                  {
+                    "id": "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431"
+                  },
+                  {
+                    "id": "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c"
+                  },
+                  {
+                    "id": "sha256:aec11b0267a711f6bee2824a9914e88ca55a01738bf409b7ef7e7a38e37a9037"
+                  },
+                  {
+                    "id": "sha256:03e569d5e0e7b80fe5439c920580024fb34b599f2dbe82bd8aa80381348bc958"
+                  },
+                  {
+                    "id": "sha256:7658cb0e7b6518d9786d863c04f12781992989b8bbafefc6c5634104ea138321"
+                  },
+                  {
+                    "id": "sha256:43616a0a035c29c98cdf462c0dc2a7c5e98c56000ca7ec358984947b7b222902"
+                  },
+                  {
+                    "id": "sha256:d1fb8b3c6fb9a98d63766c3c9a228bb97453ba62cc4a490b6c187b1dfe42fae2"
+                  },
+                  {
+                    "id": "sha256:b8f77d5b3714ca6d1b19736ad13588997ab31dc39b036f842a07b061af0fd247"
+                  },
+                  {
+                    "id": "sha256:730dc7a252fdf9307d8a59e6d2788671eeb582175f471522785e479c9f60cfa9"
+                  },
+                  {
+                    "id": "sha256:e085d2171393ba86e53bf8b47cc897fccc09382a8a15bf629303c5486e8bd1cc"
+                  },
+                  {
+                    "id": "sha256:672035f4b12c0ce547a90287d936caeadcb0c06dbdda01a026071eab9622da04"
+                  },
+                  {
+                    "id": "sha256:b83c398d8040ad255360d3fb37f04982a31d7e51d81815c5fafaf0dbe8fda9e7"
+                  },
+                  {
+                    "id": "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9"
+                  },
+                  {
+                    "id": "sha256:3230783603695707b5b037f700c0293658afeff26541bde93c2743b335c70e1b"
+                  },
+                  {
+                    "id": "sha256:73a140a5c8d48a34b9dbcd0534a1c10c2045d261c8594f334ea438f8803d7b0b"
+                  },
+                  {
+                    "id": "sha256:859f352a4b9eb6b91dba755b6404b60bd7bf015e88ad6643648f3681d3a8a55f"
+                  },
+                  {
+                    "id": "sha256:6e7dae153c72989bcbf0f9174f513dbca277578eba1fe08895b4dafb98308caf"
+                  },
+                  {
+                    "id": "sha256:916f6a6c4b25af9a227e943cf61ca0873553e2ac67479aa43b954f98735e5d7f"
+                  },
+                  {
+                    "id": "sha256:37675735e4ea2e72205985d04535c7bd8901db2d618de333b783ae29c0117d2e"
+                  },
+                  {
+                    "id": "sha256:3b25187cbec0cc9c4c6884f1534e45384639644a4819f24a47536b6ae4515eda"
+                  },
+                  {
+                    "id": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+                  },
+                  {
+                    "id": "sha256:f5605e1b409610564b3f58a07ad22d246af4f679eef1784624e83ecd47d2fd86"
+                  },
+                  {
+                    "id": "sha256:1e7a15f2d6078a39d5bac5aaf964e91e22476d03aa84f9519b5797c202fbc355"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:4dc9a401c2514336e46adc87f5d05244ca743eb08bf6bcab1443a9eba6b81970"
+                  },
+                  {
+                    "id": "sha256:77a55f2182769815d41519b53ca15b54aa09cbe48249cd91487a091e81fdd7c2"
+                  },
+                  {
+                    "id": "sha256:19f7ca6bf9d8e762c376d0d8b52e2982e900a3d3e5fe7d3f095d1b27f4ab95aa"
+                  },
+                  {
+                    "id": "sha256:cc4fe3933ba69f933159e8ac41aad28f0c9b853dd31cc8f9670f1a40840f0d7e"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+                  },
+                  {
+                    "id": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+                  },
+                  {
+                    "id": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:9d09e49c6f92e1673f0ce5486cb4e12588694793918a9265436000d2fcb88b7d"
+                  },
+                  {
+                    "id": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+                  },
+                  {
+                    "id": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+                  },
+                  {
+                    "id": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+                  },
+                  {
+                    "id": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+                  },
+                  {
+                    "id": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+                  },
+                  {
+                    "id": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+                  },
+                  {
+                    "id": "sha256:123c1d340937aa080aa329f8ebba4705dfd06fdbe26aa69418ca9fcde8df2680"
+                  },
+                  {
+                    "id": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+                  },
+                  {
+                    "id": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+                  },
+                  {
+                    "id": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+                  },
+                  {
+                    "id": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+                  },
+                  {
+                    "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+                  },
+                  {
+                    "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+                  },
+                  {
+                    "id": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+                  },
+                  {
+                    "id": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+                  },
+                  {
+                    "id": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+                  },
+                  {
+                    "id": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+                  },
+                  {
+                    "id": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+                  },
+                  {
+                    "id": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+                  },
+                  {
+                    "id": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+                  },
+                  {
+                    "id": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+                  },
+                  {
+                    "id": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+                  },
+                  {
+                    "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+                  },
+                  {
+                    "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+                  },
+                  {
+                    "id": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+                  },
+                  {
+                    "id": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+                  },
+                  {
+                    "id": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+                  },
+                  {
+                    "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+                  },
+                  {
+                    "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+                  },
+                  {
+                    "id": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+                  },
+                  {
+                    "id": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+                  },
+                  {
+                    "id": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+                  },
+                  {
+                    "id": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+                  },
+                  {
+                    "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+                  },
+                  {
+                    "id": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+                  },
+                  {
+                    "id": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+                  },
+                  {
+                    "id": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+                  },
+                  {
+                    "id": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+                  },
+                  {
+                    "id": "sha256:c672527f93c914be54899edbd5f855c3c957e4493b218db7a69a4e6f54ce2e09"
+                  },
+                  {
+                    "id": "sha256:3b14cb5167b2dc1d2b999e87a9f376f60e81faa4552c36293b770b277d432881"
+                  },
+                  {
+                    "id": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+                  },
+                  {
+                    "id": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+                  },
+                  {
+                    "id": "sha256:88ff978b561a31e1bec818870a09e7078e9f3d0f2530293dde79348ad2ee8697"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:a600088d03991ca3970973f4c9759790939403eeb0ecaacdc18267ab35f1162a"
+                  },
+                  {
+                    "id": "sha256:2293799f84ccf36c681066a3aa0f7fe713b913e589c105713ecbb98e86966cc7"
+                  },
+                  {
+                    "id": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+                  },
+                  {
+                    "id": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+                  },
+                  {
+                    "id": "sha256:3b00ddc8c3a9fa3c06e995a08e9eb169615b762769fa800c60656e0dd7af3a97"
+                  },
+                  {
+                    "id": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+                  },
+                  {
+                    "id": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+                  },
+                  {
+                    "id": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+                  },
+                  {
+                    "id": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+                  },
+                  {
+                    "id": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+                  },
+                  {
+                    "id": "sha256:d89d9f74f8b028975b72aa435cd49e708195cd746f9eee3c12ca8b09a2accc0b"
+                  },
+                  {
+                    "id": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+                  },
+                  {
+                    "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+                  },
+                  {
+                    "id": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+                  },
+                  {
+                    "id": "sha256:4f587a23bbc728df6fbb528e95967259659d1cf636f18a31f54477b95dc10945"
+                  },
+                  {
+                    "id": "sha256:3d30debfa65d5354cde7e515ddee39110d6f846647b806e46192fd7956100d9d"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+                  },
+                  {
+                    "id": "sha256:7c9af23f813f4b3449075ef79118a69343be7e8878c8ae3ec5907cd6521e319b"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:920c61a08e456094c25495efb453e04b77b7fa9b1cb6c708cdca4b0e1cf488a3"
+                  },
+                  {
+                    "id": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+                  },
+                  {
+                    "id": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+                  },
+                  {
+                    "id": "sha256:7e95db3a020beca4526cad1fb550e360fc776779721902b0401f40425ad2910d"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+                  },
+                  {
+                    "id": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+                  },
+                  {
+                    "id": "sha256:96458b749b0783cc8062aa5417da53712b91676dd1a6284f05ec3b68a29261e8"
+                  },
+                  {
+                    "id": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+                  },
+                  {
+                    "id": "sha256:03691e07c6a6d7e149e429e2c19dfd9ed038d417f01cd69a496759daf22053fd"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:4dd6e7bf33d6407e2b6a1d4aed75c3c07c2cbb8c82b600a63efe6cd02b315d27"
+                  },
+                  {
+                    "id": "sha256:8878a5eb20b8e84d226dc0f27f3df8ad41350f06efcffec159fcacf8238cc771"
+                  },
+                  {
+                    "id": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+                  },
+                  {
+                    "id": "sha256:f4b5c68dee1b1505dafc6b8c1553aa3448137f4b6b06f600b3afd63fe25259fc"
+                  },
+                  {
+                    "id": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+                  },
+                  {
+                    "id": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+                  },
+                  {
+                    "id": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+                  },
+                  {
+                    "id": "sha256:c95fb7d3137031016bce7742a5a56b2bdb83903d91004783a138cfb4def075ae"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:d6622bbbb6b862f9ea41e7f0d48e4086c76743f712c9218bb7f63c98912b4fb0"
+                  },
+                  {
+                    "id": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+                  },
+                  {
+                    "id": "sha256:1ea11c6adbcf231fd57764c656515815a32385d8625a815699e7caccdc178a81"
+                  },
+                  {
+                    "id": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+                  },
+                  {
+                    "id": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+                  },
+                  {
+                    "id": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+                  },
+                  {
+                    "id": "sha256:cea2802e226f857af3899655a86e3b8fb5e761c309c6f4bea61b7972cdede7fc"
+                  },
+                  {
+                    "id": "sha256:5487de1bac24442383d789e48ba61456ec1b28095b481ca87a2bd5a2a67b6c43"
+                  },
+                  {
+                    "id": "sha256:cf6a087cbf1537d450020c50e0a26d8cab97b6acbff3aed417080fde4c531ec9"
+                  },
+                  {
+                    "id": "sha256:04642ee7c7604a79ed9b009a660b3d201d1c2a384c04f1026716588097644b57"
+                  },
+                  {
+                    "id": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:48adf3c630487ead8f233cde6fdfe8819a8cfe1e76bf6fc4d62cf4b5059a630b"
+                  },
+                  {
+                    "id": "sha256:a349778d7638edf0225ccfd0ee10c8463a8696cb7e1910b23fdb0bb5effc6edb"
+                  },
+                  {
+                    "id": "sha256:f7c4319ec1ae973242046f0ef6d4af54c53421124a1339efbd4e06c26f5c809f"
+                  },
+                  {
+                    "id": "sha256:20252a90fbf74378e6d3663818703adcc0a5450320d6df68f7df4ab5544c7326"
+                  },
+                  {
+                    "id": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:e329ec13f2a48b369c1d1c454e149bfb0b750d6976d9dba6bc0282410e061b07"
+                  },
+                  {
+                    "id": "sha256:9fa7096dd4182602e14dbe682086e74c777b54ddd511e832091719eff101a927"
+                  },
+                  {
+                    "id": "sha256:06b51b9c622b2a097ae8ca07b443dcc956da5a9ea9f6785ea4c6893fdba7dd7b"
+                  },
+                  {
+                    "id": "sha256:95f4c75d788a1b2d5d11f028b04f69d4f0f036f1c814b3cc396ea6ac7f419b6a"
+                  },
+                  {
+                    "id": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+                  },
+                  {
+                    "id": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+                  },
+                  {
+                    "id": "sha256:5cbaafb7edb56eea2ae1b469597e1d24304b5f1f5294316bcb72d99b2edf1acd"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:917a406f75a6c064cffe15f7926854750ecb656a34b80ac24e36146d1560cccd"
+                  },
+                  {
+                    "id": "sha256:a61dcf3c31bc66497c86d007870305008e2ab6d11fc6a570af179afa19bfcbc2"
+                  },
+                  {
+                    "id": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+                  },
+                  {
+                    "id": "sha256:efd39d4e825667654577d535aa236a2326b130a30c1150dda522c7208c7c8c33"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:69dcb613e5b4a65bceb2e711d09e110e717c6ad0cbb32f577cfb9589fdc443b8"
+                  },
+                  {
+                    "id": "sha256:8f005cf975d92d5d5f69888633a2b0c842d03d9a58140db8ea5a40e7bbf67415"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:609bcd5fca60d9453c9a06a97a8c597028ba30db711bcfdda1e761edff0f8f3b"
+                  },
+                  {
+                    "id": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+                  },
+                  {
+                    "id": "sha256:d5748eae1488c315afb264a75e64bf0d1b83771abffbf742efd44ba97d27005d"
+                  },
+                  {
+                    "id": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+                  },
+                  {
+                    "id": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+                  },
+                  {
+                    "id": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+                  },
+                  {
+                    "id": "sha256:d763b5794e0ba4ed71da2ac5dbe36f5db84d454bce8c7ee2a09f812edd5b5453"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:84dddb64dbfa4ef82b02a08fe95491eb909351f8fa7f96a754124a9084c6c8fe"
+                  },
+                  {
+                    "id": "sha256:bd09459910a5331c3dccd2a795b6af83c7db2c74df0ee9ec091012bb63a67cb3"
+                  },
+                  {
+                    "id": "sha256:385f0ed7359b8ec4c0e4e62b78aae094dd487d48b670b0bbc2a1fead2ca41140"
+                  },
+                  {
+                    "id": "sha256:8606dc6028993db6b8fc612ee43021c43399c07562385b8d024130051d36c1bb"
+                  },
+                  {
+                    "id": "sha256:b609592c9a241bc13e6ca1606a1bc24e9bf7d8b002f965d8645b3e51a5f7c569"
+                  },
+                  {
+                    "id": "sha256:7a994d8e50f9e5ced5d2082a58ecfb8f79ab1656cec77c65ec67453fbd6839fb"
+                  },
+                  {
+                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7"
+                  },
+                  {
+                    "id": "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736"
+                  },
+                  {
+                    "id": "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0"
+                  },
+                  {
+                    "id": "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95"
+                  },
+                  {
+                    "id": "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e"
+                  },
+                  {
+                    "id": "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c"
+                  },
+                  {
+                    "id": "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b"
+                  },
+                  {
+                    "id": "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef"
+                  },
+                  {
+                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+                  },
+                  {
+                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+                  },
+                  {
+                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+                  },
+                  {
+                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+                  },
+                  {
+                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  },
+                  {
+                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+                  },
+                  {
+                    "id": "sha256:000bd49aea30ee3534e6cde11188afa4b567711b13acbcf531e5542fc7b2aefe"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys.fromtree": [
+                "/etc/pki/rpm-gpg/RPM-GPG-KEY-microsoft-azure-release",
+                "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US.UTF-8"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "Etc/UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "cloud-config",
+                "cloud-final",
+                "cloud-init-local",
+                "cloud-init",
+                "firewalld",
+                "NetworkManager",
+                "sshd",
+                "waagent"
+              ],
+              "default_target": "multi-user.target"
+            }
+          },
+          {
+            "type": "org.osbuild.sysconfig",
+            "options": {
+              "kernel": {
+                "update_default": true,
+                "default_kernel": "kernel-core"
+              },
+              "network": {
+                "networking": true,
+                "no_zero_conf": true
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "yum-plugins": {
+                "subscription-manager": {
+                  "enabled": false
+                }
+              },
+              "subscription-manager": {
+                "rhsm": {
+                  "manage_repos": false
+                },
+                "rhsmcertd": {
+                  "auto_registration": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.cloud-init",
+            "options": {
+              "filename": "06_logging_override.cfg",
+              "config": {
+                "output": {
+                  "all": "| tee -a /var/log/cloud-init-output.log"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.cloud-init",
+            "options": {
+              "filename": "10-azure-kvp.cfg",
+              "config": {
+                "reporting": {
+                  "logging": {
+                    "type": "log"
+                  },
+                  "telemetry": {
+                    "type": "hyperv"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.cloud-init",
+            "options": {
+              "filename": "91-azure_datasource.cfg",
+              "config": {
+                "datasource": {
+                  "Azure": {
+                    "apply_network_config": false
+                  }
+                },
+                "datasource_list": [
+                  "Azure"
+                ]
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-nouveau.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-floppy.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "floppy"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.sshd.config",
+            "options": {
+              "config": {
+                "ClientAliveInterval": 180
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.authconfig",
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.pwquality.conf",
+            "options": {
+              "config": {
+                "minlen": 6,
+                "dcredit": 0,
+                "ucredit": 0,
+                "lcredit": 0,
+                "ocredit": 0,
+                "minclass": 3
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.waagent.conf",
+            "options": {
+              "config": {
+                "ResourceDisk.Format": false,
+                "ResourceDisk.EnableSwap": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.yum.config",
+            "options": {
+              "config": {
+                "http_caching": "packages"
+              },
+              "plugins": {
+                "langpacks": {
+                  "locales": [
+                    "en_US.UTF-8"
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.udev.rules",
+            "options": {
+              "filename": "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+              "rules": [
+                {
+                  "comment": [
+                    "Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+                    "This interface is transparently bonded to the synthetic interface,",
+                    "so NetworkManager should just ignore any SRIOV interfaces."
+                  ]
+                },
+                [
+                  {
+                    "key": "SUBSYSTEM",
+                    "op": "==",
+                    "val": "net"
+                  },
+                  {
+                    "key": "DRIVERS",
+                    "op": "==",
+                    "val": "hv_pci"
+                  },
+                  {
+                    "key": "ACTION",
+                    "op": "==",
+                    "val": "add"
+                  },
+                  {
+                    "key": {
+                      "name": "ENV",
+                      "arg": "NM_UNMANAGED"
+                    },
+                    "op": "=",
+                    "val": "1"
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/home",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+                  "vfs_type": "xfs",
+                  "path": "/tmp",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
+                  "vfs_type": "xfs",
+                  "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2.legacy",
+            "options": {
+              "rootfs": {
+                "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+              },
+              "entries": [
+                {
+                  "default": true,
+                  "id": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                  "kernel": "3.10.0-1160.el7.x86_64",
+                  "product": {
+                    "name": "Red Hat Enterprise Linux",
+                    "version": "7.9",
+                    "nick": "Maipo"
+                  }
+                }
+              ],
+              "bios": {
+                "platform": "i386-pc"
+              },
+              "uefi": {
+                "vendor": "redhat"
+              },
+              "bootfs": {
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+              },
+              "config": {
+                "terminal_input": [
+                  "serial",
+                  "console"
+                ],
+                "terminal_output": [
+                  "serial",
+                  "console"
+                ],
+                "timeout": 10,
+                "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+                "cmdline": "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y",
+                "distributor": "$(sed 's, release .*$,,g' /etc/system-release)"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "force_autorelabel": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "68719476736"
+            }
+          },
+          {
+            "type": "org.osbuild.sgdisk",
+            "options": {
+              "uuid": "d209c89e-ea5e-4fbd-b161-b461cce297e0",
+              "partitions": [
+                {
+                  "size": 1024000,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68b2905b-df3e-4fb3-80fa-49d1e773aa33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 1026048,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "cb07c243-bc44-4717-853e-28852021225b"
+                },
+                {
+                  "bootable": true,
+                  "size": 4096,
+                  "start": 2050048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "fac7f1fb-3e8d-4137-a512-961de09a5549"
+                },
+                {
+                  "size": 132163551,
+                  "start": 2054144,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                  "uuid": "6264d520-3fb9-423f-8ab8-7a0a8e3d3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "homelv",
+                  "size": "1073741824B"
+                },
+                {
+                  "name": "rootlv",
+                  "size": "2147483648B"
+                },
+                {
+                  "name": "tmplv",
+                  "size": "2147483648B"
+                },
+                {
+                  "name": "usrlv",
+                  "size": "10737418240B"
+                },
+                {
+                  "name": "varlv",
+                  "size": "10737418240B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "home"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "homelv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+              "label": "tmp"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "tmplv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
+              "label": "usr"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "usrlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+              "label": "var"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "varlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1024000
+                }
+              },
+              "home": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "homelv"
+                }
+              },
+              "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551
+                }
+              },
+              "tmp": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "tmplv"
+                }
+              },
+              "usr": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "usrlv"
+                }
+              },
+              "var": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "varlv"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              },
+              {
+                "name": "home",
+                "type": "org.osbuild.xfs",
+                "source": "home",
+                "target": "/home"
+              },
+              {
+                "name": "tmp",
+                "type": "org.osbuild.xfs",
+                "source": "tmp",
+                "target": "/tmp"
+              },
+              {
+                "name": "usr",
+                "type": "org.osbuild.xfs",
+                "source": "usr",
+                "target": "/usr"
+              },
+              {
+                "name": "var",
+                "type": "org.osbuild.xfs",
+                "source": "var",
+                "target": "/var"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2054144,
+                  "size": 132163551,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "i386-pc",
+              "location": 2050048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "xfs"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 1,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "vpc",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.qemu",
+            "inputs": {
+              "image": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.vhd",
+              "format": {
+                "type": "vpc",
+                "force_size": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "archive",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.xz",
+            "inputs": {
+              "file": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:vpc": {
+                    "file": "disk.vhd"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.vhd.xz"
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:000bd49aea30ee3534e6cde11188afa4b567711b13acbcf531e5542fc7b2aefe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530/rhui-azure-rhel7-2.2-222.noarch.rpm"
+          },
+          "sha256:005d3c65516a8021aac3e640d498a5fafe7f86eb7848009aed399a42730aa79f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-tools-firmware-1.1.0-1.el7.x86_64.rpm"
+          },
+          "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm"
+          },
+          "sha256:00bae5c24b3d71b20e66526b17f74457d0be31a17f005e3bf0abab0e61e19e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-web-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:0242b754ddce29e5a16f952a132c0181457f98312c4e1c5c31afa8e4358102ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-TimeDate-2.30-2.el7.noarch.rpm"
+          },
+          "sha256:03691e07c6a6d7e149e429e2c19dfd9ed038d417f01cd69a496759daf22053fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sos-3.9-2.el7.noarch.rpm"
+          },
+          "sha256:03e569d5e0e7b80fe5439c920580024fb34b599f2dbe82bd8aa80381348bc958": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Escapes-1.04-297.el7.noarch.rpm"
+          },
+          "sha256:04642ee7c7604a79ed9b009a660b3d201d1c2a384c04f1026716588097644b57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/traceroute-2.0.22-2.el7.x86_64.rpm"
+          },
+          "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm"
+          },
+          "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm"
+          },
+          "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm"
+          },
+          "sha256:05b11d41594ae949abd8f0f65f265dd815fb1ae2e8618bb3be63a7b7062be100": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-cli-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-URI/1.71/1.el7eng/noarch/perl-URI-1.71-1.el7eng.noarch.rpm"
+          },
+          "sha256:06b51b9c622b2a097ae8ca07b443dcc956da5a9ea9f6785ea4c6893fdba7dd7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-enhanced-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm"
+          },
+          "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-IO-Socket-IP/0.31/1.el7eng/noarch/perl-IO-Socket-IP-0.31-1.el7eng.noarch.rpm"
+          },
+          "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-firmware-1.0.28-2.el7.noarch.rpm"
+          },
+          "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:08a7cd07930cc331c629d79dcfc919f44695cddbc60ae44b0af08d5618462484": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Carp-1.26-244.el7.noarch.rpm"
+          },
+          "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm"
+          },
+          "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm"
+          },
+          "sha256:096652bf46e6ed5a256632cb11ca56d660830e60f4fdca3b254bb5d4b1ba3d7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libproxy-0.4.11-11.el7.x86_64.rpm"
+          },
+          "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm"
+          },
+          "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm"
+          },
+          "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm"
+          },
+          "sha256:0b4110cf94f7f793dbabb7a1a616087455ab316ec74ad5204abb0fd2f211ee58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6050-firmware-41.28.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm"
+          },
+          "sha256:0d3b093a48d64797df3a93d7dec2d26554efbece0ede5c6d4b90347ae4a9e1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-utils-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm"
+          },
+          "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm"
+          },
+          "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm"
+          },
+          "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm"
+          },
+          "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm"
+          },
+          "sha256:10c1e258fd2bbc90f1ddf5082676ad9b0c748faa5f7968039e16ce9eace381e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:11ac559bb43266411c847e259a1bb111ee67b4fdc09c3d9dbf6e91094f815e0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl135-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:11fc857bbb8e1ae64b236afcecf7d741b73d66a99d65e0014f1da0e45f3b3140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-filesystem-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:123c1d340937aa080aa329f8ebba4705dfd06fdbe26aa69418ca9fcde8df2680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-augeas-0.5.0-2.el7.noarch.rpm"
+          },
+          "sha256:12b098f5666193520fc84a092ce438a39f8c3ff53f7a7c4eee55e6515b49618c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2000-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:12b5567baa42fc4200d7a02264d8bae115c4a3ead6f04fb634d6f8243988e3e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dyninst-9.3.1-3.el7.x86_64.rpm"
+          },
+          "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm"
+          },
+          "sha256:12d3f2ca7449af3e3a3cff8be6b024cd1106987f49a7be16a84fa9bb39f2dde9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl100-firmware-39.31.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm"
+          },
+          "sha256:12e5a19c594ccbce0507ce57297b8305033a07c474c9d4c176d70545e1a20b23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mdadm-4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm"
+          },
+          "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm"
+          },
+          "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:14ea0df235cd8b92e60655961c88d3ea801e81bfab0f39f8356e934948b9185f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdb-7.6.1-120.el7.x86_64.rpm"
+          },
+          "sha256:15b698148ae0f924adf4e287e2de86c2289a3f2d46d9170ff21972ab0a73ba36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-File-Temp-0.23.01-3.el7.noarch.rpm"
+          },
+          "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm"
+          },
+          "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm"
+          },
+          "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm"
+          },
+          "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm"
+          },
+          "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm"
+          },
+          "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:19f7ca6bf9d8e762c376d0d8b52e2982e900a3d3e5fe7d3f095d1b27f4ab95aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-scripts-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm"
+          },
+          "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:1afd06d4eafb5bb6d2e5098a498d5eccc9d06f5e5413ce35ce0fb08eccfd6175": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-pages-3.53-5.el7.noarch.rpm"
+          },
+          "sha256:1b69e24543d83757d4f6b14167a3b8c777f214eb21caa309598a4177423f61de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-completion-2.1-8.el7.noarch.rpm"
+          },
+          "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm"
+          },
+          "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm"
+          },
+          "sha256:1e7a15f2d6078a39d5bac5aaf964e91e22476d03aa84f9519b5797c202fbc355": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pixman-0.34.0-1.el7.x86_64.rpm"
+          },
+          "sha256:1ea11c6adbcf231fd57764c656515815a32385d8625a815699e7caccdc178a81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemtap-runtime-4.0-13.el7.x86_64.rpm"
+          },
+          "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:20252a90fbf74378e6d3663818703adcc0a5450320d6df68f7df4ab5544c7326": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usbutils-007-5.el7.x86_64.rpm"
+          },
+          "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-SSLeay-1.55-6.el7.x86_64.rpm"
+          },
+          "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm"
+          },
+          "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm"
+          },
+          "sha256:2293799f84ccf36c681066a3aa0f7fe713b913e589c105713ecbb98e86966cc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-logos-70.7.0-1.el7.noarch.rpm"
+          },
+          "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm"
+          },
+          "sha256:2345c8acf8cf82a953622d784b2200fd114a3b52fe92b3864929d305618424bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-cli-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:2367c7a15f8067150791d2f485693249a0f65a970b1b3e7e1d5d82768173304b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hyperv-daemons-license-0-0.34.20180415git.el7.noarch.rpm"
+          },
+          "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm"
+          },
+          "sha256:24d1e9b218aa1c0649bafabeb78234deee3ef0388c372cb621dee67e74a64370": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ed-1.9-4.el7.x86_64.rpm"
+          },
+          "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:2540ffdba1bfc89714d18489247193d661ec5ac342159c3f5907e13981cf5a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mtr-0.85-7.el7.x86_64.rpm"
+          },
+          "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-IO-Socket-SSL-1.94-7.el7.noarch.rpm"
+          },
+          "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm"
+          },
+          "sha256:25f29adfb9ba39f408b7c268bd6e089e901593f1c36840ebb59e801afef0430c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fprintd-0.8.1-2.el7.x86_64.rpm"
+          },
+          "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm"
+          },
+          "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm"
+          },
+          "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
+          },
+          "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm"
+          },
+          "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm"
+          },
+          "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Mozilla-CA-20130114-5.el7.noarch.rpm"
+          },
+          "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm"
+          },
+          "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:2a2f4b503c06c43f5a838109b40134e0663efeb92c00d6b725ef52f2ffedc6e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsof-4.87-6.el7.x86_64.rpm"
+          },
+          "sha256:2a63a5dc60cbc1cd87af739663f4becd6e05b46bf7daf28e092142f9b140469b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-dbus-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm"
+          },
+          "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
+          },
+          "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
+          },
+          "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Getopt-Long-2.40-3.el7.noarch.rpm"
+          },
+          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
+          },
+          "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:2e56f3449308538a955393ca85e4908d9022885fa34894cb365669b9d38de282": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-3.2.28-4.el7.x86_64.rpm"
+          },
+          "sha256:2e725765793b2f83faaec043d050f138b0c9e6c24d1fb7fe455e3743135d3c60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/blktrace-1.0.5-9.el7.x86_64.rpm"
+          },
+          "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:2ec491fcbf33117f504cacfff9f2332fd89c260c56355c1d463e7ebc9b11f04e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/at-3.1.13-24.el7.x86_64.rpm"
+          },
+          "sha256:2ecf5b8dbb340dd2d3e87909a48db4e2fe640b4d6fbe582ee313388bd1ed61cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-tui-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:2edbe67c9f917f0f26c9caf326f59045209f40d474c1d586ad64b24babe04727": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-python-1.8.1-1.el7.noarch.rpm"
+          },
+          "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:311477ee57b269f9693a70931066ef2852c030557fb3c61313308af71bf46b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-libs-lite-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:315b1c75761f80eb7a2905319f8f6c16926ad9f04a3ebab2a3b205d36da82745": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/GeoIP-1.5.0-14.el7.x86_64.rpm"
+          },
+          "sha256:31c3efd8249034f7a5b00c5c87cface914234c10c3f55c95a81fb621466c3b0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libusbx-1.0.21-1.el7.x86_64.rpm"
+          },
+          "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3230783603695707b5b037f700c0293658afeff26541bde93c2743b335c70e1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-constant-1.27-2.el7.noarch.rpm"
+          },
+          "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm"
+          },
+          "sha256:33fba59c069f63b29ac955363d97683c582178f5e314d594c452b8a630a59170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl7260-firmware-25.30.13.0-79.el7.noarch.rpm"
+          },
+          "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm"
+          },
+          "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm"
+          },
+          "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:37675735e4ea2e72205985d04535c7bd8901db2d618de333b783ae29c0117d2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-threads-1.87-4.el7.x86_64.rpm"
+          },
+          "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm"
+          },
+          "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm"
+          },
+          "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm"
+          },
+          "sha256:385f0ed7359b8ec4c0e4e62b78aae094dd487d48b670b0bbc2a1fead2ca41140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-dotnetcore-1.1-3.el7.x86_64.rpm"
+          },
+          "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm"
+          },
+          "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm"
+          },
+          "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Encode/2.78/2.1.el7/x86_64/perl-Encode-2.78-2.1.el7.x86_64.rpm"
+          },
+          "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm"
+          },
+          "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:3b00ddc8c3a9fa3c06e995a08e9eb169615b762769fa800c60656e0dd7af3a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rfkill-0.4-10.el7.x86_64.rpm"
+          },
+          "sha256:3b14cb5167b2dc1d2b999e87a9f376f60e81faa4552c36293b770b277d432881": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python2-pyasn1-0.1.9-7.el7.noarch.rpm"
+          },
+          "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:3b25187cbec0cc9c4c6884f1534e45384639644a4819f24a47536b6ae4515eda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-threads-shared-1.43-6.el7.x86_64.rpm"
+          },
+          "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm"
+          },
+          "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm"
+          },
+          "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm"
+          },
+          "sha256:3d21b95e0248c86ffaff71a1df85fd7073ab09dc05874fd8a6940eab6edac6fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfprint-0.8.2-1.el7.x86_64.rpm"
+          },
+          "sha256:3d24d7a5ff7832751ccee0b6acbbef45cea0154ba4f038fc0cce045a30460ae3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-license-9.11.4-26.P2.el7.noarch.rpm"
+          },
+          "sha256:3d30debfa65d5354cde7e515ddee39110d6f846647b806e46192fd7956100d9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/scl-utils-20130529-19.el7.x86_64.rpm"
+          },
+          "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Mozilla-PublicSuffix/0.1.19/1.el7eng/noarch/perl-Mozilla-PublicSuffix-0.1.19-1.el7eng.noarch.rpm"
+          },
+          "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5000-firmware-8.83.5.1_1-79.el7.noarch.rpm"
+          },
+          "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
+          },
+          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm"
+          },
+          "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-LibIDN-0.12-15.el7.x86_64.rpm"
+          },
+          "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm"
+          },
+          "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm"
+          },
+          "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm"
+          },
+          "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:43616a0a035c29c98cdf462c0dc2a7c5e98c56000ca7ec358984947b7b222902": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Simple-3.28-4.el7.noarch.rpm"
+          },
+          "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Date-6.02-8.el7.noarch.rpm"
+          },
+          "sha256:448840196e3439f64d64ac56e71d5e2e1d83b7100aeca7ac2719d70e7913f5e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-libs-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm"
+          },
+          "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm"
+          },
+          "sha256:48adf3c630487ead8f233cde6fdfe8819a8cfe1e76bf6fc4d62cf4b5059a630b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/unzip-6.0-21.el7.x86_64.rpm"
+          },
+          "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm"
+          },
+          "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm"
+          },
+          "sha256:49176af8fa7ec5f144b33988ab7ac6b186793c0438e28d0b12f343e9addb8451": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Filter-1.49-3.el7.x86_64.rpm"
+          },
+          "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm"
+          },
+          "sha256:4d5368561d92f2a57a443e5f161b289c3862ec677906634c6bca536c3e0860b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-0.20121024-6.el7.noarch.rpm"
+          },
+          "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm"
+          },
+          "sha256:4dc9a401c2514336e46adc87f5d05244ca743eb08bf6bcab1443a9eba6b81970": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:4dd6e7bf33d6407e2b6a1d4aed75c3c07c2cbb8c82b600a63efe6cd02b315d27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sssd-client-1.16.5-10.el7.x86_64.rpm"
+          },
+          "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm"
+          },
+          "sha256:4f587a23bbc728df6fbb528e95967259659d1cf636f18a31f54477b95dc10945": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/satyr-0.13-15.el7.x86_64.rpm"
+          },
+          "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm"
+          },
+          "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm"
+          },
+          "sha256:512db073b9eaecb7d9f5b8cfd16fd1f7ca213ce98f9f77d3e859a2680601e8b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-pstoreoops-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm"
+          },
+          "sha256:52119268a72a5b22af74b0d71fcfd6c8b2ac6237c161b5eb628f345fa52704da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lm_sensors-libs-3.4.0-8.20160601gitf9185e5.el7.x86_64.rpm"
+          },
+          "sha256:52b0f84c76826cc370f665ae358e9525e2a374446fc680b3eada61520ab0c1e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-rhel-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm"
+          },
+          "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:535aec9847767995152b43de3f8323e53c7c36decf894ca6e426742fb1507322": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-cli-3.2.28-4.el7.x86_64.rpm"
+          },
+          "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm"
+          },
+          "sha256:5487de1bac24442383d789e48ba61456ec1b28095b481ca87a2bd5a2a67b6c43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/teamd-1.29-3.el7.x86_64.rpm"
+          },
+          "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm"
+          },
+          "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm"
+          },
+          "sha256:57cf80287c438875891cbf68322b3ae37682fd2a3c54d7ff247630239dbb2fd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-xorg-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:589adacd70beea80aabbd1ed217632f98a3ee4a327622a86aeb83fb05bd2de4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/make-3.82-24.el7.x86_64.rpm"
+          },
+          "sha256:58ce6f65f4b61dfcb190deac65fca0cc210abfdae65b54a88ee5f61c61e3e47e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/jansson-2.10-1.el7.x86_64.rpm"
+          },
+          "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm"
+          },
+          "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm"
+          },
+          "sha256:5aa53274792dcf7e419e57a7af5d17c9edad42a0caf6c71b007c2e1f86bd1dfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nano-2.3.1-10.el7.x86_64.rpm"
+          },
+          "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:5c72631f154e7cbfa12f04df7e3b2efcfd6f5c77a0fa7a30b684001a277cae0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/authconfig-6.2.8-30.el7.x86_64.rpm"
+          },
+          "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5cbaafb7edb56eea2ae1b469597e1d24304b5f1f5294316bcb72d99b2edf1acd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wget-1.14-18.el7_6.1.x86_64.rpm"
+          },
+          "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-CookieJar/0.006/1.el7eng/noarch/perl-HTTP-CookieJar-0.006-1.el7eng.noarch.rpm"
+          },
+          "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-Tiny/0.047/1.el7eng/noarch/perl-HTTP-Tiny-0.047-1.el7eng.noarch.rpm"
+          },
+          "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm"
+          },
+          "sha256:5f05c450273ead37b116bc141378fc2da9ac7096c2ecbd11bb4d41aed000fcfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmraid-events-1.0.0.rc16-28.el7.x86_64.rpm"
+          },
+          "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm"
+          },
+          "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:609bcd5fca60d9453c9a06a97a8c597028ba30db711bcfdda1e761edff0f8f3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yajl-2.0.4-4.el7.x86_64.rpm"
+          },
+          "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm"
+          },
+          "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm"
+          },
+          "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm"
+          },
+          "sha256:641326bddc57b01e75135caff060a9b94fb26f9a322df71a53a4138540148b09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-mailx-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm"
+          },
+          "sha256:645ae25a1ff4f52ed840eb5d93043596c3c84fa4c36e117678e57f10423586c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crda-3.18_2018.05.31-4.el7.x86_64.rpm"
+          },
+          "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm"
+          },
+          "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm"
+          },
+          "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5150-firmware-8.24.2.2-79.el7.noarch.rpm"
+          },
+          "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm"
+          },
+          "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:672035f4b12c0ce547a90287d936caeadcb0c06dbdda01a026071eab9622da04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Time-HiRes-1.9725-3.el7.x86_64.rpm"
+          },
+          "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm"
+          },
+          "sha256:683ee2641d3562d86c587971a43828110908202066520bd7027871de0b0487b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ledmon-0.92-1.el7.x86_64.rpm"
+          },
+          "sha256:688dbfd142affe8b88385239fd072973abadd2223634322b0b84e201cdb3b046": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdwarf-20130207-4.el7.x86_64.rpm"
+          },
+          "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm"
+          },
+          "sha256:69dcb613e5b4a65bceb2e711d09e110e717c6ad0cbb32f577cfb9589fdc443b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xmlrpc-c-1.32.5-1905.svn2451.el7.x86_64.rpm"
+          },
+          "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm"
+          },
+          "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm"
+          },
+          "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm"
+          },
+          "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm"
+          },
+          "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6e7dae153c72989bcbf0f9174f513dbca277578eba1fe08895b4dafb98308caf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-parent-0.225-244.el7.noarch.rpm"
+          },
+          "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm"
+          },
+          "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:6ff39c0b322acbf413a853deeb745d2f68c7843c55f5352ea56cc5d94548ee9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmodman-2.0.1-8.el7.x86_64.rpm"
+          },
+          "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm"
+          },
+          "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:71fa2eceea6cea25283dccee16f61cedef49f4262af360821ceebef808401090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-File-Path-2.09-2.el7.noarch.rpm"
+          },
+          "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:730dc7a252fdf9307d8a59e6d2788671eeb582175f471522785e479c9f60cfa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Storable-2.45-3.el7.x86_64.rpm"
+          },
+          "sha256:73a140a5c8d48a34b9dbcd0534a1c10c2045d261c8594f334ea438f8803d7b0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-libs-5.16.3-297.el7.x86_64.rpm"
+          },
+          "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm"
+          },
+          "sha256:7567202eb027a1efb739092a6204307d735db326cf92a2c979201e36d841a284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libndp-1.2-9.el7.x86_64.rpm"
+          },
+          "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:7658cb0e7b6518d9786d863c04f12781992989b8bbafefc6c5634104ea138321": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Perldoc-3.20-4.el7.noarch.rpm"
+          },
+          "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm"
+          },
+          "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm"
+          },
+          "sha256:77a55f2182769815d41519b53ca15b54aa09cbe48249cd91487a091e81fdd7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-core-libs-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm"
+          },
+          "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm"
+          },
+          "sha256:791a9cbd72458f4f28a5e7d267ad415c51f9647a60c5645cb288cc4cd85381ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Exporter-5.68-3.el7.noarch.rpm"
+          },
+          "sha256:7a994d8e50f9e5ced5d2082a58ecfb8f79ab1656cec77c65ec67453fbd6839fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-runtime-1.0-1.el7.x86_64.rpm"
+          },
+          "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm"
+          },
+          "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm"
+          },
+          "sha256:7c9af23f813f4b3449075ef79118a69343be7e8878c8ae3ec5907cd6521e319b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setserial-2.17-33.el7.x86_64.rpm"
+          },
+          "sha256:7d15ad33bec7d5bdc64074edaecff6019f590069b5375de7640c7df7e8e3776d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl1000-firmware-39.31.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm"
+          },
+          "sha256:7e3edabd3ad60028285e194934644e087602c2440a672dc8c05996afb044ece4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3160-firmware-25.30.13.0-79.el7.noarch.rpm"
+          },
+          "sha256:7e95db3a020beca4526cad1fb550e360fc776779721902b0401f40425ad2910d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sgpio-1.2.0.10-13.el7.x86_64.rpm"
+          },
+          "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm"
+          },
+          "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:8054fbbaf33682c5c93c39f068bda45fd83df0eed913a6c3102c078c24f4f9d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsss_idmap-1.16.5-10.el7.x86_64.rpm"
+          },
+          "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Scalar-List-Utils/1.45/1.el7eng/x86_64/perl-Scalar-List-Utils-1.45-1.el7eng.x86_64.rpm"
+          },
+          "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdaemon-0.14-7.el7.x86_64.rpm"
+          },
+          "sha256:8287097d72794f1eb40ba7e4da1eaf7d010724f7bcbbd6b33381bb9a9e0bda93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-python-clibs-1.8.1-1.el7.x86_64.rpm"
+          },
+          "sha256:8292047f2f3599b9b32d87143cf717bdb39f65de65a618ebcb864ec19b7b4d7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmraid-1.0.0.rc16-28.el7.x86_64.rpm"
+          },
+          "sha256:8303f7eb2f02a0d34fd34cb8c266c0eab46918411d6bb40d2462d7072da89107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iw-4.3-2.el7.x86_64.rpm"
+          },
+          "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm"
+          },
+          "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Test-Simple/1.302040/1.el7eng/noarch/perl-Test-Simple-1.302040-1.el7eng.noarch.rpm"
+          },
+          "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm"
+          },
+          "sha256:848e44f6fccdd7be3de701153a87acfc6c50c93161d8d7e5f38e2b499b508fdb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bridge-utils-1.5-9.el7.x86_64.rpm"
+          },
+          "sha256:84dddb64dbfa4ef82b02a08fe95491eb909351f8fa7f96a754124a9084c6c8fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530/Packages/WALinuxAgent-2.2.46-2.el7_9.noarch.rpm"
+          },
+          "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm"
+          },
+          "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm"
+          },
+          "sha256:859f352a4b9eb6b91dba755b6404b60bd7bf015e88ad6643648f3681d3a8a55f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-macros-5.16.3-297.el7.x86_64.rpm"
+          },
+          "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm"
+          },
+          "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:8606dc6028993db6b8fc612ee43021c43399c07562385b8d024130051d36c1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-libcurl-7.47.1-4.el7.x86_64.rpm"
+          },
+          "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:86e6a979b9ddfa18c910cb38fa1f9d133761939c2a866a5f594f94124d6d0a43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-vmcore-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:8878a5eb20b8e84d226dc0f27f3df8ad41350f06efcffec159fcacf8238cc771": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/strace-4.24-6.el7.x86_64.rpm"
+          },
+          "sha256:88ca4efd493183e4def9ceaf63e5a07be6bbb1eea11b84dd66213d677e68d9bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervfcopyd-0-0.34.20180415git.el7.x86_64.rpm"
+          },
+          "sha256:88ff978b561a31e1bec818870a09e7078e9f3d0f2530293dde79348ad2ee8697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rdate-1.4-25.el7.x86_64.rpm"
+          },
+          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
+          },
+          "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
+          },
+          "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm"
+          },
+          "sha256:8ae96665d13a50a59f51837fa400670368c6c88fa02528132e889d28071b5348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/geoipupdate-2.5.0-1.el7.x86_64.rpm"
+          },
+          "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm"
+          },
+          "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm"
+          },
+          "sha256:8c91e2e8241f222a2ca540011b58cfdf10b581ae9c6eacdf235bad5da31009f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-kvdo-6.1.3.23-5.el7.x86_64.rpm"
+          },
+          "sha256:8d9f342e8cfe60b59ac65145b7db24f5f4b7ef9de9f7af458c514955c2fd56e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/attr-2.4.46-13.el7.x86_64.rpm"
+          },
+          "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:8f005cf975d92d5d5f69888633a2b0c842d03d9a58140db8ea5a40e7bbf67415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xmlrpc-c-client-1.32.5-1905.svn2451.el7.x86_64.rpm"
+          },
+          "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:916f6a6c4b25af9a227e943cf61ca0873553e2ac67479aa43b954f98735e5d7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-podlators-2.5.1-3.el7.noarch.rpm"
+          },
+          "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:917a406f75a6c064cffe15f7926854750ecb656a34b80ac24e36146d1560cccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/words-3.0-22.el7.noarch.rpm"
+          },
+          "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:920c61a08e456094c25495efb453e04b77b7fa9b1cb6c708cdca4b0e1cf488a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setuptool-1.19.11-8.el7.x86_64.rpm"
+          },
+          "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm"
+          },
+          "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm"
+          },
+          "sha256:93503e6622050a007698e4649903b26f7c76b207461c5e97c9215437a33b031f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libteam-1.29-3.el7.x86_64.rpm"
+          },
+          "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm"
+          },
+          "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm"
+          },
+          "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm"
+          },
+          "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm"
+          },
+          "sha256:95f4c75d788a1b2d5d11f028b04f69d4f0f036f1c814b3cc396ea6ac7f419b6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-filesystem-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:95f881bf85e0867c2023d85d5b86b78835e6997a1078cdc52d727d2ac89e4ae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-pages-overrides-7.9.0-1.el7.x86_64.rpm"
+          },
+          "sha256:96458b749b0783cc8062aa5417da53712b91676dd1a6284f05ec3b68a29261e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/smartmontools-7.0-2.el7.x86_64.rpm"
+          },
+          "sha256:9719db8c12246ac32792b5cc42142e4c1fdc084eb47210623600202ae120b87e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-ureport-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:972ceab21a6657b69dad156a8af938be7242524b52dec1759f7d69e5e555b277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-python-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:978c60b716fd39216dede943a6149f2673a6277b534f5310190dd765e5b0010c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/aic94xx-firmware-30-6.el7.noarch.rpm"
+          },
+          "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm"
+          },
+          "sha256:97dfbf353c370ee92b04a856a883255217528af0cfcbc9f234531efe71c043e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl105-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm"
+          },
+          "sha256:988b25517fadb0af5a9d96ebbaea08b8eaff964d987b93c4687a94af0c436a56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-ccpp-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:99c5dddb22433a4991da81bec61c535ce73ac78228ed4532e64761a77c31942f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-python-0.0.31-4.el7.noarch.rpm"
+          },
+          "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm"
+          },
+          "sha256:9b1dfc6830cce0e4292348f46adb357bb9177d9bc34f10ec4148addfd9fc10c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-date-time-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:9b47cda1043733241a300ee9313c588f3a2f47b66b199bd625febdd3e454357f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-2.0.3-6.el7.x86_64.rpm"
+          },
+          "sha256:9b8a185b88e6d414b5d744aabd5817950d112a8f351bff3c2a01b1ab2b766b1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libicu-50.2-4.el7_7.x86_64.rpm"
+          },
+          "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9cbd12093d658f57664a1e385a5d38401b6c99e70f0b1cca029236ce950bf77d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hyperv-daemons-0-0.34.20180415git.el7.x86_64.rpm"
+          },
+          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
+          },
+          "sha256:9d09e49c6f92e1673f0ce5486cb4e12588694793918a9265436000d2fcb88b7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/psacct-6.6.1-13.el7.x86_64.rpm"
+          },
+          "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm"
+          },
+          "sha256:9ecef8165f4dae5f3e31ff14bc762c927a0cabed1342f1db9422f5599b6f26ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtar-1.2.11-29.el7.x86_64.rpm"
+          },
+          "sha256:9fa4df8bc1cf44c15afcbefc132af31a3cf10092efe11cf7f07995918b2d9f48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fprintd-pam-0.8.1-2.el7.x86_64.rpm"
+          },
+          "sha256:9fa7096dd4182602e14dbe682086e74c777b54ddd511e832091719eff101a927": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-common-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:a08cd4a656134c5923c4ad980c0bb2b5027a7ad73f99ee268127b48f961f7478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-kerneloops-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:a0fecb62ade3bbce7df090cc2364708de0da41fefeb6e06548f0532ca5d9b19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-1.0.2k-19.el7.x86_64.rpm"
+          },
+          "sha256:a11590a762d0990e1c9d0b9f702af5c7925d50950ec8ad889e6e1f128d3c28c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm"
+          },
+          "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm"
+          },
+          "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm"
+          },
+          "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm"
+          },
+          "sha256:a349778d7638edf0225ccfd0ee10c8463a8696cb7e1910b23fdb0bb5effc6edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usb_modeswitch-2.5.1-1.el7.x86_64.rpm"
+          },
+          "sha256:a37d2eeb9810427888dfe2eea1712441e0bb91e74f93d2166a8978a29f82ca98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000-firmware-9.221.4.1-79.el7.noarch.rpm"
+          },
+          "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm"
+          },
+          "sha256:a3dc70cc6472c7eb9d1216acc144a6dceb48bdb69955f01b8585cd80ffdd538a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2b-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm"
+          },
+          "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:a5e3bfb580c6f5e199ea5114bcdd10b395cd5f705c81aa021dc2238fc9de472a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bpftool-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:a600088d03991ca3970973f4c9759790939403eeb0ecaacdc18267ab35f1162a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-indexhtml-7-13.el7.noarch.rpm"
+          },
+          "sha256:a61dcf3c31bc66497c86d007870305008e2ab6d11fc6a570af179afa19bfcbc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wpa_supplicant-2.6-12.el7.x86_64.rpm"
+          },
+          "sha256:a676654d1700d3fd065951eb022ca49800ae5f8f41d6828504e2e5b23293bab7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunwind-1.2-2.el7.x86_64.rpm"
+          },
+          "sha256:a69a9c804aca28b14c8bc7ab65238ecf9a13ee5081b0172377edf007d0def5aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-python-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm"
+          },
+          "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm"
+          },
+          "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm"
+          },
+          "sha256:a85e9f5cbe6f217ed678b18abe2009ab96a0a448ac1140d2dacde37a7fb4f78f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-0.0.31-4.el7.noarch.rpm"
+          },
+          "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm"
+          },
+          "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm"
+          },
+          "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm"
+          },
+          "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:ab255e1e536cbc9e8dc453892ac6f6dcd4b73b20740bb20b9c39fedcd4266107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpm-libs-1.20.7-6.el7.x86_64.rpm"
+          },
+          "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm"
+          },
+          "sha256:aced7b9842dab221f2ca286c7532c9342e81fff0df3f09c4f265ec3fa83d4ece": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3945-firmware-15.32.2.9-79.el7.noarch.rpm"
+          },
+          "sha256:ad851567ad8d5c79b1f26a98c77f67e5630790c8cd08bc58583a34dac023cd4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-1.3.2-16.el7.x86_64.rpm"
+          },
+          "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm"
+          },
+          "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm"
+          },
+          "sha256:aeb22ef9ac260054a3641602a021740b6d0985cbddc60bc00ce2b3279017ca1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpciaccess-0.14-1.el7.x86_64.rpm"
+          },
+          "sha256:aec11b0267a711f6bee2824a9914e88ca55a01738bf409b7ef7e7a38e37a9037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-PathTools-3.40-5.el7.x86_64.rpm"
+          },
+          "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm"
+          },
+          "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm"
+          },
+          "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm"
+          },
+          "sha256:b40290eeee6074620408362d136df5336e221399544480ebfba773fd90a08485": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mailx-12.5-19.el7.x86_64.rpm"
+          },
+          "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:b46266a836d3630b3ee29954714e25e45e1a721a10516661c594490c45365e87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-1.8.1-1.el7.x86_64.rpm"
+          },
+          "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm"
+          },
+          "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm"
+          },
+          "sha256:b59fc16e525b857da2333a7354eec6d1721588e3f7a6714088652a57a32d85ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpatch-0.6.1-6.el7.noarch.rpm"
+          },
+          "sha256:b5a9f5afb8cc541d689a44146b51c3aca035068f9649393f7e8b0e981b22f8de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-rhtsupport-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm"
+          },
+          "sha256:b609592c9a241bc13e6ca1606a1bc24e9bf7d8b002f965d8645b3e51a5f7c569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-libuv-1.9.0-1.el7.x86_64.rpm"
+          },
+          "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b83c398d8040ad255360d3fb37f04982a31d7e51d81815c5fafaf0dbe8fda9e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Time-Local-1.2300-2.el7.noarch.rpm"
+          },
+          "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:b8f77d5b3714ca6d1b19736ad13588997ab31dc39b036f842a07b061af0fd247": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Socket-2.010-5.el7.x86_64.rpm"
+          },
+          "sha256:b94ecd37a58dc42572a099e62c68d449e9c46e857031520d2734c04d4500b801": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm"
+          },
+          "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm"
+          },
+          "sha256:bb7b02048bc98c2f62e62ce67f36eb54cfcbf53f763ea0cd557053d20b2a2682": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdrm-2.4.97-2.el7.x86_64.rpm"
+          },
+          "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:bcc8c0dd7c9650d12b89f7ed0c037709d41dcd13310cfaf48d44323f87735e2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-5.16.3-297.el7.x86_64.rpm"
+          },
+          "sha256:bd09459910a5331c3dccd2a795b6af83c7db2c74df0ee9ec091012bb63a67cb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-1.0-1.el7.x86_64.rpm"
+          },
+          "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm"
+          },
+          "sha256:bd5524100101fc58617dd09216349a130ac7e44b9886e702b46c47d507b796f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervvssd-0-0.34.20180415git.el7.x86_64.rpm"
+          },
+          "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm"
+          },
+          "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm"
+          },
+          "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-tui-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm"
+          },
+          "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm"
+          },
+          "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm"
+          },
+          "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm"
+          },
+          "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
+          },
+          "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm"
+          },
+          "sha256:c4703397f0a79f8f9f47549f3c535ef7c650bc169b5fbe67dfa5699f2ae91e18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chrony-3.4-1.el7.x86_64.rpm"
+          },
+          "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm"
+          },
+          "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm"
+          },
+          "sha256:c672527f93c914be54899edbd5f855c3c957e4493b218db7a69a4e6f54ce2e09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python2-futures-3.1.1-5.el7.noarch.rpm"
+          },
+          "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm"
+          },
+          "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm"
+          },
+          "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm"
+          },
+          "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
+          },
+          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:c95fb7d3137031016bce7742a5a56b2bdb83903d91004783a138cfb4def075ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysstat-10.1.5-19.el7.x86_64.rpm"
+          },
+          "sha256:ca24f6143d050170b1ac8558ebb34aaea23f271e558ce33cf895bd8267f43475": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-data-0.0.31-4.el7.noarch.rpm"
+          },
+          "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cc4fe3933ba69f933159e8ac41aad28f0c9b853dd31cc8f9670f1a40840f0d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pm-utils-1.4.1-27.el7.x86_64.rpm"
+          },
+          "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm"
+          },
+          "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:cea2802e226f857af3899655a86e3b8fb5e761c309c6f4bea61b7972cdede7fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcsh-6.18.01-17.el7.x86_64.rpm"
+          },
+          "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:cf2b99d65041c66e7c71016facdfd1149131f4375b95509307d348472a008713": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-console-notification-2.1.11-60.el7.x86_64.rpm"
+          },
+          "sha256:cf6a087cbf1537d450020c50e0a26d8cab97b6acbff3aed417080fde4c531ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/time-1.7-45.el7.x86_64.rpm"
+          },
+          "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm"
+          },
+          "sha256:d029559bf7ec180b3c1d698cbc2d3f4d7988cc9f17ec40ae62e4da90c4816d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fxload-2002_04_11-16.el7.x86_64.rpm"
+          },
+          "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm"
+          },
+          "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm"
+          },
+          "sha256:d1fb8b3c6fb9a98d63766c3c9a228bb97453ba62cc4a490b6c187b1dfe42fae2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Usage-1.63-3.el7.noarch.rpm"
+          },
+          "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm"
+          },
+          "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:d4c4630f794b5538d8947a5317a69e7dabd7072c2de2f9e39e77cd6c992ac576": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-GB-0.20121024-6.el7.noarch.rpm"
+          },
+          "sha256:d5748eae1488c315afb264a75e64bf0d1b83771abffbf742efd44ba97d27005d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-langpacks-0.4.2-7.el7.noarch.rpm"
+          },
+          "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:d6622bbbb6b862f9ea41e7f0d48e4086c76743f712c9218bb7f63c98912b4fb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-python-219-78.el7.x86_64.rpm"
+          },
+          "sha256:d69952b6417c422f416fe3baddd49dec88a26cd826749961ee24b6721977a2ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ivtv-firmware-20080701-26.el7.noarch.rpm"
+          },
+          "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm"
+          },
+          "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:d763b5794e0ba4ed71da2ac5dbe36f5db84d454bce8c7ee2a09f812edd5b5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zip-3.0-11.el7.x86_64.rpm"
+          },
+          "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm"
+          },
+          "sha256:d866a841fa8afa3b5f4210f172d4eb78aafaa13b0de26ccbea708779fb746b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2a-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:d89d9f74f8b028975b72aa435cd49e708195cd746f9eee3c12ca8b09a2accc0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rng-tools-6.3.1-5.el7.x86_64.rpm"
+          },
+          "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm"
+          },
+          "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm"
+          },
+          "sha256:da015b114f953919b376173d378507d79bd79352960606fe2c941a53543da473": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-US-0.20121024-6.el7.noarch.rpm"
+          },
+          "sha256:da67098eeba3936506e2fcd15e5332d4afffe37e31b97f9170bea8ce9ceafd76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm"
+          },
+          "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm"
+          },
+          "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm"
+          },
+          "sha256:dcb552bcfe95d9f7d30cd11370a3bb1cc106eb1f56c57cbc8a92afa128bcdc7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervkvpd-0-0.34.20180415git.el7.x86_64.rpm"
+          },
+          "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm"
+          },
+          "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm"
+          },
+          "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm"
+          },
+          "sha256:de9f33935b91553ca6880aecde850fbdb92b81786e87c7e04329c4d896320d3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ntpdate-4.2.6p5-29.el7_8.2.x86_64.rpm"
+          },
+          "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm"
+          },
+          "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm"
+          },
+          "sha256:e085d2171393ba86e53bf8b47cc897fccc09382a8a15bf629303c5486e8bd1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Text-ParseWords-3.29-4.el7.noarch.rpm"
+          },
+          "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm"
+          },
+          "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm"
+          },
+          "sha256:e29916f4a360db8235f2130273d6bd60be00611cd8d626ec14f6e143f1e946c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libconfig-1.4.9-5.el7.x86_64.rpm"
+          },
+          "sha256:e329ec13f2a48b369c1d1c454e149bfb0b750d6976d9dba6bc0282410e061b07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vdo-6.1.3.23-5.el7.x86_64.rpm"
+          },
+          "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:e70333dc0e327dd19cd56dd2ad8251ba42920b88ee38718ba99fa1d0f9b06913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-lib-1.1.8-1.el7.x86_64.rpm"
+          },
+          "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm"
+          },
+          "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm"
+          },
+          "sha256:e87571e303e233bbbaed2bfa760111850b8ad262772a73861e62721da31f04d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/augeas-libs-1.4.0-10.el7.x86_64.rpm"
+          },
+          "sha256:e88107f8fa81c9322a1c04e3de4f8459cef9d3b30a8c7763c1c8e22abc70fb5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-python-2.1.11-53.el7.x86_64.rpm"
+          },
+          "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
+          },
+          "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm"
+          },
+          "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm"
+          },
+          "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm"
+          },
+          "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm"
+          },
+          "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm"
+          },
+          "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm"
+          },
+          "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm"
+          },
+          "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm"
+          },
+          "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm"
+          },
+          "sha256:ef6fe84eab681d8549d44ab81ebb8c1ef2c147fa2b90df34cc1dab70b21df355": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsss_nss_idmap-1.16.5-10.el7.x86_64.rpm"
+          },
+          "sha256:efd39d4e825667654577d535aa236a2326b130a30c1150dda522c7208c7c8c33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsdump-3.1.7-1.el7.x86_64.rpm"
+          },
+          "sha256:f0573f0630208eb7e500ff5a58d0bbddf06a3c01fe19979012cfc96e0d650175": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ntsysv-1.7.6-1.el7.x86_64.rpm"
+          },
+          "sha256:f09c7f9cbd9e60531ee2311cfd8ec6a76a6a7d7cebe2ba8d520e333176fbc650": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-1.0.6-13.el7.x86_64.rpm"
+          },
+          "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:f0fcbddda64a9b621d19f72adbc09e35dbeb3d258d55e2a5883c7734e26522d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mlocate-0.26-8.el7.x86_64.rpm"
+          },
+          "sha256:f18f1203a701537f33df24e384493d038346d423475219d1d74c003cbe9cc264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-plain-2.1.26-23.el7.x86_64.rpm"
+          },
+          "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm"
+          },
+          "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm"
+          },
+          "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm"
+          },
+          "sha256:f486a12e4b85857e9f9f66b665e4a65b094e287e31762d22d032cb7c94277ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-libs-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:f4b5c68dee1b1505dafc6b8c1553aa3448137f4b6b06f600b3afd63fe25259fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-plugin-container-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:f4e8763f1a42799dbcbada6f3c7f7f0943c89d9f5369bb750ea067a6e7a5ce4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2030-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:f5605e1b409610564b3f58a07ad22d246af4f679eef1784624e83ecd47d2fd86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinfo-0.6.10-9.el7.x86_64.rpm"
+          },
+          "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm"
+          },
+          "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm"
+          },
+          "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm"
+          },
+          "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm"
+          },
+          "sha256:f7c4319ec1ae973242046f0ef6d4af54c53421124a1339efbd4e06c26f5c809f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usb_modeswitch-data-20170806-1.el7.noarch.rpm"
+          },
+          "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm"
+          },
+          "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm"
+          },
+          "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
+          },
+          "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:fca63e69026cd824dbe1d0ba051894e2bb63b3277d5a01c42fda7accc909b6a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-team-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm"
+          },
+          "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm"
+          },
+          "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm"
+          },
+          "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm"
+          },
+          "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "boost-iostreams",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+      },
+      {
+        "name": "boost-random",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+      },
+      {
+        "name": "boost-system",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+      },
+      {
+        "name": "boost-thread",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "3.0.20",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm",
+        "checksum": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "0.8.10",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm",
+        "checksum": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "glusterfs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+      },
+      {
+        "name": "glusterfs-api",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+      },
+      {
+        "name": "glusterfs-client-xlators",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+      },
+      {
+        "name": "glusterfs-libs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gperftools-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.109",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm",
+        "checksum": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libiscsi",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm",
+        "checksum": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "librados2",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+      },
+      {
+        "name": "librbd1",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm",
+        "checksum": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm",
+        "checksum": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 10,
+        "version": "1.5.3",
+        "release": "175.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm",
+        "checksum": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python3-PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+      },
+      {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm",
+        "checksum": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      }
+    ],
+    "packages": [
+      {
+        "name": "GeoIP",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/GeoIP-1.5.0-14.el7.x86_64.rpm",
+        "checksum": "sha256:315b1c75761f80eb7a2905319f8f6c16926ad9f04a3ebab2a3b205d36da82745"
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655"
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0"
+      },
+      {
+        "name": "NetworkManager-team",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-team-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:fca63e69026cd824dbe1d0ba051894e2bb63b3277d5a01c42fda7accc909b6a9"
+      },
+      {
+        "name": "NetworkManager-tui",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-tui-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
+      },
+      {
+        "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
+        "epoch": 0,
+        "version": "7",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm",
+        "checksum": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+      },
+      {
+        "name": "abrt",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:b94ecd37a58dc42572a099e62c68d449e9c46e857031520d2734c04d4500b801"
+      },
+      {
+        "name": "abrt-addon-ccpp",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-ccpp-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:988b25517fadb0af5a9d96ebbaea08b8eaff964d987b93c4687a94af0c436a56"
+      },
+      {
+        "name": "abrt-addon-kerneloops",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-kerneloops-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:a08cd4a656134c5923c4ad980c0bb2b5027a7ad73f99ee268127b48f961f7478"
+      },
+      {
+        "name": "abrt-addon-pstoreoops",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-pstoreoops-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:512db073b9eaecb7d9f5b8cfd16fd1f7ca213ce98f9f77d3e859a2680601e8b5"
+      },
+      {
+        "name": "abrt-addon-python",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-python-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:a69a9c804aca28b14c8bc7ab65238ecf9a13ee5081b0172377edf007d0def5aa"
+      },
+      {
+        "name": "abrt-addon-vmcore",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-vmcore-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:86e6a979b9ddfa18c910cb38fa1f9d133761939c2a866a5f594f94124d6d0a43"
+      },
+      {
+        "name": "abrt-addon-xorg",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-addon-xorg-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:57cf80287c438875891cbf68322b3ae37682fd2a3c54d7ff247630239dbb2fd2"
+      },
+      {
+        "name": "abrt-cli",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-cli-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:05b11d41594ae949abd8f0f65f265dd815fb1ae2e8618bb3be63a7b7062be100"
+      },
+      {
+        "name": "abrt-console-notification",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-console-notification-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:cf2b99d65041c66e7c71016facdfd1149131f4375b95509307d348472a008713"
+      },
+      {
+        "name": "abrt-dbus",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-dbus-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:2a63a5dc60cbc1cd87af739663f4becd6e05b46bf7daf28e092142f9b140469b"
+      },
+      {
+        "name": "abrt-libs",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-libs-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:448840196e3439f64d64ac56e71d5e2e1d83b7100aeca7ac2719d70e7913f5e6"
+      },
+      {
+        "name": "abrt-python",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-python-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:972ceab21a6657b69dad156a8af938be7242524b52dec1759f7d69e5e555b277"
+      },
+      {
+        "name": "abrt-tui",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "60.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/abrt-tui-2.1.11-60.el7.x86_64.rpm",
+        "checksum": "sha256:2ecf5b8dbb340dd2d3e87909a48db4e2fe640b4d6fbe582ee313388bd1ed61cb"
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "aic94xx-firmware",
+        "epoch": 0,
+        "version": "30",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/aic94xx-firmware-30-6.el7.noarch.rpm",
+        "checksum": "sha256:978c60b716fd39216dede943a6149f2673a6277b534f5310190dd765e5b0010c"
+      },
+      {
+        "name": "alsa-firmware",
+        "epoch": 0,
+        "version": "1.0.28",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-firmware-1.0.28-2.el7.noarch.rpm",
+        "checksum": "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0"
+      },
+      {
+        "name": "alsa-lib",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-lib-1.1.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:e70333dc0e327dd19cd56dd2ad8251ba42920b88ee38718ba99fa1d0f9b06913"
+      },
+      {
+        "name": "alsa-tools-firmware",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-tools-firmware-1.1.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:005d3c65516a8021aac3e640d498a5fafe7f86eb7848009aed399a42730aa79f"
+      },
+      {
+        "name": "at",
+        "epoch": 0,
+        "version": "3.1.13",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/at-3.1.13-24.el7.x86_64.rpm",
+        "checksum": "sha256:2ec491fcbf33117f504cacfff9f2332fd89c260c56355c1d463e7ebc9b11f04e"
+      },
+      {
+        "name": "attr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/attr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:8d9f342e8cfe60b59ac65145b7db24f5f4b7ef9de9f7af458c514955c2fd56e7"
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "audit-libs-python",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+      },
+      {
+        "name": "augeas-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/augeas-libs-1.4.0-10.el7.x86_64.rpm",
+        "checksum": "sha256:e87571e303e233bbbaed2bfa760111850b8ad262772a73861e62721da31f04d7"
+      },
+      {
+        "name": "authconfig",
+        "epoch": 0,
+        "version": "6.2.8",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/authconfig-6.2.8-30.el7.x86_64.rpm",
+        "checksum": "sha256:5c72631f154e7cbfa12f04df7e3b2efcfd6f5c77a0fa7a30b684001a277cae0b"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "bash-completion",
+        "epoch": 1,
+        "version": "2.1",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-completion-2.1-8.el7.noarch.rpm",
+        "checksum": "sha256:1b69e24543d83757d4f6b14167a3b8c777f214eb21caa309598a4177423f61de"
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.06.95",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm",
+        "checksum": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+      },
+      {
+        "name": "bind-libs",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-libs-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:f486a12e4b85857e9f9f66b665e4a65b094e287e31762d22d032cb7c94277ede"
+      },
+      {
+        "name": "bind-libs-lite",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-libs-lite-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:311477ee57b269f9693a70931066ef2852c030557fb3c61313308af71bf46b94"
+      },
+      {
+        "name": "bind-license",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-license-9.11.4-26.P2.el7.noarch.rpm",
+        "checksum": "sha256:3d24d7a5ff7832751ccee0b6acbbef45cea0154ba4f038fc0cce045a30460ae3"
+      },
+      {
+        "name": "bind-utils",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-utils-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:0d3b093a48d64797df3a93d7dec2d26554efbece0ede5c6d4b90347ae4a9e1c4"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "biosdevname",
+        "epoch": 0,
+        "version": "0.7.3",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm",
+        "checksum": "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f"
+      },
+      {
+        "name": "blktrace",
+        "epoch": 0,
+        "version": "1.0.5",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/blktrace-1.0.5-9.el7.x86_64.rpm",
+        "checksum": "sha256:2e725765793b2f83faaec043d050f138b0c9e6c24d1fb7fe455e3743135d3c60"
+      },
+      {
+        "name": "boost-date-time",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-date-time-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:9b1dfc6830cce0e4292348f46adb357bb9177d9bc34f10ec4148addfd9fc10c2"
+      },
+      {
+        "name": "boost-system",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+      },
+      {
+        "name": "boost-thread",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+      },
+      {
+        "name": "bpftool",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bpftool-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:a5e3bfb580c6f5e199ea5114bcdd10b395cd5f705c81aa021dc2238fc9de472a"
+      },
+      {
+        "name": "bridge-utils",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bridge-utils-1.5-9.el7.x86_64.rpm",
+        "checksum": "sha256:848e44f6fccdd7be3de701153a87acfc6c50c93161d8d7e5f38e2b499b508fdb"
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "4.9.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+      },
+      {
+        "name": "bzip2",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:f09c7f9cbd9e60531ee2311cfd8ec6a76a6a7d7cebe2ba8d520e333176fbc650"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm",
+        "checksum": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chrony-3.4-1.el7.x86_64.rpm",
+        "checksum": "sha256:c4703397f0a79f8f9f47549f3c535ef7c650bc169b5fbe67dfa5699f2ae91e18"
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "19.4",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm",
+        "checksum": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.29",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm",
+        "checksum": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "crda",
+        "epoch": 0,
+        "version": "3.18_2018.05.31",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crda-3.18_2018.05.31-4.el7.x86_64.rpm",
+        "checksum": "sha256:645ae25a1ff4f52ed840eb5d93043596c3c84fa4c36e117678e57f10423586c8"
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.20121102git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm",
+        "checksum": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+      },
+      {
+        "name": "cryptsetup",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:9b47cda1043733241a300ee9313c588f3a2f47b66b199bd625febdd3e454357f"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "cyrus-sasl-plain",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-plain-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:f18f1203a701537f33df24e384493d038346d423475219d1d74c003cbe9cc264"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.100",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm",
+        "checksum": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "dbus-python",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+      },
+      {
+        "name": "desktop-file-utils",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+      },
+      {
+        "name": "dhclient",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+      },
+      {
+        "name": "dmraid",
+        "epoch": 0,
+        "version": "1.0.0.rc16",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmraid-1.0.0.rc16-28.el7.x86_64.rpm",
+        "checksum": "sha256:8292047f2f3599b9b32d87143cf717bdb39f65de65a618ebcb864ec19b7b4d7a"
+      },
+      {
+        "name": "dmraid-events",
+        "epoch": 0,
+        "version": "1.0.0.rc16",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmraid-events-1.0.0.rc16-28.el7.x86_64.rpm",
+        "checksum": "sha256:5f05c450273ead37b116bc141378fc2da9ac7096c2ecbd11bb4d41aed000fcfd"
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "3.0.20",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm",
+        "checksum": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+      },
+      {
+        "name": "dyninst",
+        "epoch": 0,
+        "version": "9.3.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dyninst-9.3.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:12b5567baa42fc4200d7a02264d8bae115c4a3ead6f04fb634d6f8243988e3e8"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "ebtables",
+        "epoch": 0,
+        "version": "2.0.10",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm",
+        "checksum": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+      },
+      {
+        "name": "ed",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ed-1.9-4.el7.x86_64.rpm",
+        "checksum": "sha256:24d1e9b218aa1c0649bafabeb78234deee3ef0388c372cb621dee67e74a64370"
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "17",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm",
+        "checksum": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "36",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm",
+        "checksum": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+      },
+      {
+        "name": "elfutils",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:a11590a762d0990e1c9d0b9f702af5c7925d50950ec8ad889e6e1f128d3c28c3"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "emacs-filesystem",
+        "epoch": 1,
+        "version": "24.3",
+        "release": "23.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm",
+        "checksum": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "4.8",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm",
+        "checksum": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "fipscheck",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+      },
+      {
+        "name": "fipscheck-lib",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+      },
+      {
+        "name": "fprintd",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fprintd-0.8.1-2.el7.x86_64.rpm",
+        "checksum": "sha256:25f29adfb9ba39f408b7c268bd6e089e901593f1c36840ebb59e801afef0430c"
+      },
+      {
+        "name": "fprintd-pam",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fprintd-pam-0.8.1-2.el7.x86_64.rpm",
+        "checksum": "sha256:9fa4df8bc1cf44c15afcbefc132af31a3cf10092efe11cf7f07995918b2d9f48"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "fxload",
+        "epoch": 0,
+        "version": "2002_04_11",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fxload-2002_04_11-16.el7.x86_64.rpm",
+        "checksum": "sha256:d029559bf7ec180b3c1d698cbc2d3f4d7988cc9f17ec40ae62e4da90c4816d35"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdb",
+        "epoch": 0,
+        "version": "7.6.1",
+        "release": "120.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdb-7.6.1-120.el7.x86_64.rpm",
+        "checksum": "sha256:14ea0df235cd8b92e60655961c88d3ea801e81bfab0f39f8356e934948b9185f"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "0.8.10",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm",
+        "checksum": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+      },
+      {
+        "name": "geoipupdate",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/geoipupdate-2.5.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:8ae96665d13a50a59f51837fa400670368c6c88fa02528132e889d28071b5348"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.0.22",
+        "release": "5.el7_5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm",
+        "checksum": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+      },
+      {
+        "name": "gpm-libs",
+        "epoch": 0,
+        "version": "1.20.7",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpm-libs-1.20.7-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab255e1e536cbc9e8dc453892ac6f6dcd4b73b20740bb20b9c39fedcd4266107"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.2",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm",
+        "checksum": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+      },
+      {
+        "name": "grub2",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:0242b754ddce29e5a16f952a132c0181457f98312c4e1c5c31afa8e4358102ca"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.28",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm",
+        "checksum": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-1.3.2-16.el7.x86_64.rpm",
+        "checksum": "sha256:ad851567ad8d5c79b1f26a98c77f67e5630790c8cd08bc58583a34dac023cd4b"
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20121024",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-0.20121024-6.el7.noarch.rpm",
+        "checksum": "sha256:4d5368561d92f2a57a443e5f161b289c3862ec677906634c6bca536c3e0860b0"
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20121024",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-GB-0.20121024-6.el7.noarch.rpm",
+        "checksum": "sha256:d4c4630f794b5538d8947a5317a69e7dabd7072c2de2f9e39e77cd6c992ac576"
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20121024",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hunspell-en-US-0.20121024-6.el7.noarch.rpm",
+        "checksum": "sha256:da015b114f953919b376173d378507d79bd79352960606fe2c941a53543da473"
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.252",
+        "release": "9.7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm",
+        "checksum": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+      },
+      {
+        "name": "hyperv-daemons",
+        "epoch": 0,
+        "version": "0",
+        "release": "0.34.20180415git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hyperv-daemons-0-0.34.20180415git.el7.x86_64.rpm",
+        "checksum": "sha256:9cbd12093d658f57664a1e385a5d38401b6c99e70f0b1cca029236ce950bf77d"
+      },
+      {
+        "name": "hyperv-daemons-license",
+        "epoch": 0,
+        "version": "0",
+        "release": "0.34.20180415git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hyperv-daemons-license-0-0.34.20180415git.el7.noarch.rpm",
+        "checksum": "sha256:2367c7a15f8067150791d2f485693249a0f65a970b1b3e7e1d5d82768173304b"
+      },
+      {
+        "name": "hypervfcopyd",
+        "epoch": 0,
+        "version": "0",
+        "release": "0.34.20180415git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervfcopyd-0-0.34.20180415git.el7.x86_64.rpm",
+        "checksum": "sha256:88ca4efd493183e4def9ceaf63e5a07be6bbb1eea11b84dd66213d677e68d9bd"
+      },
+      {
+        "name": "hypervkvpd",
+        "epoch": 0,
+        "version": "0",
+        "release": "0.34.20180415git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervkvpd-0-0.34.20180415git.el7.x86_64.rpm",
+        "checksum": "sha256:dcb552bcfe95d9f7d30cd11370a3bb1cc106eb1f56c57cbc8a92afa128bcdc7b"
+      },
+      {
+        "name": "hypervvssd",
+        "epoch": 0,
+        "version": "0",
+        "release": "0.34.20180415git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hypervvssd-0-0.34.20180415git.el7.x86_64.rpm",
+        "checksum": "sha256:bd5524100101fc58617dd09216349a130ac7e44b9886e702b46c47d507b796f6"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "9.49.53",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm",
+        "checksum": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "4.11.0",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm",
+        "checksum": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+      },
+      {
+        "name": "iprutils",
+        "epoch": 0,
+        "version": "2.4.17.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee"
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.4.21",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm",
+        "checksum": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20160308",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm",
+        "checksum": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 3,
+        "version": "1.0.7",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm",
+        "checksum": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+      },
+      {
+        "name": "ivtv-firmware",
+        "epoch": 2,
+        "version": "20080701",
+        "release": "26.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ivtv-firmware-20080701-26.el7.noarch.rpm",
+        "checksum": "sha256:d69952b6417c422f416fe3baddd49dec88a26cd826749961ee24b6721977a2ce"
+      },
+      {
+        "name": "iw",
+        "epoch": 0,
+        "version": "4.3",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iw-4.3-2.el7.x86_64.rpm",
+        "checksum": "sha256:8303f7eb2f02a0d34fd34cb8c266c0eab46918411d6bb40d2462d7072da89107"
+      },
+      {
+        "name": "iwl100-firmware",
+        "epoch": 0,
+        "version": "39.31.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl100-firmware-39.31.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:12d3f2ca7449af3e3a3cff8be6b024cd1106987f49a7be16a84fa9bb39f2dde9"
+      },
+      {
+        "name": "iwl1000-firmware",
+        "epoch": 1,
+        "version": "39.31.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl1000-firmware-39.31.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:7d15ad33bec7d5bdc64074edaecff6019f590069b5375de7640c7df7e8e3776d"
+      },
+      {
+        "name": "iwl105-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl105-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:97dfbf353c370ee92b04a856a883255217528af0cfcbc9f234531efe71c043e6"
+      },
+      {
+        "name": "iwl135-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl135-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:11ac559bb43266411c847e259a1bb111ee67b4fdc09c3d9dbf6e91094f815e0f"
+      },
+      {
+        "name": "iwl2000-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2000-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:12b098f5666193520fc84a092ce438a39f8c3ff53f7a7c4eee55e6515b49618c"
+      },
+      {
+        "name": "iwl2030-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2030-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:f4e8763f1a42799dbcbada6f3c7f7f0943c89d9f5369bb750ea067a6e7a5ce4b"
+      },
+      {
+        "name": "iwl3160-firmware",
+        "epoch": 0,
+        "version": "25.30.13.0",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3160-firmware-25.30.13.0-79.el7.noarch.rpm",
+        "checksum": "sha256:7e3edabd3ad60028285e194934644e087602c2440a672dc8c05996afb044ece4"
+      },
+      {
+        "name": "iwl3945-firmware",
+        "epoch": 0,
+        "version": "15.32.2.9",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3945-firmware-15.32.2.9-79.el7.noarch.rpm",
+        "checksum": "sha256:aced7b9842dab221f2ca286c7532c9342e81fff0df3f09c4f265ec3fa83d4ece"
+      },
+      {
+        "name": "iwl4965-firmware",
+        "epoch": 0,
+        "version": "228.61.2.24",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm",
+        "checksum": "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8"
+      },
+      {
+        "name": "iwl5000-firmware",
+        "epoch": 0,
+        "version": "8.83.5.1_1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5000-firmware-8.83.5.1_1-79.el7.noarch.rpm",
+        "checksum": "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244"
+      },
+      {
+        "name": "iwl5150-firmware",
+        "epoch": 0,
+        "version": "8.24.2.2",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5150-firmware-8.24.2.2-79.el7.noarch.rpm",
+        "checksum": "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a"
+      },
+      {
+        "name": "iwl6000-firmware",
+        "epoch": 0,
+        "version": "9.221.4.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000-firmware-9.221.4.1-79.el7.noarch.rpm",
+        "checksum": "sha256:a37d2eeb9810427888dfe2eea1712441e0bb91e74f93d2166a8978a29f82ca98"
+      },
+      {
+        "name": "iwl6000g2a-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2a-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:d866a841fa8afa3b5f4210f172d4eb78aafaa13b0de26ccbea708779fb746b14"
+      },
+      {
+        "name": "iwl6000g2b-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2b-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:a3dc70cc6472c7eb9d1216acc144a6dceb48bdb69955f01b8585cd80ffdd538a"
+      },
+      {
+        "name": "iwl6050-firmware",
+        "epoch": 0,
+        "version": "41.28.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6050-firmware-41.28.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:0b4110cf94f7f793dbabb7a1a616087455ab316ec74ad5204abb0fd2f211ee58"
+      },
+      {
+        "name": "iwl7260-firmware",
+        "epoch": 0,
+        "version": "25.30.13.0",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl7260-firmware-25.30.13.0-79.el7.noarch.rpm",
+        "checksum": "sha256:33fba59c069f63b29ac955363d97683c582178f5e314d594c452b8a630a59170"
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/jansson-2.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:58ce6f65f4b61dfcb190deac65fca0cc210abfdae65b54a88ee5f61c61e3e47e"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.15",
+        "release": "51.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm",
+        "checksum": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-kvdo",
+        "epoch": 0,
+        "version": "6.1.3.23",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-kvdo-6.1.3.23-5.el7.x86_64.rpm",
+        "checksum": "sha256:8c91e2e8241f222a2ca540011b58cfdf10b581ae9c6eacdf235bad5da31009f5"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "kpatch",
+        "epoch": 0,
+        "version": "0.6.1",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpatch-0.6.1-6.el7.noarch.rpm",
+        "checksum": "sha256:b59fc16e525b857da2333a7354eec6d1721588e3f7a6714088652a57a32d85ee"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "langtable",
+        "epoch": 0,
+        "version": "0.0.31",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-0.0.31-4.el7.noarch.rpm",
+        "checksum": "sha256:a85e9f5cbe6f217ed678b18abe2009ab96a0a448ac1140d2dacde37a7fb4f78f"
+      },
+      {
+        "name": "langtable-data",
+        "epoch": 0,
+        "version": "0.0.31",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-data-0.0.31-4.el7.noarch.rpm",
+        "checksum": "sha256:ca24f6143d050170b1ac8558ebb34aaea23f271e558ce33cf895bd8267f43475"
+      },
+      {
+        "name": "langtable-python",
+        "epoch": 0,
+        "version": "0.0.31",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/langtable-python-0.0.31-4.el7.noarch.rpm",
+        "checksum": "sha256:99c5dddb22433a4991da81bec61c535ce73ac78228ed4532e64761a77c31942f"
+      },
+      {
+        "name": "ledmon",
+        "epoch": 0,
+        "version": "0.92",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ledmon-0.92-1.el7.x86_64.rpm",
+        "checksum": "sha256:683ee2641d3562d86c587971a43828110908202066520bd7027871de0b0487b3"
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "458",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm",
+        "checksum": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.109",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm",
+        "checksum": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcgroup",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm",
+        "checksum": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libconfig",
+        "epoch": 0,
+        "version": "1.4.9",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libconfig-1.4.9-5.el7.x86_64.rpm",
+        "checksum": "sha256:e29916f4a360db8235f2130273d6bd60be00611cd8d626ec14f6e143f1e946c6"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdaemon",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdaemon-0.14-7.el7.x86_64.rpm",
+        "checksum": "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libdrm",
+        "epoch": 0,
+        "version": "2.4.97",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdrm-2.4.97-2.el7.x86_64.rpm",
+        "checksum": "sha256:bb7b02048bc98c2f62e62ce67f36eb54cfcbf53f763ea0cd557053d20b2a2682"
+      },
+      {
+        "name": "libdwarf",
+        "epoch": 0,
+        "version": "20130207",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdwarf-20130207-4.el7.x86_64.rpm",
+        "checksum": "sha256:688dbfd142affe8b88385239fd072973abadd2223634322b0b84e201cdb3b046"
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "12.20121213cvs.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm",
+        "checksum": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.9",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm",
+        "checksum": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libfprint",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfprint-0.8.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3d21b95e0248c86ffaff71a1df85fd7073ab09dc05874fd8a6940eab6edac6fd"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libgudev1",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "50.2",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libicu-50.2-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:9b8a185b88e6d414b5d744aabd5817950d112a8f351bff3c2a01b1ab2b766b1e"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+      },
+      {
+        "name": "libmodman",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmodman-2.0.1-8.el7.x86_64.rpm",
+        "checksum": "sha256:6ff39c0b322acbf413a853deeb745d2f68c7843c55f5352ea56cc5d94548ee9d"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libndp-1.2-9.el7.x86_64.rpm",
+        "checksum": "sha256:7567202eb027a1efb739092a6204307d735db326cf92a2c979201e36d841a284"
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm",
+        "checksum": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+      },
+      {
+        "name": "libnl",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.2.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-3.2.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:2e56f3449308538a955393ca85e4908d9022885fa34894cb365669b9d38de282"
+      },
+      {
+        "name": "libnl3-cli",
+        "epoch": 0,
+        "version": "3.2.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-cli-3.2.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:535aec9847767995152b43de3f8323e53c7c36decf894ca6e426742fb1507322"
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.5.3",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm",
+        "checksum": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+      },
+      {
+        "name": "libpciaccess",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpciaccess-0.14-1.el7.x86_64.rpm",
+        "checksum": "sha256:aeb22ef9ac260054a3641602a021740b6d0985cbddc60bc00ce2b3279017ca1c"
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm",
+        "checksum": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libproxy",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libproxy-0.4.11-11.el7.x86_64.rpm",
+        "checksum": "sha256:096652bf46e6ed5a256632cb11ca56d660830e60f4fdca3b254bb5d4b1ba3d7c"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "libreport",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:10c1e258fd2bbc90f1ddf5082676ad9b0c748faa5f7968039e16ce9eace381e4"
+      },
+      {
+        "name": "libreport-cli",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-cli-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:2345c8acf8cf82a953622d784b2200fd114a3b52fe92b3864929d305618424bc"
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-filesystem-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:11fc857bbb8e1ae64b236afcecf7d741b73d66a99d65e0014f1da0e45f3b3140"
+      },
+      {
+        "name": "libreport-plugin-mailx",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-mailx-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:641326bddc57b01e75135caff060a9b94fb26f9a322df71a53a4138540148b09"
+      },
+      {
+        "name": "libreport-plugin-rhtsupport",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-rhtsupport-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:b5a9f5afb8cc541d689a44146b51c3aca035068f9649393f7e8b0e981b22f8de"
+      },
+      {
+        "name": "libreport-plugin-ureport",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-plugin-ureport-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:9719db8c12246ac32792b5cc42142e4c1fdc084eb47210623600202ae120b87e"
+      },
+      {
+        "name": "libreport-python",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-python-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:e88107f8fa81c9322a1c04e3de4f8459cef9d3b30a8c7763c1c8e22abc70fb5b"
+      },
+      {
+        "name": "libreport-rhel",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-rhel-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:52b0f84c76826cc370f665ae358e9525e2a374446fc680b3eada61520ab0c1e0"
+      },
+      {
+        "name": "libreport-web",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "53.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libreport-web-2.1.11-53.el7.x86_64.rpm",
+        "checksum": "sha256:00bae5c24b3d71b20e66526b17f74457d0be31a17f005e3bf0abab0e61e19e97"
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:da67098eeba3936506e2fcd15e5332d4afffe37e31b97f9170bea8ce9ceafd76"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsemanage-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "1.16.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsss_idmap-1.16.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:8054fbbaf33682c5c93c39f068bda45fd83df0eed913a6c3102c078c24f4f9d7"
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "1.16.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsss_nss_idmap-1.16.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:ef6fe84eab681d8549d44ab81ebb8c1ef2c147fa2b90df34cc1dab70b21df355"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libstoragemgmt",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-1.8.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:b46266a836d3630b3ee29954714e25e45e1a721a10516661c594490c45365e87"
+      },
+      {
+        "name": "libstoragemgmt-python",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-python-1.8.1-1.el7.noarch.rpm",
+        "checksum": "sha256:2edbe67c9f917f0f26c9caf326f59045209f40d474c1d586ad64b24babe04727"
+      },
+      {
+        "name": "libstoragemgmt-python-clibs",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstoragemgmt-python-clibs-1.8.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:8287097d72794f1eb40ba7e4da1eaf7d010724f7bcbbd6b33381bb9a9e0bda93"
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm",
+        "checksum": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+      },
+      {
+        "name": "libtar",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "29.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtar-1.2.11-29.el7.x86_64.rpm",
+        "checksum": "sha256:9ecef8165f4dae5f3e31ff14bc762c927a0cabed1342f1db9422f5599b6f26ee"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libteam",
+        "epoch": 0,
+        "version": "1.29",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libteam-1.29-3.el7.x86_64.rpm",
+        "checksum": "sha256:93503e6622050a007698e4649903b26f7c76b207461c5e97c9215437a33b031f"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libunwind",
+        "epoch": 2,
+        "version": "1.2",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunwind-1.2-2.el7.x86_64.rpm",
+        "checksum": "sha256:a676654d1700d3fd065951eb022ca49800ae5f8f41d6828504e2e5b23293bab7"
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.21",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libusbx-1.0.21-1.el7.x86_64.rpm",
+        "checksum": "sha256:31c3efd8249034f7a5b00c5c87cface914234c10c3f55c95a81fb621466c3b0e"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libxml2-python",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+      },
+      {
+        "name": "libxslt",
+        "epoch": 0,
+        "version": "1.1.28",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm",
+        "checksum": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200421",
+        "release": "79.git78c0348.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm",
+        "checksum": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+      },
+      {
+        "name": "lm_sensors-libs",
+        "epoch": 0,
+        "version": "3.4.0",
+        "release": "8.20160601gitf9185e5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lm_sensors-libs-3.4.0-8.20160601gitf9185e5.el7.x86_64.rpm",
+        "checksum": "sha256:52119268a72a5b22af74b0d71fcfd6c8b2ac6237c161b5eb628f345fa52704da"
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.8.6",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm",
+        "checksum": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.18",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+      },
+      {
+        "name": "lsof",
+        "epoch": 0,
+        "version": "4.87",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsof-4.87-6.el7.x86_64.rpm",
+        "checksum": "sha256:2a2f4b503c06c43f5a838109b40134e0663efeb92c00d6b725ef52f2ffedc6e7"
+      },
+      {
+        "name": "lsscsi",
+        "epoch": 0,
+        "version": "0.27",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm",
+        "checksum": "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.06",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm",
+        "checksum": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+      },
+      {
+        "name": "m2crypto",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+      },
+      {
+        "name": "mailx",
+        "epoch": 0,
+        "version": "12.5",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mailx-12.5-19.el7.x86_64.rpm",
+        "checksum": "sha256:b40290eeee6074620408362d136df5336e221399544480ebfba773fd90a08485"
+      },
+      {
+        "name": "make",
+        "epoch": 1,
+        "version": "3.82",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/make-3.82-24.el7.x86_64.rpm",
+        "checksum": "sha256:589adacd70beea80aabbd1ed217632f98a3ee4a327622a86aeb83fb05bd2de4d"
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+      },
+      {
+        "name": "man-pages",
+        "epoch": 0,
+        "version": "3.53",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-pages-3.53-5.el7.noarch.rpm",
+        "checksum": "sha256:1afd06d4eafb5bb6d2e5098a498d5eccc9d06f5e5413ce35ce0fb08eccfd6175"
+      },
+      {
+        "name": "man-pages-overrides",
+        "epoch": 0,
+        "version": "7.9.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-pages-overrides-7.9.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:95f881bf85e0867c2023d85d5b86b78835e6997a1078cdc52d727d2ac89e4ae7"
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mdadm-4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:12e5a19c594ccbce0507ce57297b8305033a07c474c9d4c176d70545e1a20b23"
+      },
+      {
+        "name": "microcode_ctl",
+        "epoch": 2,
+        "version": "2.1",
+        "release": "73.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm",
+        "checksum": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+      },
+      {
+        "name": "mlocate",
+        "epoch": 0,
+        "version": "0.26",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mlocate-0.26-8.el7.x86_64.rpm",
+        "checksum": "sha256:f0fcbddda64a9b621d19f72adbc09e35dbeb3d258d55e2a5883c7734e26522d2"
+      },
+      {
+        "name": "mokutil",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+      },
+      {
+        "name": "mozjs17",
+        "epoch": 0,
+        "version": "17.0.0",
+        "release": "20.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm",
+        "checksum": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+      },
+      {
+        "name": "mtr",
+        "epoch": 2,
+        "version": "0.85",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mtr-0.85-7.el7.x86_64.rpm",
+        "checksum": "sha256:2540ffdba1bfc89714d18489247193d661ec5ac342159c3f5907e13981cf5a21"
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nano-2.3.1-10.el7.x86_64.rpm",
+        "checksum": "sha256:5aa53274792dcf7e419e57a7af5d17c9edad42a0caf6c71b007c2e1f86bd1dfb"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.25.20131004git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm",
+        "checksum": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+      },
+      {
+        "name": "newt-python",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "ntpdate",
+        "epoch": 0,
+        "version": "4.2.6p5",
+        "release": "29.el7_8.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ntpdate-4.2.6p5-29.el7_8.2.x86_64.rpm",
+        "checksum": "sha256:de9f33935b91553ca6880aecde850fbdb92b81786e87c7e04329c4d896320d3c"
+      },
+      {
+        "name": "ntsysv",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ntsysv-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:f0573f0630208eb7e500ff5a58d0bbddf06a3c01fe19979012cfc96e0d650175"
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm",
+        "checksum": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+      },
+      {
+        "name": "openssl",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:a0fecb62ade3bbce7df090cc2364708de0da41fefeb6e06548f0532ca5d9b19c"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.79",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm",
+        "checksum": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "perl",
+        "epoch": 4,
+        "version": "5.16.3",
+        "release": "297.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-5.16.3-297.el7.x86_64.rpm",
+        "checksum": "sha256:bcc8c0dd7c9650d12b89f7ed0c037709d41dcd13310cfaf48d44323f87735e2b"
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.26",
+        "release": "244.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Carp-1.26-244.el7.noarch.rpm",
+        "checksum": "sha256:08a7cd07930cc331c629d79dcfc919f44695cddbc60ae44b0af08d5618462484"
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.68",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Exporter-5.68-3.el7.noarch.rpm",
+        "checksum": "sha256:791a9cbd72458f4f28a5e7d267ad415c51f9647a60c5645cb288cc4cd85381ea"
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.09",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-File-Path-2.09-2.el7.noarch.rpm",
+        "checksum": "sha256:71fa2eceea6cea25283dccee16f61cedef49f4262af360821ceebef808401090"
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 0,
+        "version": "0.23.01",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-File-Temp-0.23.01-3.el7.noarch.rpm",
+        "checksum": "sha256:15b698148ae0f924adf4e287e2de86c2289a3f2d46d9170ff21972ab0a73ba36"
+      },
+      {
+        "name": "perl-Filter",
+        "epoch": 0,
+        "version": "1.49",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Filter-1.49-3.el7.x86_64.rpm",
+        "checksum": "sha256:49176af8fa7ec5f144b33988ab7ac6b186793c0438e28d0b12f343e9addb8451"
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 0,
+        "version": "2.40",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Getopt-Long-2.40-3.el7.noarch.rpm",
+        "checksum": "sha256:2d777b3e8a9940a4d6111c7212bbbb44de83916e3a61457ea269107b29740e64"
+      },
+      {
+        "name": "perl-HTTP-Date",
+        "epoch": 0,
+        "version": "6.02",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-HTTP-Date-6.02-8.el7.noarch.rpm",
+        "checksum": "sha256:44067d820351d312a98fe1ac443abe0d665ee2abe126ffed30a02852e7829982"
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-IO-Socket-SSL-1.94-7.el7.noarch.rpm",
+        "checksum": "sha256:2585143d999b18c0613fd978acabe0f8d4454a761562454b5d1b7fbb14817a45"
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20130114",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Mozilla-CA-20130114-5.el7.noarch.rpm",
+        "checksum": "sha256:29453086d819698dc37f2ae638d20d7c4bf87d681d4031d6ae747a8025c79007"
+      },
+      {
+        "name": "perl-Net-LibIDN",
+        "epoch": 0,
+        "version": "0.12",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-LibIDN-0.12-15.el7.x86_64.rpm",
+        "checksum": "sha256:40a98b2b368731fc1cc323472b3b8aafb82e9bc8205009dabe9e822b30adb431"
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.55",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Net-SSLeay-1.55-6.el7.x86_64.rpm",
+        "checksum": "sha256:20ca404a59b969e7e5bc88bdced333ce241d5eb4682f703e72674a40603fda8c"
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.40",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-PathTools-3.40-5.el7.x86_64.rpm",
+        "checksum": "sha256:aec11b0267a711f6bee2824a9914e88ca55a01738bf409b7ef7e7a38e37a9037"
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.04",
+        "release": "297.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Escapes-1.04-297.el7.noarch.rpm",
+        "checksum": "sha256:03e569d5e0e7b80fe5439c920580024fb34b599f2dbe82bd8aa80381348bc958"
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.20",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Perldoc-3.20-4.el7.noarch.rpm",
+        "checksum": "sha256:7658cb0e7b6518d9786d863c04f12781992989b8bbafefc6c5634104ea138321"
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.28",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Simple-3.28-4.el7.noarch.rpm",
+        "checksum": "sha256:43616a0a035c29c98cdf462c0dc2a7c5e98c56000ca7ec358984947b7b222902"
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 0,
+        "version": "1.63",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Pod-Usage-1.63-3.el7.noarch.rpm",
+        "checksum": "sha256:d1fb8b3c6fb9a98d63766c3c9a228bb97453ba62cc4a490b6c187b1dfe42fae2"
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 0,
+        "version": "2.010",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Socket-2.010-5.el7.x86_64.rpm",
+        "checksum": "sha256:b8f77d5b3714ca6d1b19736ad13588997ab31dc39b036f842a07b061af0fd247"
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 0,
+        "version": "2.45",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Storable-2.45-3.el7.x86_64.rpm",
+        "checksum": "sha256:730dc7a252fdf9307d8a59e6d2788671eeb582175f471522785e479c9f60cfa9"
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.29",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Text-ParseWords-3.29-4.el7.noarch.rpm",
+        "checksum": "sha256:e085d2171393ba86e53bf8b47cc897fccc09382a8a15bf629303c5486e8bd1cc"
+      },
+      {
+        "name": "perl-Time-HiRes",
+        "epoch": 4,
+        "version": "1.9725",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Time-HiRes-1.9725-3.el7.x86_64.rpm",
+        "checksum": "sha256:672035f4b12c0ce547a90287d936caeadcb0c06dbdda01a026071eab9622da04"
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 0,
+        "version": "1.2300",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-Time-Local-1.2300-2.el7.noarch.rpm",
+        "checksum": "sha256:b83c398d8040ad255360d3fb37f04982a31d7e51d81815c5fafaf0dbe8fda9e7"
+      },
+      {
+        "name": "perl-TimeDate",
+        "epoch": 1,
+        "version": "2.30",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-TimeDate-2.30-2.el7.noarch.rpm",
+        "checksum": "sha256:034def562f71d5c64101f5959acec91a91a6ed7f0e1ccdcb50f098938a437ef9"
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.27",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-constant-1.27-2.el7.noarch.rpm",
+        "checksum": "sha256:3230783603695707b5b037f700c0293658afeff26541bde93c2743b335c70e1b"
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.16.3",
+        "release": "297.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-libs-5.16.3-297.el7.x86_64.rpm",
+        "checksum": "sha256:73a140a5c8d48a34b9dbcd0534a1c10c2045d261c8594f334ea438f8803d7b0b"
+      },
+      {
+        "name": "perl-macros",
+        "epoch": 4,
+        "version": "5.16.3",
+        "release": "297.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-macros-5.16.3-297.el7.x86_64.rpm",
+        "checksum": "sha256:859f352a4b9eb6b91dba755b6404b60bd7bf015e88ad6643648f3681d3a8a55f"
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.225",
+        "release": "244.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-parent-0.225-244.el7.noarch.rpm",
+        "checksum": "sha256:6e7dae153c72989bcbf0f9174f513dbca277578eba1fe08895b4dafb98308caf"
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-podlators-2.5.1-3.el7.noarch.rpm",
+        "checksum": "sha256:916f6a6c4b25af9a227e943cf61ca0873553e2ac67479aa43b954f98735e5d7f"
+      },
+      {
+        "name": "perl-threads",
+        "epoch": 0,
+        "version": "1.87",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-threads-1.87-4.el7.x86_64.rpm",
+        "checksum": "sha256:37675735e4ea2e72205985d04535c7bd8901db2d618de333b783ae29c0117d2e"
+      },
+      {
+        "name": "perl-threads-shared",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/perl-threads-shared-1.43-6.el7.x86_64.rpm",
+        "checksum": "sha256:3b25187cbec0cc9c4c6884f1534e45384639644a4819f24a47536b6ae4515eda"
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+      },
+      {
+        "name": "pinfo",
+        "epoch": 0,
+        "version": "0.6.10",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinfo-0.6.10-9.el7.x86_64.rpm",
+        "checksum": "sha256:f5605e1b409610564b3f58a07ad22d246af4f679eef1784624e83ecd47d2fd86"
+      },
+      {
+        "name": "pixman",
+        "epoch": 0,
+        "version": "0.34.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pixman-0.34.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:1e7a15f2d6078a39d5bac5aaf964e91e22476d03aa84f9519b5797c202fbc355"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:4dc9a401c2514336e46adc87f5d05244ca743eb08bf6bcab1443a9eba6b81970"
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-core-libs-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:77a55f2182769815d41519b53ca15b54aa09cbe48249cd91487a091e81fdd7c2"
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-scripts-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:19f7ca6bf9d8e762c376d0d8b52e2982e900a3d3e5fe7d3f095d1b27f4ab95aa"
+      },
+      {
+        "name": "pm-utils",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "27.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pm-utils-1.4.1-27.el7.x86_64.rpm",
+        "checksum": "sha256:cc4fe3933ba69f933159e8ac41aad28f0c9b853dd31cc8f9670f1a40840f0d7e"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "policycoreutils-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.112",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm",
+        "checksum": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "psacct",
+        "epoch": 0,
+        "version": "6.6.1",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/psacct-6.6.1-13.el7.x86_64.rpm",
+        "checksum": "sha256:9d09e49c6f92e1673f0ce5486cb4e12588694793918a9265436000d2fcb88b7d"
+      },
+      {
+        "name": "pth",
+        "epoch": 0,
+        "version": "2.0.7",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm",
+        "checksum": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+      },
+      {
+        "name": "pyOpenSSL",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+      },
+      {
+        "name": "pygobject2",
+        "epoch": 0,
+        "version": "2.28.6",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm",
+        "checksum": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+      },
+      {
+        "name": "pygpgme",
+        "epoch": 0,
+        "version": "0.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+      },
+      {
+        "name": "pyliblzma",
+        "epoch": 0,
+        "version": "0.5.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+      },
+      {
+        "name": "pyserial",
+        "epoch": 0,
+        "version": "2.6",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm",
+        "checksum": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-IPy",
+        "epoch": 0,
+        "version": "0.75",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm",
+        "checksum": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+      },
+      {
+        "name": "python-augeas",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-augeas-0.5.0-2.el7.noarch.rpm",
+        "checksum": "sha256:123c1d340937aa080aa329f8ebba4705dfd06fdbe26aa69418ca9fcde8df2680"
+      },
+      {
+        "name": "python-babel",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm",
+        "checksum": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+      },
+      {
+        "name": "python-backports",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm",
+        "checksum": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+      },
+      {
+        "name": "python-backports-ssl_match_hostname",
+        "epoch": 0,
+        "version": "3.5.0.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm",
+        "checksum": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+      },
+      {
+        "name": "python-chardet",
+        "epoch": 0,
+        "version": "2.2.1",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm",
+        "checksum": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+      },
+      {
+        "name": "python-configobj",
+        "epoch": 0,
+        "version": "4.7.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm",
+        "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+      },
+      {
+        "name": "python-decorator",
+        "epoch": 0,
+        "version": "3.4.0",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm",
+        "checksum": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+      },
+      {
+        "name": "python-dmidecode",
+        "epoch": 0,
+        "version": "3.12.2",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm",
+        "checksum": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+      },
+      {
+        "name": "python-ethtool",
+        "epoch": 0,
+        "version": "0.8",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm",
+        "checksum": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+      },
+      {
+        "name": "python-firewall",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+      },
+      {
+        "name": "python-gobject-base",
+        "epoch": 0,
+        "version": "3.22.0",
+        "release": "1.el7_4.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm",
+        "checksum": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+      },
+      {
+        "name": "python-gudev",
+        "epoch": 0,
+        "version": "147.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+      },
+      {
+        "name": "python-hwdata",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm",
+        "checksum": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+      },
+      {
+        "name": "python-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm",
+        "checksum": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+      },
+      {
+        "name": "python-inotify",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm",
+        "checksum": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+      },
+      {
+        "name": "python-ipaddr",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm",
+        "checksum": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+      },
+      {
+        "name": "python-ipaddress",
+        "epoch": 0,
+        "version": "1.0.16",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm",
+        "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+      },
+      {
+        "name": "python-jsonpatch",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm",
+        "checksum": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+      },
+      {
+        "name": "python-jsonpointer",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm",
+        "checksum": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+      },
+      {
+        "name": "python-kitchen",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm",
+        "checksum": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python-linux-procfs",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm",
+        "checksum": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+      },
+      {
+        "name": "python-lxml",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+      },
+      {
+        "name": "python-magic",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm",
+        "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+      },
+      {
+        "name": "python-perf",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+      },
+      {
+        "name": "python-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm",
+        "checksum": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+      },
+      {
+        "name": "python-pycurl",
+        "epoch": 0,
+        "version": "7.19.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+      },
+      {
+        "name": "python-pyudev",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm",
+        "checksum": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+      },
+      {
+        "name": "python-requests",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm",
+        "checksum": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+      },
+      {
+        "name": "python-schedutils",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
+        "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-slip",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+      },
+      {
+        "name": "python-slip-dbus",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+      },
+      {
+        "name": "python-syspurpose",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+      },
+      {
+        "name": "python-urlgrabber",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm",
+        "checksum": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+      },
+      {
+        "name": "python-urllib3",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm",
+        "checksum": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+      },
+      {
+        "name": "python2-futures",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python2-futures-3.1.1-5.el7.noarch.rpm",
+        "checksum": "sha256:c672527f93c914be54899edbd5f855c3c957e4493b218db7a69a4e6f54ce2e09"
+      },
+      {
+        "name": "python2-pyasn1",
+        "epoch": 0,
+        "version": "0.1.9",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python2-pyasn1-0.1.9-7.el7.noarch.rpm",
+        "checksum": "sha256:3b14cb5167b2dc1d2b999e87a9f376f60e81faa4552c36293b770b277d432881"
+      },
+      {
+        "name": "pyxattr",
+        "epoch": 0,
+        "version": "0.5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "quota",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm",
+        "checksum": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+      },
+      {
+        "name": "quota-nls",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm",
+        "checksum": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+      },
+      {
+        "name": "rdate",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rdate-1.4-25.el7.x86_64.rpm",
+        "checksum": "sha256:88ff978b561a31e1bec818870a09e7078e9f3d0f2530293dde79348ad2ee8697"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-indexhtml",
+        "epoch": 0,
+        "version": "7",
+        "release": "13.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-indexhtml-7-13.el7.noarch.rpm",
+        "checksum": "sha256:a600088d03991ca3970973f4c9759790939403eeb0ecaacdc18267ab35f1162a"
+      },
+      {
+        "name": "redhat-logos",
+        "epoch": 0,
+        "version": "70.7.0",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-logos-70.7.0-1.el7.noarch.rpm",
+        "checksum": "sha256:2293799f84ccf36c681066a3aa0f7fe713b913e589c105713ecbb98e86966cc7"
+      },
+      {
+        "name": "redhat-release-eula",
+        "epoch": 0,
+        "version": "7.8",
+        "release": "0.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm",
+        "checksum": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "redhat-support-lib-python",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm",
+        "checksum": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+      },
+      {
+        "name": "redhat-support-tool",
+        "epoch": 0,
+        "version": "0.12.2",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm",
+        "checksum": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+      },
+      {
+        "name": "rfkill",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rfkill-0.4-10.el7.x86_64.rpm",
+        "checksum": "sha256:3b00ddc8c3a9fa3c06e995a08e9eb169615b762769fa800c60656e0dd7af3a97"
+      },
+      {
+        "name": "rhn-check",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+      },
+      {
+        "name": "rhn-client-tools",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+      },
+      {
+        "name": "rhn-setup",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+      },
+      {
+        "name": "rhnlib",
+        "epoch": 0,
+        "version": "2.5.65",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm",
+        "checksum": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+      },
+      {
+        "name": "rhnsd",
+        "epoch": 0,
+        "version": "5.0.13",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm",
+        "checksum": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+      },
+      {
+        "name": "rng-tools",
+        "epoch": 0,
+        "version": "6.3.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rng-tools-6.3.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:d89d9f74f8b028975b72aa435cd49e708195cd746f9eee3c12ca8b09a2accc0b"
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm",
+        "checksum": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+      },
+      {
+        "name": "rpcbind",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "49.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
+        "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.2",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm",
+        "checksum": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.24.0",
+        "release": "55.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm",
+        "checksum": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+      },
+      {
+        "name": "satyr",
+        "epoch": 0,
+        "version": "0.13",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/satyr-0.13-15.el7.x86_64.rpm",
+        "checksum": "sha256:4f587a23bbc728df6fbb528e95967259659d1cf636f18a31f54477b95dc10945"
+      },
+      {
+        "name": "scl-utils",
+        "epoch": 0,
+        "version": "20130529",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/scl-utils-20130529-19.el7.x86_64.rpm",
+        "checksum": "sha256:3d30debfa65d5354cde7e515ddee39110d6f846647b806e46192fd7956100d9d"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setools-libs",
+        "epoch": 0,
+        "version": "3.3.8",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm",
+        "checksum": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+      },
+      {
+        "name": "setserial",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "33.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setserial-2.17-33.el7.x86_64.rpm",
+        "checksum": "sha256:7c9af23f813f4b3449075ef79118a69343be7e8878c8ae3ec5907cd6521e319b"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "setuptool",
+        "epoch": 0,
+        "version": "1.19.11",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setuptool-1.19.11-8.el7.x86_64.rpm",
+        "checksum": "sha256:920c61a08e456094c25495efb453e04b77b7fa9b1cb6c708cdca4b0e1cf488a3"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+      },
+      {
+        "name": "sgpio",
+        "epoch": 0,
+        "version": "1.2.0.10",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sgpio-1.2.0.10-13.el7.x86_64.rpm",
+        "checksum": "sha256:7e95db3a020beca4526cad1fb550e360fc776779721902b0401f40425ad2910d"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.2.4",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm",
+        "checksum": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+      },
+      {
+        "name": "smartmontools",
+        "epoch": 1,
+        "version": "7.0",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/smartmontools-7.0-2.el7.x86_64.rpm",
+        "checksum": "sha256:96458b749b0783cc8062aa5417da53712b91676dd1a6284f05ec3b68a29261e8"
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+      },
+      {
+        "name": "sos",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sos-3.9-2.el7.noarch.rpm",
+        "checksum": "sha256:03691e07c6a6d7e149e429e2c19dfd9ed038d417f01cd69a496759daf22053fd"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "1.16.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sssd-client-1.16.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:4dd6e7bf33d6407e2b6a1d4aed75c3c07c2cbb8c82b600a63efe6cd02b315d27"
+      },
+      {
+        "name": "strace",
+        "epoch": 0,
+        "version": "4.24",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/strace-4.24-6.el7.x86_64.rpm",
+        "checksum": "sha256:8878a5eb20b8e84d226dc0f27f3df8ad41350f06efcffec159fcacf8238cc771"
+      },
+      {
+        "name": "subscription-manager",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+      },
+      {
+        "name": "subscription-manager-plugin-container",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-plugin-container-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:f4b5c68dee1b1505dafc6b8c1553aa3448137f4b6b06f600b3afd63fe25259fc"
+      },
+      {
+        "name": "subscription-manager-rhsm",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+      },
+      {
+        "name": "subscription-manager-rhsm-certificates",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.23",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm",
+        "checksum": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+      },
+      {
+        "name": "sysstat",
+        "epoch": 0,
+        "version": "10.1.5",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysstat-10.1.5-19.el7.x86_64.rpm",
+        "checksum": "sha256:c95fb7d3137031016bce7742a5a56b2bdb83903d91004783a138cfb4def075ae"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "systemd-python",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-python-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:d6622bbbb6b862f9ea41e7f0d48e4086c76743f712c9218bb7f63c98912b4fb0"
+      },
+      {
+        "name": "systemd-sysv",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+      },
+      {
+        "name": "systemtap-runtime",
+        "epoch": 0,
+        "version": "4.0",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemtap-runtime-4.0-13.el7.x86_64.rpm",
+        "checksum": "sha256:1ea11c6adbcf231fd57764c656515815a32385d8625a815699e7caccdc178a81"
+      },
+      {
+        "name": "sysvinit-tools",
+        "epoch": 0,
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm",
+        "checksum": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tcp_wrappers",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+      },
+      {
+        "name": "tcp_wrappers-libs",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+      },
+      {
+        "name": "tcpdump",
+        "epoch": 14,
+        "version": "4.9.2",
+        "release": "4.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+      },
+      {
+        "name": "tcsh",
+        "epoch": 0,
+        "version": "6.18.01",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcsh-6.18.01-17.el7.x86_64.rpm",
+        "checksum": "sha256:cea2802e226f857af3899655a86e3b8fb5e761c309c6f4bea61b7972cdede7fc"
+      },
+      {
+        "name": "teamd",
+        "epoch": 0,
+        "version": "1.29",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/teamd-1.29-3.el7.x86_64.rpm",
+        "checksum": "sha256:5487de1bac24442383d789e48ba61456ec1b28095b481ca87a2bd5a2a67b6c43"
+      },
+      {
+        "name": "time",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "45.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/time-1.7-45.el7.x86_64.rpm",
+        "checksum": "sha256:cf6a087cbf1537d450020c50e0a26d8cab97b6acbff3aed417080fde4c531ec9"
+      },
+      {
+        "name": "traceroute",
+        "epoch": 3,
+        "version": "2.0.22",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/traceroute-2.0.22-2.el7.x86_64.rpm",
+        "checksum": "sha256:04642ee7c7604a79ed9b009a660b3d201d1c2a384c04f1026716588097644b57"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm",
+        "checksum": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "unzip",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/unzip-6.0-21.el7.x86_64.rpm",
+        "checksum": "sha256:48adf3c630487ead8f233cde6fdfe8819a8cfe1e76bf6fc4d62cf4b5059a630b"
+      },
+      {
+        "name": "usb_modeswitch",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usb_modeswitch-2.5.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:a349778d7638edf0225ccfd0ee10c8463a8696cb7e1910b23fdb0bb5effc6edb"
+      },
+      {
+        "name": "usb_modeswitch-data",
+        "epoch": 0,
+        "version": "20170806",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usb_modeswitch-data-20170806-1.el7.noarch.rpm",
+        "checksum": "sha256:f7c4319ec1ae973242046f0ef6d4af54c53421124a1339efbd4e06c26f5c809f"
+      },
+      {
+        "name": "usbutils",
+        "epoch": 0,
+        "version": "007",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usbutils-007-5.el7.x86_64.rpm",
+        "checksum": "sha256:20252a90fbf74378e6d3663818703adcc0a5450320d6df68f7df4ab5544c7326"
+      },
+      {
+        "name": "usermode",
+        "epoch": 0,
+        "version": "1.111",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm",
+        "checksum": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "vdo",
+        "epoch": 0,
+        "version": "6.1.3.23",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vdo-6.1.3.23-5.el7.x86_64.rpm",
+        "checksum": "sha256:e329ec13f2a48b369c1d1c454e149bfb0b750d6976d9dba6bc0282410e061b07"
+      },
+      {
+        "name": "vim-common",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-common-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:9fa7096dd4182602e14dbe682086e74c777b54ddd511e832091719eff101a927"
+      },
+      {
+        "name": "vim-enhanced",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-enhanced-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:06b51b9c622b2a097ae8ca07b443dcc956da5a9ea9f6785ea4c6893fdba7dd7b"
+      },
+      {
+        "name": "vim-filesystem",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-filesystem-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:95f4c75d788a1b2d5d11f028b04f69d4f0f036f1c814b3cc396ea6ac7f419b6a"
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm",
+        "checksum": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+      },
+      {
+        "name": "wget",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "18.el7_6.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wget-1.14-18.el7_6.1.x86_64.rpm",
+        "checksum": "sha256:5cbaafb7edb56eea2ae1b469597e1d24304b5f1f5294316bcb72d99b2edf1acd"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "words",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "22.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/words-3.0-22.el7.noarch.rpm",
+        "checksum": "sha256:917a406f75a6c064cffe15f7926854750ecb656a34b80ac24e36146d1560cccd"
+      },
+      {
+        "name": "wpa_supplicant",
+        "epoch": 1,
+        "version": "2.6",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wpa_supplicant-2.6-12.el7.x86_64.rpm",
+        "checksum": "sha256:a61dcf3c31bc66497c86d007870305008e2ab6d11fc6a570af179afa19bfcbc2"
+      },
+      {
+        "name": "xdg-utils",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "0.17.20120809git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm",
+        "checksum": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+      },
+      {
+        "name": "xfsdump",
+        "epoch": 0,
+        "version": "3.1.7",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsdump-3.1.7-1.el7.x86_64.rpm",
+        "checksum": "sha256:efd39d4e825667654577d535aa236a2326b130a30c1150dda522c7208c7c8c33"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xmlrpc-c",
+        "epoch": 0,
+        "version": "1.32.5",
+        "release": "1905.svn2451.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xmlrpc-c-1.32.5-1905.svn2451.el7.x86_64.rpm",
+        "checksum": "sha256:69dcb613e5b4a65bceb2e711d09e110e717c6ad0cbb32f577cfb9589fdc443b8"
+      },
+      {
+        "name": "xmlrpc-c-client",
+        "epoch": 0,
+        "version": "1.32.5",
+        "release": "1905.svn2451.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xmlrpc-c-client-1.32.5-1905.svn2451.el7.x86_64.rpm",
+        "checksum": "sha256:8f005cf975d92d5d5f69888633a2b0c842d03d9a58140db8ea5a40e7bbf67415"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yajl-2.0.4-4.el7.x86_64.rpm",
+        "checksum": "sha256:609bcd5fca60d9453c9a06a97a8c597028ba30db711bcfdda1e761edff0f8f3b"
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "3.4.3",
+        "release": "168.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm",
+        "checksum": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+      },
+      {
+        "name": "yum-langpacks",
+        "epoch": 0,
+        "version": "0.4.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-langpacks-0.4.2-7.el7.noarch.rpm",
+        "checksum": "sha256:d5748eae1488c315afb264a75e64bf0d1b83771abffbf742efd44ba97d27005d"
+      },
+      {
+        "name": "yum-metadata-parser",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm",
+        "checksum": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+      },
+      {
+        "name": "yum-rhn-plugin",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm",
+        "checksum": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+      },
+      {
+        "name": "yum-utils",
+        "epoch": 0,
+        "version": "1.1.31",
+        "release": "54.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm",
+        "checksum": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+      },
+      {
+        "name": "zip",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zip-3.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:d763b5794e0ba4ed71da2ac5dbe36f5db84d454bce8c7ee2a09f812edd5b5453"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "WALinuxAgent",
+        "epoch": 0,
+        "version": "2.2.46",
+        "release": "2.el7_9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530/Packages/WALinuxAgent-2.2.46-2.el7_9.noarch.rpm",
+        "checksum": "sha256:84dddb64dbfa4ef82b02a08fe95491eb909351f8fa7f96a754124a9084c6c8fe"
+      },
+      {
+        "name": "rh-dotnetcore11",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-1.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:bd09459910a5331c3dccd2a795b6af83c7db2c74df0ee9ec091012bb63a67cb3"
+      },
+      {
+        "name": "rh-dotnetcore11-dotnetcore",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-dotnetcore-1.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:385f0ed7359b8ec4c0e4e62b78aae094dd487d48b670b0bbc2a1fead2ca41140"
+      },
+      {
+        "name": "rh-dotnetcore11-libcurl",
+        "epoch": 0,
+        "version": "7.47.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-libcurl-7.47.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:8606dc6028993db6b8fc612ee43021c43399c07562385b8d024130051d36c1bb"
+      },
+      {
+        "name": "rh-dotnetcore11-libuv",
+        "epoch": 1,
+        "version": "1.9.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-libuv-1.9.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:b609592c9a241bc13e6ca1606a1bc24e9bf7d8b002f965d8645b3e51a5f7c569"
+      },
+      {
+        "name": "rh-dotnetcore11-runtime",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530/Packages/rh-dotnetcore11-runtime-1.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:7a994d8e50f9e5ced5d2082a58ecfb8f79ab1656cec77c65ec67453fbd6839fb"
+      },
+      {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 3,
+        "version": "2.78",
+        "release": "2.1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Encode/2.78/2.1.el7/x86_64/perl-Encode-2.78-2.1.el7.x86_64.rpm",
+        "checksum": "sha256:3996788fc70d7171ff6e76bda0961a246919fa7e1689000a3daa0c5e080513a7"
+      },
+      {
+        "name": "perl-HTTP-CookieJar",
+        "epoch": 0,
+        "version": "0.006",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-CookieJar/0.006/1.el7eng/noarch/perl-HTTP-CookieJar-0.006-1.el7eng.noarch.rpm",
+        "checksum": "sha256:5d32146c850a3fcd57b22ca6dce89533ffbd66d67fb3766526f3d6298f2b3736"
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.047",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-HTTP-Tiny/0.047/1.el7eng/noarch/perl-HTTP-Tiny-0.047-1.el7eng.noarch.rpm",
+        "checksum": "sha256:5e0c7dc6d85c0971198bc7ef307ece04dca827ad6b585d13244b7f38e8ebbec0"
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-IO-Socket-IP/0.31/1.el7eng/noarch/perl-IO-Socket-IP-0.31-1.el7eng.noarch.rpm",
+        "checksum": "sha256:070f190e8b046b63f11c256dd7db97c6d52bd003c07fc2d27c17b4ccc59fce95"
+      },
+      {
+        "name": "perl-Mozilla-PublicSuffix",
+        "epoch": 0,
+        "version": "0.1.19",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Mozilla-PublicSuffix/0.1.19/1.el7eng/noarch/perl-Mozilla-PublicSuffix-0.1.19-1.el7eng.noarch.rpm",
+        "checksum": "sha256:3d6d67ac18cede7b2c6138c3ef3f0229bcce82b7408e5e979e8f1c36b565966e"
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.45",
+        "release": "1.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Scalar-List-Utils/1.45/1.el7eng/x86_64/perl-Scalar-List-Utils-1.45-1.el7eng.x86_64.rpm",
+        "checksum": "sha256:8247226762011ab0f728756cdd6961fb0a8de6e40dd0946e15fbbf3ed504e52c"
+      },
+      {
+        "name": "perl-Test-Simple",
+        "epoch": 4,
+        "version": "1.302040",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-Test-Simple/1.302040/1.el7eng/noarch/perl-Test-Simple-1.302040-1.el7eng.noarch.rpm",
+        "checksum": "sha256:8343c381ab75a1ee65db0e3d9cdac7d8a83bb7ab2aaef5ed1059191efe008b8b"
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 4,
+        "version": "1.71",
+        "release": "1.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/perl-URI/1.71/1.el7eng/noarch/perl-URI-1.71-1.el7eng.noarch.rpm",
+        "checksum": "sha256:06693d2eb44ac57bc2bbefd18dc42751e96b6571803d1c17b5e68576c76fceef"
+      },
+      {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "2.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
+        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+      },
+      {
+        "name": "python2-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "1.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
+        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+      },
+      {
+        "name": "python2-markupsafe",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
+        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+      },
+      {
+        "name": "python2-setuptools",
+        "epoch": 0,
+        "version": "38.4.0",
+        "release": "3.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
+        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+      },
+      {
+        "name": "rhui-azure-rhel7",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "222",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530/rhui-azure-rhel7-2.2-222.noarch.rpm",
+        "checksum": "sha256:000bd49aea30ee3534e6cde11188afa4b567711b13acbcf531e5542fc7b2aefe"
+      }
+    ]
+  }
+}

--- a/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
@@ -1,0 +1,8805 @@
+{
+  "compose-request": {
+    "distro": "rhel-7",
+    "arch": "x86_64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "server",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530"
+      },
+      {
+        "name": "server-extras",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530"
+      },
+      {
+        "name": "server-optional",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-optional-r7.9-20220530"
+      },
+      {
+        "name": "server-dotnet",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530"
+      },
+      {
+        "name": "rhel-eng",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
+      },
+      {
+        "name": "azure-rhui-7",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.rhel7",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+                  },
+                  {
+                    "id": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+                  },
+                  {
+                    "id": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+                  },
+                  {
+                    "id": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+                  },
+                  {
+                    "id": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+                  },
+                  {
+                    "id": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+                  },
+                  {
+                    "id": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+                  },
+                  {
+                    "id": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+                  },
+                  {
+                    "id": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+                  },
+                  {
+                    "id": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+                  },
+                  {
+                    "id": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+                  },
+                  {
+                    "id": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+                  },
+                  {
+                    "id": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+                  },
+                  {
+                    "id": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+                  },
+                  {
+                    "id": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+                  },
+                  {
+                    "id": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  }
+                ]
+              }
+            },
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
+                  },
+                  {
+                    "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+                  },
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+                  },
+                  {
+                    "id": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+                  },
+                  {
+                    "id": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+                  },
+                  {
+                    "id": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+                  },
+                  {
+                    "id": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+                  },
+                  {
+                    "id": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+                  },
+                  {
+                    "id": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+                  },
+                  {
+                    "id": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+                  },
+                  {
+                    "id": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+                  },
+                  {
+                    "id": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+                  },
+                  {
+                    "id": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+                  },
+                  {
+                    "id": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+                  },
+                  {
+                    "id": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+                  },
+                  {
+                    "id": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+                  },
+                  {
+                    "id": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+                  },
+                  {
+                    "id": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+                  },
+                  {
+                    "id": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+                  },
+                  {
+                    "id": "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+                  },
+                  {
+                    "id": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+                  },
+                  {
+                    "id": "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d"
+                  },
+                  {
+                    "id": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+                  },
+                  {
+                    "id": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+                  },
+                  {
+                    "id": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+                  },
+                  {
+                    "id": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+                  },
+                  {
+                    "id": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+                  },
+                  {
+                    "id": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+                  },
+                  {
+                    "id": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+                  },
+                  {
+                    "id": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+                  },
+                  {
+                    "id": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+                  },
+                  {
+                    "id": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+                  },
+                  {
+                    "id": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+                  },
+                  {
+                    "id": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+                  },
+                  {
+                    "id": "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+                  },
+                  {
+                    "id": "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+                  },
+                  {
+                    "id": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+                  },
+                  {
+                    "id": "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e"
+                  },
+                  {
+                    "id": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff"
+                  },
+                  {
+                    "id": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+                  },
+                  {
+                    "id": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+                  },
+                  {
+                    "id": "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7"
+                  },
+                  {
+                    "id": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+                  },
+                  {
+                    "id": "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49"
+                  },
+                  {
+                    "id": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+                  },
+                  {
+                    "id": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+                  },
+                  {
+                    "id": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+                  },
+                  {
+                    "id": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+                  },
+                  {
+                    "id": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+                  },
+                  {
+                    "id": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+                  },
+                  {
+                    "id": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+                  },
+                  {
+                    "id": "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644"
+                  },
+                  {
+                    "id": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+                  },
+                  {
+                    "id": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+                  },
+                  {
+                    "id": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+                  },
+                  {
+                    "id": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+                  },
+                  {
+                    "id": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+                  },
+                  {
+                    "id": "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+                  },
+                  {
+                    "id": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+                  },
+                  {
+                    "id": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+                  },
+                  {
+                    "id": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+                  },
+                  {
+                    "id": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+                  },
+                  {
+                    "id": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+                  },
+                  {
+                    "id": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+                  },
+                  {
+                    "id": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+                  },
+                  {
+                    "id": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+                  },
+                  {
+                    "id": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+                  },
+                  {
+                    "id": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+                  },
+                  {
+                    "id": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+                  },
+                  {
+                    "id": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+                  },
+                  {
+                    "id": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+                  },
+                  {
+                    "id": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+                  },
+                  {
+                    "id": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+                  },
+                  {
+                    "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+                  },
+                  {
+                    "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+                  },
+                  {
+                    "id": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+                  },
+                  {
+                    "id": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+                  },
+                  {
+                    "id": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+                  },
+                  {
+                    "id": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+                  },
+                  {
+                    "id": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+                  },
+                  {
+                    "id": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+                  },
+                  {
+                    "id": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+                  },
+                  {
+                    "id": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+                  },
+                  {
+                    "id": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+                  },
+                  {
+                    "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+                  },
+                  {
+                    "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+                  },
+                  {
+                    "id": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+                  },
+                  {
+                    "id": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+                  },
+                  {
+                    "id": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+                  },
+                  {
+                    "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+                  },
+                  {
+                    "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+                  },
+                  {
+                    "id": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+                  },
+                  {
+                    "id": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+                  },
+                  {
+                    "id": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+                  },
+                  {
+                    "id": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+                  },
+                  {
+                    "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+                  },
+                  {
+                    "id": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+                  },
+                  {
+                    "id": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+                  },
+                  {
+                    "id": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+                  },
+                  {
+                    "id": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+                  },
+                  {
+                    "id": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+                  },
+                  {
+                    "id": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+                  },
+                  {
+                    "id": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+                  },
+                  {
+                    "id": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+                  },
+                  {
+                    "id": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+                  },
+                  {
+                    "id": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+                  },
+                  {
+                    "id": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+                  },
+                  {
+                    "id": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+                  },
+                  {
+                    "id": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+                  },
+                  {
+                    "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+                  },
+                  {
+                    "id": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+                  },
+                  {
+                    "id": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+                  },
+                  {
+                    "id": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+                  },
+                  {
+                    "id": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+                  },
+                  {
+                    "id": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+                  },
+                  {
+                    "id": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+                  },
+                  {
+                    "id": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+                  },
+                  {
+                    "id": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+                  },
+                  {
+                    "id": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+                  },
+                  {
+                    "id": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+                  },
+                  {
+                    "id": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+                  },
+                  {
+                    "id": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+                  },
+                  {
+                    "id": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+                  },
+                  {
+                    "id": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+                  },
+                  {
+                    "id": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+                  },
+                  {
+                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+                  },
+                  {
+                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+                  },
+                  {
+                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+                  },
+                  {
+                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  },
+                  {
+                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys.fromtree": [
+                "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US.UTF-8"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "America/New_York"
+            }
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "redhat": {
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "default_target": "multi-user.target"
+            }
+          },
+          {
+            "type": "org.osbuild.sysconfig",
+            "options": {
+              "kernel": {
+                "update_default": true,
+                "default_kernel": "kernel"
+              },
+              "network": {
+                "networking": true,
+                "no_zero_conf": true
+              },
+              "network-scripts": {
+                "ifcfg": {
+                  "eth0": {
+                    "bootproto": "dhcp",
+                    "device": "eth0",
+                    "ipv6init": false,
+                    "onboot": true,
+                    "peerdns": true,
+                    "type": "Ethernet",
+                    "userctl": true
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "yum-plugins": {
+                "product-id": {
+                  "enabled": false
+                },
+                "subscription-manager": {
+                  "enabled": false
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2.legacy",
+            "options": {
+              "rootfs": {
+                "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+              },
+              "entries": [
+                {
+                  "default": true,
+                  "id": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                  "kernel": "3.10.0-1160.el7.x86_64",
+                  "product": {
+                    "name": "Red Hat Enterprise Linux",
+                    "version": "7.9",
+                    "nick": "Maipo"
+                  }
+                }
+              ],
+              "bios": {
+                "platform": "i386-pc"
+              },
+              "uefi": {
+                "vendor": "redhat"
+              },
+              "bootfs": {
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+              },
+              "config": {
+                "cmdline": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+                "distributor": "$(sed 's, release .*$,,g' /etc/system-release)"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "force_autorelabel": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sgdisk",
+            "options": {
+              "uuid": "d209c89e-ea5e-4fbd-b161-b461cce297e0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "fac7f1fb-3e8d-4137-a512-961de09a5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68b2905b-df3e-4fb3-80fa-49d1e773aa33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "cb07c243-bc44-4717-853e-28852021225b"
+                },
+                {
+                  "size": 19533791,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264d520-3fb9-423f-8ab8-7a0a8e3d3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "xfs"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "qcow2",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.qemu",
+            "inputs": {
+              "image": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.qcow2",
+              "format": {
+                "type": "qcow2",
+                "compat": "0.10"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm"
+          },
+          "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm"
+          },
+          "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm"
+          },
+          "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm"
+          },
+          "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm"
+          },
+          "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm"
+          },
+          "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm"
+          },
+          "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm"
+          },
+          "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm"
+          },
+          "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcollection-0.7.0-32.el7.x86_64.rpm"
+          },
+          "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm"
+          },
+          "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/insights-client-3.0.13-1.el7.noarch.rpm"
+          },
+          "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm"
+          },
+          "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm"
+          },
+          "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm"
+          },
+          "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm"
+          },
+          "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm"
+          },
+          "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm"
+          },
+          "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm"
+          },
+          "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm"
+          },
+          "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm"
+          },
+          "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm"
+          },
+          "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm"
+          },
+          "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm"
+          },
+          "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm"
+          },
+          "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm"
+          },
+          "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm"
+          },
+          "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm"
+          },
+          "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm"
+          },
+          "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm"
+          },
+          "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm"
+          },
+          "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm"
+          },
+          "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm"
+          },
+          "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm"
+          },
+          "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm"
+          },
+          "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm"
+          },
+          "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
+          },
+          "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm"
+          },
+          "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm"
+          },
+          "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm"
+          },
+          "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm"
+          },
+          "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
+          },
+          "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
+          },
+          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
+          },
+          "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm"
+          },
+          "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mariadb-libs-5.5.68-1.el7.x86_64.rpm"
+          },
+          "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm"
+          },
+          "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm"
+          },
+          "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm"
+          },
+          "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm"
+          },
+          "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm"
+          },
+          "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm"
+          },
+          "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm"
+          },
+          "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm"
+          },
+          "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm"
+          },
+          "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm"
+          },
+          "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm"
+          },
+          "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
+          },
+          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm"
+          },
+          "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm"
+          },
+          "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm"
+          },
+          "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm"
+          },
+          "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm"
+          },
+          "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm"
+          },
+          "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm"
+          },
+          "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm"
+          },
+          "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm"
+          },
+          "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm"
+          },
+          "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm"
+          },
+          "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm"
+          },
+          "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm"
+          },
+          "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm"
+          },
+          "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm"
+          },
+          "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm"
+          },
+          "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm"
+          },
+          "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm"
+          },
+          "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm"
+          },
+          "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm"
+          },
+          "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-1.5.8-3.el7.x86_64.rpm"
+          },
+          "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm"
+          },
+          "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm"
+          },
+          "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm"
+          },
+          "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm"
+          },
+          "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm"
+          },
+          "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm"
+          },
+          "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm"
+          },
+          "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm"
+          },
+          "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm"
+          },
+          "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm"
+          },
+          "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm"
+          },
+          "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm"
+          },
+          "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libref_array-0.1.5-32.el7.x86_64.rpm"
+          },
+          "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm"
+          },
+          "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm"
+          },
+          "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm"
+          },
+          "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm"
+          },
+          "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm"
+          },
+          "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm"
+          },
+          "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libbasicobjects-0.1.1-32.el7.x86_64.rpm"
+          },
+          "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm"
+          },
+          "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm"
+          },
+          "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm"
+          },
+          "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm"
+          },
+          "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm"
+          },
+          "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm"
+          },
+          "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm"
+          },
+          "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm"
+          },
+          "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-libevent-0.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm"
+          },
+          "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm"
+          },
+          "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm"
+          },
+          "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm"
+          },
+          "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm"
+          },
+          "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm"
+          },
+          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
+          },
+          "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
+          },
+          "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm"
+          },
+          "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm"
+          },
+          "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm"
+          },
+          "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm"
+          },
+          "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gssproxy-0.7.0-29.el7.x86_64.rpm"
+          },
+          "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm"
+          },
+          "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm"
+          },
+          "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm"
+          },
+          "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm"
+          },
+          "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm"
+          },
+          "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm"
+          },
+          "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm"
+          },
+          "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm"
+          },
+          "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm"
+          },
+          "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
+          },
+          "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm"
+          },
+          "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm"
+          },
+          "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm"
+          },
+          "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm"
+          },
+          "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm"
+          },
+          "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm"
+          },
+          "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm"
+          },
+          "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm"
+          },
+          "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm"
+          },
+          "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm"
+          },
+          "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm"
+          },
+          "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm"
+          },
+          "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm"
+          },
+          "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm"
+          },
+          "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm"
+          },
+          "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libini_config-1.3.1-32.el7.x86_64.rpm"
+          },
+          "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm"
+          },
+          "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm"
+          },
+          "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm"
+          },
+          "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm"
+          },
+          "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm"
+          },
+          "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm"
+          },
+          "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm"
+          },
+          "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm"
+          },
+          "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm"
+          },
+          "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nfs-utils-1.3.0-0.68.el7.x86_64.rpm"
+          },
+          "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm"
+          },
+          "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm"
+          },
+          "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm"
+          },
+          "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm"
+          },
+          "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm"
+          },
+          "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm"
+          },
+          "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm"
+          },
+          "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
+          },
+          "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm"
+          },
+          "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm"
+          },
+          "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm"
+          },
+          "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm"
+          },
+          "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm"
+          },
+          "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
+          },
+          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm"
+          },
+          "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/postfix-2.10.1-9.el7.x86_64.rpm"
+          },
+          "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm"
+          },
+          "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm"
+          },
+          "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm"
+          },
+          "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm"
+          },
+          "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm"
+          },
+          "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm"
+          },
+          "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm"
+          },
+          "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm"
+          },
+          "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libevent-2.0.21-4.el7.x86_64.rpm"
+          },
+          "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm"
+          },
+          "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm"
+          },
+          "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm"
+          },
+          "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm"
+          },
+          "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm"
+          },
+          "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm"
+          },
+          "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm"
+          },
+          "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm"
+          },
+          "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm"
+          },
+          "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm"
+          },
+          "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm"
+          },
+          "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
+          },
+          "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm"
+          },
+          "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm"
+          },
+          "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm"
+          },
+          "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm"
+          },
+          "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm"
+          },
+          "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm"
+          },
+          "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm"
+          },
+          "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm"
+          },
+          "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm"
+          },
+          "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm"
+          },
+          "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm"
+          },
+          "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm"
+          },
+          "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm"
+          },
+          "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm"
+          },
+          "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm"
+          },
+          "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm"
+          },
+          "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm"
+          },
+          "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
+          },
+          "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm"
+          },
+          "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm"
+          },
+          "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm"
+          },
+          "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm"
+          },
+          "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.06.95",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm",
+        "checksum": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.28",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm",
+        "checksum": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "9.49.53",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm",
+        "checksum": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "4.11.0",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm",
+        "checksum": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.4.21",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm",
+        "checksum": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20160308",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm",
+        "checksum": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm",
+        "checksum": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200421",
+        "release": "79.git78c0348.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm",
+        "checksum": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "sysvinit-tools",
+        "epoch": 0,
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm",
+        "checksum": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      }
+    ],
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "boost-iostreams",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+      },
+      {
+        "name": "boost-random",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+      },
+      {
+        "name": "boost-system",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+      },
+      {
+        "name": "boost-thread",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "3.0.20",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm",
+        "checksum": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "0.8.10",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm",
+        "checksum": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "glusterfs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+      },
+      {
+        "name": "glusterfs-api",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+      },
+      {
+        "name": "glusterfs-client-xlators",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+      },
+      {
+        "name": "glusterfs-libs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gperftools-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.109",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm",
+        "checksum": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libiscsi",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm",
+        "checksum": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "librados2",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+      },
+      {
+        "name": "librbd1",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm",
+        "checksum": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm",
+        "checksum": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 10,
+        "version": "1.5.3",
+        "release": "175.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm",
+        "checksum": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python3-PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+      },
+      {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm",
+        "checksum": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      }
+    ],
+    "packages": [
+      {
+        "name": "NetworkManager-config-server",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm",
+        "checksum": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
+      },
+      {
+        "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
+        "epoch": 0,
+        "version": "7",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm",
+        "checksum": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "audit-libs-python",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.06.95",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm",
+        "checksum": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "4.9.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm",
+        "checksum": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "19.4",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm",
+        "checksum": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.29",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm",
+        "checksum": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.20121102git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm",
+        "checksum": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.100",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm",
+        "checksum": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "dbus-python",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+      },
+      {
+        "name": "desktop-file-utils",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "dhclient",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "ebtables",
+        "epoch": 0,
+        "version": "2.0.10",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm",
+        "checksum": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "17",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm",
+        "checksum": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "36",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm",
+        "checksum": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "emacs-filesystem",
+        "epoch": 1,
+        "version": "24.3",
+        "release": "23.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm",
+        "checksum": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "4.8",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm",
+        "checksum": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "fipscheck",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+      },
+      {
+        "name": "fipscheck-lib",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.0.22",
+        "release": "5.el7_5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm",
+        "checksum": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.2",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm",
+        "checksum": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.28",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm",
+        "checksum": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+      },
+      {
+        "name": "gssproxy",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "29.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gssproxy-0.7.0-29.el7.x86_64.rpm",
+        "checksum": "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.252",
+        "release": "9.7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm",
+        "checksum": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "9.49.53",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm",
+        "checksum": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+      },
+      {
+        "name": "insights-client",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/insights-client-3.0.13-1.el7.noarch.rpm",
+        "checksum": "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d"
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "4.11.0",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm",
+        "checksum": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.4.21",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm",
+        "checksum": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20160308",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm",
+        "checksum": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 3,
+        "version": "1.0.7",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm",
+        "checksum": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.15",
+        "release": "51.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm",
+        "checksum": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "458",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm",
+        "checksum": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libbasicobjects-0.1.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcgroup",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm",
+        "checksum": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcollection-0.7.0-32.el7.x86_64.rpm",
+        "checksum": "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "12.20121213cvs.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm",
+        "checksum": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.9",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm",
+        "checksum": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.0.21",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libevent-2.0.21-4.el7.x86_64.rpm",
+        "checksum": "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e"
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libgudev1",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libini_config-1.3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm",
+        "checksum": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 0,
+        "version": "0.25",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm",
+        "checksum": "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7"
+      },
+      {
+        "name": "libnl",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49"
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.5.3",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm",
+        "checksum": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm",
+        "checksum": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libref_array-0.1.5-32.el7.x86_64.rpm",
+        "checksum": "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsemanage-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm",
+        "checksum": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libverto-libevent",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-libevent-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libxml2-python",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+      },
+      {
+        "name": "libxslt",
+        "epoch": 0,
+        "version": "1.1.28",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm",
+        "checksum": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200421",
+        "release": "79.git78c0348.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm",
+        "checksum": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.8.6",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm",
+        "checksum": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.18",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.06",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm",
+        "checksum": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+      },
+      {
+        "name": "m2crypto",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+      },
+      {
+        "name": "mariadb-libs",
+        "epoch": 1,
+        "version": "5.5.68",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mariadb-libs-5.5.68-1.el7.x86_64.rpm",
+        "checksum": "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644"
+      },
+      {
+        "name": "microcode_ctl",
+        "epoch": 2,
+        "version": "2.1",
+        "release": "73.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm",
+        "checksum": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+      },
+      {
+        "name": "mokutil",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+      },
+      {
+        "name": "mozjs17",
+        "epoch": 0,
+        "version": "17.0.0",
+        "release": "20.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm",
+        "checksum": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.25.20131004git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm",
+        "checksum": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+      },
+      {
+        "name": "newt-python",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+      },
+      {
+        "name": "nfs-utils",
+        "epoch": 1,
+        "version": "1.3.0",
+        "release": "0.68.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nfs-utils-1.3.0-0.68.el7.x86_64.rpm",
+        "checksum": "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm",
+        "checksum": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.79",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm",
+        "checksum": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "policycoreutils-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.112",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm",
+        "checksum": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "postfix",
+        "epoch": 2,
+        "version": "2.10.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/postfix-2.10.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "pth",
+        "epoch": 0,
+        "version": "2.0.7",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm",
+        "checksum": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+      },
+      {
+        "name": "pyOpenSSL",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+      },
+      {
+        "name": "pygobject2",
+        "epoch": 0,
+        "version": "2.28.6",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm",
+        "checksum": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+      },
+      {
+        "name": "pygpgme",
+        "epoch": 0,
+        "version": "0.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+      },
+      {
+        "name": "pyliblzma",
+        "epoch": 0,
+        "version": "0.5.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+      },
+      {
+        "name": "pyserial",
+        "epoch": 0,
+        "version": "2.6",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm",
+        "checksum": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-IPy",
+        "epoch": 0,
+        "version": "0.75",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm",
+        "checksum": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+      },
+      {
+        "name": "python-babel",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm",
+        "checksum": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+      },
+      {
+        "name": "python-backports",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm",
+        "checksum": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+      },
+      {
+        "name": "python-backports-ssl_match_hostname",
+        "epoch": 0,
+        "version": "3.5.0.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm",
+        "checksum": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+      },
+      {
+        "name": "python-chardet",
+        "epoch": 0,
+        "version": "2.2.1",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm",
+        "checksum": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+      },
+      {
+        "name": "python-configobj",
+        "epoch": 0,
+        "version": "4.7.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm",
+        "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+      },
+      {
+        "name": "python-decorator",
+        "epoch": 0,
+        "version": "3.4.0",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm",
+        "checksum": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+      },
+      {
+        "name": "python-dmidecode",
+        "epoch": 0,
+        "version": "3.12.2",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm",
+        "checksum": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+      },
+      {
+        "name": "python-ethtool",
+        "epoch": 0,
+        "version": "0.8",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm",
+        "checksum": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+      },
+      {
+        "name": "python-firewall",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+      },
+      {
+        "name": "python-gobject-base",
+        "epoch": 0,
+        "version": "3.22.0",
+        "release": "1.el7_4.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm",
+        "checksum": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+      },
+      {
+        "name": "python-gudev",
+        "epoch": 0,
+        "version": "147.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+      },
+      {
+        "name": "python-hwdata",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm",
+        "checksum": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+      },
+      {
+        "name": "python-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm",
+        "checksum": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+      },
+      {
+        "name": "python-inotify",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm",
+        "checksum": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+      },
+      {
+        "name": "python-ipaddr",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm",
+        "checksum": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+      },
+      {
+        "name": "python-ipaddress",
+        "epoch": 0,
+        "version": "1.0.16",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm",
+        "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+      },
+      {
+        "name": "python-jsonpatch",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm",
+        "checksum": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+      },
+      {
+        "name": "python-jsonpointer",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm",
+        "checksum": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+      },
+      {
+        "name": "python-kitchen",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm",
+        "checksum": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python-linux-procfs",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm",
+        "checksum": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+      },
+      {
+        "name": "python-lxml",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+      },
+      {
+        "name": "python-magic",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm",
+        "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+      },
+      {
+        "name": "python-perf",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+      },
+      {
+        "name": "python-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm",
+        "checksum": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+      },
+      {
+        "name": "python-pycurl",
+        "epoch": 0,
+        "version": "7.19.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+      },
+      {
+        "name": "python-pyudev",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm",
+        "checksum": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+      },
+      {
+        "name": "python-requests",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm",
+        "checksum": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+      },
+      {
+        "name": "python-schedutils",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
+        "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-slip",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+      },
+      {
+        "name": "python-slip-dbus",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+      },
+      {
+        "name": "python-syspurpose",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+      },
+      {
+        "name": "python-urlgrabber",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm",
+        "checksum": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+      },
+      {
+        "name": "python-urllib3",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm",
+        "checksum": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+      },
+      {
+        "name": "pyxattr",
+        "epoch": 0,
+        "version": "0.5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "quota",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm",
+        "checksum": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+      },
+      {
+        "name": "quota-nls",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm",
+        "checksum": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-eula",
+        "epoch": 0,
+        "version": "7.8",
+        "release": "0.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm",
+        "checksum": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "redhat-support-lib-python",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm",
+        "checksum": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+      },
+      {
+        "name": "redhat-support-tool",
+        "epoch": 0,
+        "version": "0.12.2",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm",
+        "checksum": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+      },
+      {
+        "name": "rhn-check",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+      },
+      {
+        "name": "rhn-client-tools",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+      },
+      {
+        "name": "rhn-setup",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+      },
+      {
+        "name": "rhnlib",
+        "epoch": 0,
+        "version": "2.5.65",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm",
+        "checksum": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+      },
+      {
+        "name": "rhnsd",
+        "epoch": 0,
+        "version": "5.0.13",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm",
+        "checksum": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm",
+        "checksum": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+      },
+      {
+        "name": "rpcbind",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "49.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
+        "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.2",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm",
+        "checksum": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.24.0",
+        "release": "55.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm",
+        "checksum": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setools-libs",
+        "epoch": 0,
+        "version": "3.3.8",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm",
+        "checksum": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.2.4",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm",
+        "checksum": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "subscription-manager",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+      },
+      {
+        "name": "subscription-manager-rhsm",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+      },
+      {
+        "name": "subscription-manager-rhsm-certificates",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.23",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm",
+        "checksum": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "systemd-sysv",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+      },
+      {
+        "name": "sysvinit-tools",
+        "epoch": 0,
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm",
+        "checksum": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tcp_wrappers",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+      },
+      {
+        "name": "tcp_wrappers-libs",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+      },
+      {
+        "name": "tcpdump",
+        "epoch": 14,
+        "version": "4.9.2",
+        "release": "4.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm",
+        "checksum": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "usermode",
+        "epoch": 0,
+        "version": "1.111",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm",
+        "checksum": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm",
+        "checksum": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "xdg-utils",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "0.17.20120809git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm",
+        "checksum": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "3.4.3",
+        "release": "168.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm",
+        "checksum": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+      },
+      {
+        "name": "yum-metadata-parser",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm",
+        "checksum": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+      },
+      {
+        "name": "yum-rhn-plugin",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm",
+        "checksum": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+      },
+      {
+        "name": "yum-utils",
+        "epoch": 0,
+        "version": "1.1.31",
+        "release": "54.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm",
+        "checksum": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "2.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
+        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+      },
+      {
+        "name": "python2-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "1.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
+        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+      },
+      {
+        "name": "python2-markupsafe",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
+        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+      },
+      {
+        "name": "python2-setuptools",
+        "epoch": 0,
+        "version": "38.4.0",
+        "release": "3.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
+        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+      }
+    ]
+  }
+}

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -1,0 +1,10931 @@
+{
+  "compose-request": {
+    "distro": "rhel-7",
+    "arch": "x86_64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "server",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530"
+      },
+      {
+        "name": "server-extras",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530"
+      },
+      {
+        "name": "server-optional",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-optional-r7.9-20220530"
+      },
+      {
+        "name": "server-dotnet",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530"
+      },
+      {
+        "name": "rhel-eng",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
+      },
+      {
+        "name": "azure-rhui-7",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-customize-boot-test",
+      "description": "Image for boot test",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "*"
+        }
+      ],
+      "modules": [],
+      "groups": [
+        {
+          "name": "core"
+        }
+      ],
+      "customizations": {
+        "hostname": "my-host",
+        "kernel": {
+          "append": "debug"
+        },
+        "sshkey": [
+          {
+            "user": "user1",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ],
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          }
+        ],
+        "timezone": {
+          "timezone": "Europe/London",
+          "ntpservers": [
+            "time.example.com"
+          ]
+        },
+        "locale": {
+          "languages": [
+            "el_CY.UTF-8"
+          ],
+          "keyboard": "dvorak"
+        },
+        "services": {
+          "enabled": [
+            "sshd.socket"
+          ],
+          "disabled": [
+            "bluetooth.service"
+          ]
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.rhel7",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+                  },
+                  {
+                    "id": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+                  },
+                  {
+                    "id": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+                  },
+                  {
+                    "id": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+                  },
+                  {
+                    "id": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+                  },
+                  {
+                    "id": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+                  },
+                  {
+                    "id": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+                  },
+                  {
+                    "id": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+                  },
+                  {
+                    "id": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+                  },
+                  {
+                    "id": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+                  },
+                  {
+                    "id": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+                  },
+                  {
+                    "id": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+                  },
+                  {
+                    "id": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+                  },
+                  {
+                    "id": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+                  },
+                  {
+                    "id": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+                  },
+                  {
+                    "id": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  }
+                ]
+              }
+            },
+            "options": {}
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
+                  },
+                  {
+                    "id": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+                  },
+                  {
+                    "id": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+                  },
+                  {
+                    "id": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+                  },
+                  {
+                    "id": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+                  },
+                  {
+                    "id": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+                  },
+                  {
+                    "id": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+                  },
+                  {
+                    "id": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+                  },
+                  {
+                    "id": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+                  },
+                  {
+                    "id": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+                  },
+                  {
+                    "id": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+                  },
+                  {
+                    "id": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+                  },
+                  {
+                    "id": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+                  },
+                  {
+                    "id": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+                  },
+                  {
+                    "id": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+                  },
+                  {
+                    "id": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+                  },
+                  {
+                    "id": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+                  },
+                  {
+                    "id": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+                  },
+                  {
+                    "id": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+                  },
+                  {
+                    "id": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+                  },
+                  {
+                    "id": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+                  },
+                  {
+                    "id": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+                  },
+                  {
+                    "id": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+                  },
+                  {
+                    "id": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+                  },
+                  {
+                    "id": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+                  },
+                  {
+                    "id": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+                  },
+                  {
+                    "id": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+                  },
+                  {
+                    "id": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+                  },
+                  {
+                    "id": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+                  },
+                  {
+                    "id": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+                  },
+                  {
+                    "id": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+                  },
+                  {
+                    "id": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+                  },
+                  {
+                    "id": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+                  },
+                  {
+                    "id": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+                  },
+                  {
+                    "id": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+                  },
+                  {
+                    "id": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+                  },
+                  {
+                    "id": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+                  },
+                  {
+                    "id": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+                  },
+                  {
+                    "id": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+                  },
+                  {
+                    "id": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+                  },
+                  {
+                    "id": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+                  },
+                  {
+                    "id": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+                  },
+                  {
+                    "id": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+                  },
+                  {
+                    "id": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+                  },
+                  {
+                    "id": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+                  },
+                  {
+                    "id": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+                  },
+                  {
+                    "id": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+                  },
+                  {
+                    "id": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+                  },
+                  {
+                    "id": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+                  },
+                  {
+                    "id": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+                  },
+                  {
+                    "id": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+                  },
+                  {
+                    "id": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+                  },
+                  {
+                    "id": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+                  },
+                  {
+                    "id": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+                  },
+                  {
+                    "id": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+                  },
+                  {
+                    "id": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+                  },
+                  {
+                    "id": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+                  },
+                  {
+                    "id": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+                  },
+                  {
+                    "id": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+                  },
+                  {
+                    "id": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+                  },
+                  {
+                    "id": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+                  },
+                  {
+                    "id": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+                  },
+                  {
+                    "id": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+                  },
+                  {
+                    "id": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+                  },
+                  {
+                    "id": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+                  },
+                  {
+                    "id": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+                  },
+                  {
+                    "id": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+                  },
+                  {
+                    "id": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+                  },
+                  {
+                    "id": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+                  },
+                  {
+                    "id": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+                  },
+                  {
+                    "id": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+                  },
+                  {
+                    "id": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+                  },
+                  {
+                    "id": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+                  },
+                  {
+                    "id": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+                  },
+                  {
+                    "id": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+                  },
+                  {
+                    "id": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+                  },
+                  {
+                    "id": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+                  },
+                  {
+                    "id": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+                  },
+                  {
+                    "id": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+                  },
+                  {
+                    "id": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+                  },
+                  {
+                    "id": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+                  },
+                  {
+                    "id": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+                  },
+                  {
+                    "id": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+                  },
+                  {
+                    "id": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+                  },
+                  {
+                    "id": "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904"
+                  },
+                  {
+                    "id": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+                  },
+                  {
+                    "id": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+                  },
+                  {
+                    "id": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+                  },
+                  {
+                    "id": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+                  },
+                  {
+                    "id": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+                  },
+                  {
+                    "id": "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d"
+                  },
+                  {
+                    "id": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+                  },
+                  {
+                    "id": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+                  },
+                  {
+                    "id": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+                  },
+                  {
+                    "id": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+                  },
+                  {
+                    "id": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+                  },
+                  {
+                    "id": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+                  },
+                  {
+                    "id": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+                  },
+                  {
+                    "id": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+                  },
+                  {
+                    "id": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+                  },
+                  {
+                    "id": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+                  },
+                  {
+                    "id": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+                  },
+                  {
+                    "id": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+                  },
+                  {
+                    "id": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+                  },
+                  {
+                    "id": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+                  },
+                  {
+                    "id": "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960"
+                  },
+                  {
+                    "id": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+                  },
+                  {
+                    "id": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+                  },
+                  {
+                    "id": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+                  },
+                  {
+                    "id": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+                  },
+                  {
+                    "id": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+                  },
+                  {
+                    "id": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+                  },
+                  {
+                    "id": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+                  },
+                  {
+                    "id": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+                  },
+                  {
+                    "id": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+                  },
+                  {
+                    "id": "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061"
+                  },
+                  {
+                    "id": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+                  },
+                  {
+                    "id": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+                  },
+                  {
+                    "id": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+                  },
+                  {
+                    "id": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+                  },
+                  {
+                    "id": "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4"
+                  },
+                  {
+                    "id": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+                  },
+                  {
+                    "id": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+                  },
+                  {
+                    "id": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+                  },
+                  {
+                    "id": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+                  },
+                  {
+                    "id": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+                  },
+                  {
+                    "id": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+                  },
+                  {
+                    "id": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+                  },
+                  {
+                    "id": "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e"
+                  },
+                  {
+                    "id": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+                  },
+                  {
+                    "id": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+                  },
+                  {
+                    "id": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+                  },
+                  {
+                    "id": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+                  },
+                  {
+                    "id": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+                  },
+                  {
+                    "id": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+                  },
+                  {
+                    "id": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+                  },
+                  {
+                    "id": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+                  },
+                  {
+                    "id": "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff"
+                  },
+                  {
+                    "id": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+                  },
+                  {
+                    "id": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+                  },
+                  {
+                    "id": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+                  },
+                  {
+                    "id": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+                  },
+                  {
+                    "id": "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7"
+                  },
+                  {
+                    "id": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+                  },
+                  {
+                    "id": "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49"
+                  },
+                  {
+                    "id": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+                  },
+                  {
+                    "id": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+                  },
+                  {
+                    "id": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+                  },
+                  {
+                    "id": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+                  },
+                  {
+                    "id": "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab"
+                  },
+                  {
+                    "id": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+                  },
+                  {
+                    "id": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+                  },
+                  {
+                    "id": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+                  },
+                  {
+                    "id": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+                  },
+                  {
+                    "id": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+                  },
+                  {
+                    "id": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+                  },
+                  {
+                    "id": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+                  },
+                  {
+                    "id": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+                  },
+                  {
+                    "id": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+                  },
+                  {
+                    "id": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+                  },
+                  {
+                    "id": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+                  },
+                  {
+                    "id": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+                  },
+                  {
+                    "id": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+                  },
+                  {
+                    "id": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+                  },
+                  {
+                    "id": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+                  },
+                  {
+                    "id": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+                  },
+                  {
+                    "id": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+                  },
+                  {
+                    "id": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+                  },
+                  {
+                    "id": "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25"
+                  },
+                  {
+                    "id": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+                  },
+                  {
+                    "id": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+                  },
+                  {
+                    "id": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+                  },
+                  {
+                    "id": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+                  },
+                  {
+                    "id": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+                  },
+                  {
+                    "id": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+                  },
+                  {
+                    "id": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+                  },
+                  {
+                    "id": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+                  },
+                  {
+                    "id": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+                  },
+                  {
+                    "id": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+                  },
+                  {
+                    "id": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+                  },
+                  {
+                    "id": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+                  },
+                  {
+                    "id": "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644"
+                  },
+                  {
+                    "id": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+                  },
+                  {
+                    "id": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+                  },
+                  {
+                    "id": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+                  },
+                  {
+                    "id": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+                  },
+                  {
+                    "id": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+                  },
+                  {
+                    "id": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+                  },
+                  {
+                    "id": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+                  },
+                  {
+                    "id": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+                  },
+                  {
+                    "id": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+                  },
+                  {
+                    "id": "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c"
+                  },
+                  {
+                    "id": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+                  },
+                  {
+                    "id": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+                  },
+                  {
+                    "id": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+                  },
+                  {
+                    "id": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+                  },
+                  {
+                    "id": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+                  },
+                  {
+                    "id": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+                  },
+                  {
+                    "id": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+                  },
+                  {
+                    "id": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+                  },
+                  {
+                    "id": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+                  },
+                  {
+                    "id": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+                  },
+                  {
+                    "id": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+                  },
+                  {
+                    "id": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+                  },
+                  {
+                    "id": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+                  },
+                  {
+                    "id": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+                  },
+                  {
+                    "id": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+                  },
+                  {
+                    "id": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+                  },
+                  {
+                    "id": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+                  },
+                  {
+                    "id": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+                  },
+                  {
+                    "id": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+                  },
+                  {
+                    "id": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+                  },
+                  {
+                    "id": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+                  },
+                  {
+                    "id": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+                  },
+                  {
+                    "id": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+                  },
+                  {
+                    "id": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+                  },
+                  {
+                    "id": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+                  },
+                  {
+                    "id": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+                  },
+                  {
+                    "id": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+                  },
+                  {
+                    "id": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+                  },
+                  {
+                    "id": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+                  },
+                  {
+                    "id": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+                  },
+                  {
+                    "id": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+                  },
+                  {
+                    "id": "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d"
+                  },
+                  {
+                    "id": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+                  },
+                  {
+                    "id": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+                  },
+                  {
+                    "id": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+                  },
+                  {
+                    "id": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+                  },
+                  {
+                    "id": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+                  },
+                  {
+                    "id": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+                  },
+                  {
+                    "id": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+                  },
+                  {
+                    "id": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+                  },
+                  {
+                    "id": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+                  },
+                  {
+                    "id": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+                  },
+                  {
+                    "id": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+                  },
+                  {
+                    "id": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+                  },
+                  {
+                    "id": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+                  },
+                  {
+                    "id": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+                  },
+                  {
+                    "id": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+                  },
+                  {
+                    "id": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+                  },
+                  {
+                    "id": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+                  },
+                  {
+                    "id": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+                  },
+                  {
+                    "id": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+                  },
+                  {
+                    "id": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+                  },
+                  {
+                    "id": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+                  },
+                  {
+                    "id": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+                  },
+                  {
+                    "id": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+                  },
+                  {
+                    "id": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+                  },
+                  {
+                    "id": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+                  },
+                  {
+                    "id": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+                  },
+                  {
+                    "id": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+                  },
+                  {
+                    "id": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+                  },
+                  {
+                    "id": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+                  },
+                  {
+                    "id": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+                  },
+                  {
+                    "id": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+                  },
+                  {
+                    "id": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+                  },
+                  {
+                    "id": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+                  },
+                  {
+                    "id": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+                  },
+                  {
+                    "id": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+                  },
+                  {
+                    "id": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+                  },
+                  {
+                    "id": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+                  },
+                  {
+                    "id": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+                  },
+                  {
+                    "id": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+                  },
+                  {
+                    "id": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+                  },
+                  {
+                    "id": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+                  },
+                  {
+                    "id": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+                  },
+                  {
+                    "id": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+                  },
+                  {
+                    "id": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+                  },
+                  {
+                    "id": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+                  },
+                  {
+                    "id": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+                  },
+                  {
+                    "id": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+                  },
+                  {
+                    "id": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+                  },
+                  {
+                    "id": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+                  },
+                  {
+                    "id": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+                  },
+                  {
+                    "id": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+                  },
+                  {
+                    "id": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+                  },
+                  {
+                    "id": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+                  },
+                  {
+                    "id": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+                  },
+                  {
+                    "id": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+                  },
+                  {
+                    "id": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+                  },
+                  {
+                    "id": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+                  },
+                  {
+                    "id": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+                  },
+                  {
+                    "id": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+                  },
+                  {
+                    "id": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+                  },
+                  {
+                    "id": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+                  },
+                  {
+                    "id": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+                  },
+                  {
+                    "id": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+                  },
+                  {
+                    "id": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+                  },
+                  {
+                    "id": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+                  },
+                  {
+                    "id": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+                  },
+                  {
+                    "id": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+                  },
+                  {
+                    "id": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+                  },
+                  {
+                    "id": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+                  },
+                  {
+                    "id": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+                  },
+                  {
+                    "id": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+                  },
+                  {
+                    "id": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+                  },
+                  {
+                    "id": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+                  },
+                  {
+                    "id": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+                  },
+                  {
+                    "id": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+                  },
+                  {
+                    "id": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+                  },
+                  {
+                    "id": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+                  },
+                  {
+                    "id": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+                  },
+                  {
+                    "id": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+                  },
+                  {
+                    "id": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+                  },
+                  {
+                    "id": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+                  },
+                  {
+                    "id": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+                  },
+                  {
+                    "id": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+                  },
+                  {
+                    "id": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+                  },
+                  {
+                    "id": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+                  },
+                  {
+                    "id": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+                  },
+                  {
+                    "id": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+                  },
+                  {
+                    "id": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+                  },
+                  {
+                    "id": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+                  },
+                  {
+                    "id": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+                  },
+                  {
+                    "id": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+                  },
+                  {
+                    "id": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+                  },
+                  {
+                    "id": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+                  },
+                  {
+                    "id": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+                  },
+                  {
+                    "id": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+                  },
+                  {
+                    "id": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+                  },
+                  {
+                    "id": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+                  },
+                  {
+                    "id": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+                  },
+                  {
+                    "id": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+                  },
+                  {
+                    "id": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+                  },
+                  {
+                    "id": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+                  },
+                  {
+                    "id": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+                  },
+                  {
+                    "id": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+                  },
+                  {
+                    "id": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+                  },
+                  {
+                    "id": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+                  },
+                  {
+                    "id": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+                  },
+                  {
+                    "id": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+                  },
+                  {
+                    "id": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+                  },
+                  {
+                    "id": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+                  },
+                  {
+                    "id": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+                  },
+                  {
+                    "id": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+                  },
+                  {
+                    "id": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+                  },
+                  {
+                    "id": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+                  },
+                  {
+                    "id": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys.fromtree": [
+                "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "el_CY.UTF-8"
+            }
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "dvorak"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "my-host"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "Europe/London"
+            }
+          },
+          {
+            "type": "org.osbuild.chrony",
+            "options": {
+              "timeservers": [
+                "time.example.com"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.groups",
+            "options": {
+              "groups": {
+                "group1": {
+                  "gid": 1030
+                },
+                "group2": {
+                  "gid": 1050
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "user1": {
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                },
+                "user2": {
+                  "uid": 1020,
+                  "gid": 1050,
+                  "groups": [
+                    "group1"
+                  ],
+                  "description": "description 2",
+                  "home": "/home/home2",
+                  "shell": "/bin/sh",
+                  "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd",
+            "options": {
+              "enabled_services": [
+                "sshd.socket"
+              ],
+              "disabled_services": [
+                "bluetooth.service"
+              ],
+              "default_target": "multi-user.target"
+            }
+          },
+          {
+            "type": "org.osbuild.sysconfig",
+            "options": {
+              "kernel": {
+                "update_default": true,
+                "default_kernel": "kernel"
+              },
+              "network": {
+                "networking": true,
+                "no_zero_conf": true
+              },
+              "network-scripts": {
+                "ifcfg": {
+                  "eth0": {
+                    "bootproto": "dhcp",
+                    "device": "eth0",
+                    "ipv6init": false,
+                    "onboot": true,
+                    "peerdns": true,
+                    "type": "Ethernet",
+                    "userctl": true
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.rhsm",
+            "options": {
+              "yum-plugins": {
+                "product-id": {
+                  "enabled": false
+                },
+                "subscription-manager": {
+                  "enabled": false
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2.legacy",
+            "options": {
+              "rootfs": {
+                "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+              },
+              "entries": [
+                {
+                  "default": true,
+                  "id": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                  "kernel": "3.10.0-1160.el7.x86_64",
+                  "product": {
+                    "name": "Red Hat Enterprise Linux",
+                    "version": "7.9",
+                    "nick": "Maipo"
+                  }
+                }
+              ],
+              "bios": {
+                "platform": "i386-pc"
+              },
+              "uefi": {
+                "vendor": "redhat"
+              },
+              "bootfs": {
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+              },
+              "config": {
+                "cmdline": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
+                "distributor": "$(sed 's, release .*$,,g' /etc/system-release)"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "force_autorelabel": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sgdisk",
+            "options": {
+              "uuid": "d209c89e-ea5e-4fbd-b161-b461cce297e0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "fac7f1fb-3e8d-4137-a512-961de09a5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68b2905b-df3e-4fb3-80fa-49d1e773aa33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "cb07c243-bc44-4717-853e-28852021225b"
+                },
+                {
+                  "size": 19533791,
+                  "start": 1437696,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+                  "uuid": "6264d520-3fb9-423f-8ab8-7a0a8e3d3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "xfs"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "qcow2",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.qemu",
+            "inputs": {
+              "image": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.pipeline",
+                "references": {
+                  "name:image": {
+                    "file": "disk.img"
+                  }
+                }
+              }
+            },
+            "options": {
+              "filename": "disk.qcow2",
+              "format": {
+                "type": "qcow2",
+                "compat": "0.10"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:005d3c65516a8021aac3e640d498a5fafe7f86eb7848009aed399a42730aa79f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-tools-firmware-1.1.0-1.el7.x86_64.rpm"
+          },
+          "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm"
+          },
+          "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:027e16fd46bc2ecbfdcc42f4426d80406b83db0582b1e908c058231299dc7614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-rescue-033-572.el7.x86_64.rpm"
+          },
+          "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm"
+          },
+          "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm"
+          },
+          "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm"
+          },
+          "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm"
+          },
+          "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-firmware-1.0.28-2.el7.noarch.rpm"
+          },
+          "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm"
+          },
+          "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm"
+          },
+          "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm"
+          },
+          "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm"
+          },
+          "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcollection-0.7.0-32.el7.x86_64.rpm"
+          },
+          "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm"
+          },
+          "sha256:0b4110cf94f7f793dbabb7a1a616087455ab316ec74ad5204abb0fd2f211ee58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6050-firmware-41.28.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm"
+          },
+          "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/insights-client-3.0.13-1.el7.noarch.rpm"
+          },
+          "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm"
+          },
+          "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm"
+          },
+          "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm"
+          },
+          "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm"
+          },
+          "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm"
+          },
+          "sha256:11ac559bb43266411c847e259a1bb111ee67b4fdc09c3d9dbf6e91094f815e0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl135-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:12b098f5666193520fc84a092ce438a39f8c3ff53f7a7c4eee55e6515b49618c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2000-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm"
+          },
+          "sha256:12d3f2ca7449af3e3a3cff8be6b024cd1106987f49a7be16a84fa9bb39f2dde9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl100-firmware-39.31.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm"
+          },
+          "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm"
+          },
+          "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm"
+          },
+          "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm"
+          },
+          "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm"
+          },
+          "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm"
+          },
+          "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm"
+          },
+          "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm"
+          },
+          "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:19f7ca6bf9d8e762c376d0d8b52e2982e900a3d3e5fe7d3f095d1b27f4ab95aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-scripts-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm"
+          },
+          "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm"
+          },
+          "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm"
+          },
+          "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm"
+          },
+          "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm"
+          },
+          "sha256:2293799f84ccf36c681066a3aa0f7fe713b913e589c105713ecbb98e86966cc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-logos-70.7.0-1.el7.noarch.rpm"
+          },
+          "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm"
+          },
+          "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm"
+          },
+          "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm"
+          },
+          "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm"
+          },
+          "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm"
+          },
+          "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm"
+          },
+          "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm"
+          },
+          "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm"
+          },
+          "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm"
+          },
+          "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm"
+          },
+          "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm"
+          },
+          "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm"
+          },
+          "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm"
+          },
+          "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm"
+          },
+          "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm"
+          },
+          "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:2e56f3449308538a955393ca85e4908d9022885fa34894cb365669b9d38de282": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-3.2.28-4.el7.x86_64.rpm"
+          },
+          "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm"
+          },
+          "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm"
+          },
+          "sha256:33fba59c069f63b29ac955363d97683c582178f5e314d594c452b8a630a59170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl7260-firmware-25.30.13.0-79.el7.noarch.rpm"
+          },
+          "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mariadb-libs-5.5.68-1.el7.x86_64.rpm"
+          },
+          "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm"
+          },
+          "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm"
+          },
+          "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm"
+          },
+          "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm"
+          },
+          "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm"
+          },
+          "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm"
+          },
+          "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm"
+          },
+          "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm"
+          },
+          "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm"
+          },
+          "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm"
+          },
+          "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm"
+          },
+          "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm"
+          },
+          "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5000-firmware-8.83.5.1_1-79.el7.noarch.rpm"
+          },
+          "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm"
+          },
+          "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm"
+          },
+          "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm"
+          },
+          "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm"
+          },
+          "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm"
+          },
+          "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm"
+          },
+          "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm"
+          },
+          "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm"
+          },
+          "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm"
+          },
+          "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm"
+          },
+          "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm"
+          },
+          "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm"
+          },
+          "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm"
+          },
+          "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm"
+          },
+          "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm"
+          },
+          "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm"
+          },
+          "sha256:4dc9a401c2514336e46adc87f5d05244ca743eb08bf6bcab1443a9eba6b81970": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm"
+          },
+          "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm"
+          },
+          "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm"
+          },
+          "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm"
+          },
+          "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm"
+          },
+          "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm"
+          },
+          "sha256:535aec9847767995152b43de3f8323e53c7c36decf894ca6e426742fb1507322": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-cli-3.2.28-4.el7.x86_64.rpm"
+          },
+          "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm"
+          },
+          "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm"
+          },
+          "sha256:5487de1bac24442383d789e48ba61456ec1b28095b481ca87a2bd5a2a67b6c43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/teamd-1.29-3.el7.x86_64.rpm"
+          },
+          "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm"
+          },
+          "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm"
+          },
+          "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm"
+          },
+          "sha256:58ce6f65f4b61dfcb190deac65fca0cc210abfdae65b54a88ee5f61c61e3e47e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/jansson-2.10-1.el7.x86_64.rpm"
+          },
+          "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm"
+          },
+          "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-1.5.8-3.el7.x86_64.rpm"
+          },
+          "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm"
+          },
+          "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm"
+          },
+          "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm"
+          },
+          "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm"
+          },
+          "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm"
+          },
+          "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm"
+          },
+          "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm"
+          },
+          "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm"
+          },
+          "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm"
+          },
+          "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm"
+          },
+          "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5150-firmware-8.24.2.2-79.el7.noarch.rpm"
+          },
+          "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm"
+          },
+          "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm"
+          },
+          "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm"
+          },
+          "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm"
+          },
+          "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libref_array-0.1.5-32.el7.x86_64.rpm"
+          },
+          "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm"
+          },
+          "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm"
+          },
+          "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm"
+          },
+          "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm"
+          },
+          "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm"
+          },
+          "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm"
+          },
+          "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm"
+          },
+          "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm"
+          },
+          "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm"
+          },
+          "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm"
+          },
+          "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libbasicobjects-0.1.1-32.el7.x86_64.rpm"
+          },
+          "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm"
+          },
+          "sha256:7567202eb027a1efb739092a6204307d735db326cf92a2c979201e36d841a284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libndp-1.2-9.el7.x86_64.rpm"
+          },
+          "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm"
+          },
+          "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm"
+          },
+          "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm"
+          },
+          "sha256:77a55f2182769815d41519b53ca15b54aa09cbe48249cd91487a091e81fdd7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-core-libs-0.8.9-0.34.20140113.el7.x86_64.rpm"
+          },
+          "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm"
+          },
+          "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm"
+          },
+          "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm"
+          },
+          "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm"
+          },
+          "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm"
+          },
+          "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm"
+          },
+          "sha256:7d15ad33bec7d5bdc64074edaecff6019f590069b5375de7640c7df7e8e3776d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl1000-firmware-39.31.5.1-79.el7.noarch.rpm"
+          },
+          "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm"
+          },
+          "sha256:7e3edabd3ad60028285e194934644e087602c2440a672dc8c05996afb044ece4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3160-firmware-25.30.13.0-79.el7.noarch.rpm"
+          },
+          "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-libevent-0.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm"
+          },
+          "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdaemon-0.14-7.el7.x86_64.rpm"
+          },
+          "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm"
+          },
+          "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm"
+          },
+          "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm"
+          },
+          "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm"
+          },
+          "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm"
+          },
+          "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm"
+          },
+          "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm"
+          },
+          "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm"
+          },
+          "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm"
+          },
+          "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm"
+          },
+          "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm"
+          },
+          "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm"
+          },
+          "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm"
+          },
+          "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm"
+          },
+          "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm"
+          },
+          "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm"
+          },
+          "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm"
+          },
+          "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm"
+          },
+          "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gssproxy-0.7.0-29.el7.x86_64.rpm"
+          },
+          "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm"
+          },
+          "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm"
+          },
+          "sha256:93503e6622050a007698e4649903b26f7c76b207461c5e97c9215437a33b031f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libteam-1.29-3.el7.x86_64.rpm"
+          },
+          "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm"
+          },
+          "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm"
+          },
+          "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm"
+          },
+          "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm"
+          },
+          "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm"
+          },
+          "sha256:978c60b716fd39216dede943a6149f2673a6277b534f5310190dd765e5b0010c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/aic94xx-firmware-30-6.el7.noarch.rpm"
+          },
+          "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm"
+          },
+          "sha256:97dfbf353c370ee92b04a856a883255217528af0cfcbc9f234531efe71c043e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl105-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm"
+          },
+          "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm"
+          },
+          "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm"
+          },
+          "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm"
+          },
+          "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm"
+          },
+          "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm"
+          },
+          "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm"
+          },
+          "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm"
+          },
+          "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm"
+          },
+          "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm"
+          },
+          "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm"
+          },
+          "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm"
+          },
+          "sha256:a37d2eeb9810427888dfe2eea1712441e0bb91e74f93d2166a8978a29f82ca98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000-firmware-9.221.4.1-79.el7.noarch.rpm"
+          },
+          "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm"
+          },
+          "sha256:a3dc70cc6472c7eb9d1216acc144a6dceb48bdb69955f01b8585cd80ffdd538a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2b-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm"
+          },
+          "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm"
+          },
+          "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:a61dcf3c31bc66497c86d007870305008e2ab6d11fc6a570af179afa19bfcbc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wpa_supplicant-2.6-12.el7.x86_64.rpm"
+          },
+          "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm"
+          },
+          "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm"
+          },
+          "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm"
+          },
+          "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm"
+          },
+          "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm"
+          },
+          "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm"
+          },
+          "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm"
+          },
+          "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm"
+          },
+          "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm"
+          },
+          "sha256:aced7b9842dab221f2ca286c7532c9342e81fff0df3f09c4f265ec3fa83d4ece": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3945-firmware-15.32.2.9-79.el7.noarch.rpm"
+          },
+          "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm"
+          },
+          "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libini_config-1.3.1-32.el7.x86_64.rpm"
+          },
+          "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm"
+          },
+          "sha256:aeb22ef9ac260054a3641602a021740b6d0985cbddc60bc00ce2b3279017ca1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpciaccess-0.14-1.el7.x86_64.rpm"
+          },
+          "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm"
+          },
+          "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm"
+          },
+          "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm"
+          },
+          "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm"
+          },
+          "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm"
+          },
+          "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm"
+          },
+          "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm"
+          },
+          "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm"
+          },
+          "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm"
+          },
+          "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm"
+          },
+          "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm"
+          },
+          "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm"
+          },
+          "sha256:bb7b02048bc98c2f62e62ce67f36eb54cfcbf53f763ea0cd557053d20b2a2682": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdrm-2.4.97-2.el7.x86_64.rpm"
+          },
+          "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nfs-utils-1.3.0-0.68.el7.x86_64.rpm"
+          },
+          "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm"
+          },
+          "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm"
+          },
+          "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm"
+          },
+          "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-tui-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm"
+          },
+          "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm"
+          },
+          "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm"
+          },
+          "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm"
+          },
+          "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm"
+          },
+          "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm"
+          },
+          "sha256:c4703397f0a79f8f9f47549f3c535ef7c650bc169b5fbe67dfa5699f2ae91e18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chrony-3.4-1.el7.x86_64.rpm"
+          },
+          "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm"
+          },
+          "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm"
+          },
+          "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm"
+          },
+          "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm"
+          },
+          "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm"
+          },
+          "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm"
+          },
+          "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm"
+          },
+          "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm"
+          },
+          "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm"
+          },
+          "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm"
+          },
+          "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/postfix-2.10.1-9.el7.x86_64.rpm"
+          },
+          "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm"
+          },
+          "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm"
+          },
+          "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm"
+          },
+          "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm"
+          },
+          "sha256:d029559bf7ec180b3c1d698cbc2d3f4d7988cc9f17ec40ae62e4da90c4816d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fxload-2002_04_11-16.el7.x86_64.rpm"
+          },
+          "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm"
+          },
+          "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm"
+          },
+          "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm"
+          },
+          "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm"
+          },
+          "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm"
+          },
+          "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm"
+          },
+          "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm"
+          },
+          "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm"
+          },
+          "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm"
+          },
+          "sha256:d69952b6417c422f416fe3baddd49dec88a26cd826749961ee24b6721977a2ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ivtv-firmware-20080701-26.el7.noarch.rpm"
+          },
+          "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm"
+          },
+          "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm"
+          },
+          "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm"
+          },
+          "sha256:d866a841fa8afa3b5f4210f172d4eb78aafaa13b0de26ccbea708779fb746b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2a-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm"
+          },
+          "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm"
+          },
+          "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm"
+          },
+          "sha256:da67098eeba3936506e2fcd15e5332d4afffe37e31b97f9170bea8ce9ceafd76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm"
+          },
+          "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm"
+          },
+          "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libevent-2.0.21-4.el7.x86_64.rpm"
+          },
+          "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm"
+          },
+          "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm"
+          },
+          "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm"
+          },
+          "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm"
+          },
+          "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm"
+          },
+          "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm"
+          },
+          "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm"
+          },
+          "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm"
+          },
+          "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm"
+          },
+          "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm"
+          },
+          "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm"
+          },
+          "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm"
+          },
+          "sha256:e70333dc0e327dd19cd56dd2ad8251ba42920b88ee38718ba99fa1d0f9b06913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-lib-1.1.8-1.el7.x86_64.rpm"
+          },
+          "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm"
+          },
+          "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm"
+          },
+          "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm"
+          },
+          "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm"
+          },
+          "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm"
+          },
+          "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm"
+          },
+          "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm"
+          },
+          "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm"
+          },
+          "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm"
+          },
+          "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm"
+          },
+          "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm"
+          },
+          "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm"
+          },
+          "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm"
+          },
+          "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm"
+          },
+          "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm"
+          },
+          "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm"
+          },
+          "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm"
+          },
+          "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm"
+          },
+          "sha256:f4e8763f1a42799dbcbada6f3c7f7f0943c89d9f5369bb750ea067a6e7a5ce4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2030-firmware-18.168.6.1-79.el7.noarch.rpm"
+          },
+          "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm"
+          },
+          "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm"
+          },
+          "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm"
+          },
+          "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm"
+          },
+          "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm"
+          },
+          "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm"
+          },
+          "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm"
+          },
+          "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm"
+          },
+          "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm"
+          },
+          "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm"
+          },
+          "sha256:fca63e69026cd824dbe1d0ba051894e2bb63b3277d5a01c42fda7accc909b6a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-team-1.18.8-1.el7.x86_64.rpm"
+          },
+          "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm"
+          },
+          "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm"
+          },
+          "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm"
+          },
+          "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm"
+          },
+          "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "blueprint": [
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:cc4b75e1ce83af2dbad9604e70bcf40e7f20ad8918a08f8b82f6d5e69efd9655"
+      },
+      {
+        "name": "NetworkManager-config-server",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm",
+        "checksum": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-libnm-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:cab023377a79bf3dc9317c1281abf4099aaccc0c95e69032fe2e563023a802f0"
+      },
+      {
+        "name": "NetworkManager-team",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-team-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:fca63e69026cd824dbe1d0ba051894e2bb63b3277d5a01c42fda7accc909b6a9"
+      },
+      {
+        "name": "NetworkManager-tui",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-tui-1.18.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:bfb092807d02f35824f86087b5baf279d92e3c2290d94bc00078b6ea0ec97c22"
+      },
+      {
+        "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
+        "epoch": 0,
+        "version": "7",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm",
+        "checksum": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "aic94xx-firmware",
+        "epoch": 0,
+        "version": "30",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/aic94xx-firmware-30-6.el7.noarch.rpm",
+        "checksum": "sha256:978c60b716fd39216dede943a6149f2673a6277b534f5310190dd765e5b0010c"
+      },
+      {
+        "name": "alsa-firmware",
+        "epoch": 0,
+        "version": "1.0.28",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-firmware-1.0.28-2.el7.noarch.rpm",
+        "checksum": "sha256:07aa5c8a348915ae684375cb75ab5e4d8c38bde2a90083126fe81c0ec7650db0"
+      },
+      {
+        "name": "alsa-lib",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-lib-1.1.8-1.el7.x86_64.rpm",
+        "checksum": "sha256:e70333dc0e327dd19cd56dd2ad8251ba42920b88ee38718ba99fa1d0f9b06913"
+      },
+      {
+        "name": "alsa-tools-firmware",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/alsa-tools-firmware-1.1.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:005d3c65516a8021aac3e640d498a5fafe7f86eb7848009aed399a42730aa79f"
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.06.95",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm",
+        "checksum": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "biosdevname",
+        "epoch": 0,
+        "version": "0.7.3",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/biosdevname-0.7.3-2.el7.x86_64.rpm",
+        "checksum": "sha256:838e27cadbb77a140e9c26664d37cd22d38f22500b8e9b587405e926bbb7c18f"
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "4.9.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chrony-3.4-1.el7.x86_64.rpm",
+        "checksum": "sha256:c4703397f0a79f8f9f47549f3c535ef7c650bc169b5fbe67dfa5699f2ae91e18"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.20121102git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm",
+        "checksum": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.100",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm",
+        "checksum": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "dbus-python",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+      },
+      {
+        "name": "desktop-file-utils",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+      },
+      {
+        "name": "dhclient",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-rescue-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:027e16fd46bc2ecbfdcc42f4426d80406b83db0582b1e908c058231299dc7614"
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "ebtables",
+        "epoch": 0,
+        "version": "2.0.10",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm",
+        "checksum": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "emacs-filesystem",
+        "epoch": 1,
+        "version": "24.3",
+        "release": "23.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm",
+        "checksum": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "4.8",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm",
+        "checksum": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "fipscheck",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+      },
+      {
+        "name": "fipscheck-lib",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+      },
+      {
+        "name": "fxload",
+        "epoch": 0,
+        "version": "2002_04_11",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fxload-2002_04_11-16.el7.x86_64.rpm",
+        "checksum": "sha256:d029559bf7ec180b3c1d698cbc2d3f4d7988cc9f17ec40ae62e4da90c4816d35"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.0.22",
+        "release": "5.el7_5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm",
+        "checksum": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.2",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm",
+        "checksum": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.28",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm",
+        "checksum": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.252",
+        "release": "9.7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm",
+        "checksum": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "9.49.53",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm",
+        "checksum": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "4.11.0",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm",
+        "checksum": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+      },
+      {
+        "name": "iprutils",
+        "epoch": 0,
+        "version": "2.4.17.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iprutils-2.4.17.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:c5137a9d3b9aac4dba1262800fa480bbc979a62227ad31f0d837618cdf4377ee"
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.4.21",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm",
+        "checksum": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20160308",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm",
+        "checksum": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 3,
+        "version": "1.0.7",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm",
+        "checksum": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+      },
+      {
+        "name": "ivtv-firmware",
+        "epoch": 2,
+        "version": "20080701",
+        "release": "26.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ivtv-firmware-20080701-26.el7.noarch.rpm",
+        "checksum": "sha256:d69952b6417c422f416fe3baddd49dec88a26cd826749961ee24b6721977a2ce"
+      },
+      {
+        "name": "iwl100-firmware",
+        "epoch": 0,
+        "version": "39.31.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl100-firmware-39.31.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:12d3f2ca7449af3e3a3cff8be6b024cd1106987f49a7be16a84fa9bb39f2dde9"
+      },
+      {
+        "name": "iwl1000-firmware",
+        "epoch": 1,
+        "version": "39.31.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl1000-firmware-39.31.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:7d15ad33bec7d5bdc64074edaecff6019f590069b5375de7640c7df7e8e3776d"
+      },
+      {
+        "name": "iwl105-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl105-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:97dfbf353c370ee92b04a856a883255217528af0cfcbc9f234531efe71c043e6"
+      },
+      {
+        "name": "iwl135-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl135-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:11ac559bb43266411c847e259a1bb111ee67b4fdc09c3d9dbf6e91094f815e0f"
+      },
+      {
+        "name": "iwl2000-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2000-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:12b098f5666193520fc84a092ce438a39f8c3ff53f7a7c4eee55e6515b49618c"
+      },
+      {
+        "name": "iwl2030-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl2030-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:f4e8763f1a42799dbcbada6f3c7f7f0943c89d9f5369bb750ea067a6e7a5ce4b"
+      },
+      {
+        "name": "iwl3160-firmware",
+        "epoch": 0,
+        "version": "25.30.13.0",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3160-firmware-25.30.13.0-79.el7.noarch.rpm",
+        "checksum": "sha256:7e3edabd3ad60028285e194934644e087602c2440a672dc8c05996afb044ece4"
+      },
+      {
+        "name": "iwl3945-firmware",
+        "epoch": 0,
+        "version": "15.32.2.9",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl3945-firmware-15.32.2.9-79.el7.noarch.rpm",
+        "checksum": "sha256:aced7b9842dab221f2ca286c7532c9342e81fff0df3f09c4f265ec3fa83d4ece"
+      },
+      {
+        "name": "iwl4965-firmware",
+        "epoch": 0,
+        "version": "228.61.2.24",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl4965-firmware-228.61.2.24-79.el7.noarch.rpm",
+        "checksum": "sha256:0a6d71d0c1c1d14f2a6885734232dbe2a06ca6a958a9b81f06cef008e58769c8"
+      },
+      {
+        "name": "iwl5000-firmware",
+        "epoch": 0,
+        "version": "8.83.5.1_1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5000-firmware-8.83.5.1_1-79.el7.noarch.rpm",
+        "checksum": "sha256:3da6456472355dc70e19cd3b5109a73b8f5c019bb7f24a6b17d7150314f07244"
+      },
+      {
+        "name": "iwl5150-firmware",
+        "epoch": 0,
+        "version": "8.24.2.2",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl5150-firmware-8.24.2.2-79.el7.noarch.rpm",
+        "checksum": "sha256:66149f8d65c73e297a392cf33a8c40e570ae8b16667c29d7ce967adade27eb7a"
+      },
+      {
+        "name": "iwl6000-firmware",
+        "epoch": 0,
+        "version": "9.221.4.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000-firmware-9.221.4.1-79.el7.noarch.rpm",
+        "checksum": "sha256:a37d2eeb9810427888dfe2eea1712441e0bb91e74f93d2166a8978a29f82ca98"
+      },
+      {
+        "name": "iwl6000g2a-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2a-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:d866a841fa8afa3b5f4210f172d4eb78aafaa13b0de26ccbea708779fb746b14"
+      },
+      {
+        "name": "iwl6000g2b-firmware",
+        "epoch": 0,
+        "version": "18.168.6.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6000g2b-firmware-18.168.6.1-79.el7.noarch.rpm",
+        "checksum": "sha256:a3dc70cc6472c7eb9d1216acc144a6dceb48bdb69955f01b8585cd80ffdd538a"
+      },
+      {
+        "name": "iwl6050-firmware",
+        "epoch": 0,
+        "version": "41.28.5.1",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl6050-firmware-41.28.5.1-79.el7.noarch.rpm",
+        "checksum": "sha256:0b4110cf94f7f793dbabb7a1a616087455ab316ec74ad5204abb0fd2f211ee58"
+      },
+      {
+        "name": "iwl7260-firmware",
+        "epoch": 0,
+        "version": "25.30.13.0",
+        "release": "79.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iwl7260-firmware-25.30.13.0-79.el7.noarch.rpm",
+        "checksum": "sha256:33fba59c069f63b29ac955363d97683c582178f5e314d594c452b8a630a59170"
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/jansson-2.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:58ce6f65f4b61dfcb190deac65fca0cc210abfdae65b54a88ee5f61c61e3e47e"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.15",
+        "release": "51.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm",
+        "checksum": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "458",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm",
+        "checksum": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.109",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm",
+        "checksum": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdaemon",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdaemon-0.14-7.el7.x86_64.rpm",
+        "checksum": "sha256:827757b21e2a88b67e7991f003dd30afd778ee94d966d1d91619b05ba4f801fe"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libdrm",
+        "epoch": 0,
+        "version": "2.4.97",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdrm-2.4.97-2.el7.x86_64.rpm",
+        "checksum": "sha256:bb7b02048bc98c2f62e62ce67f36eb54cfcbf53f763ea0cd557053d20b2a2682"
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "12.20121213cvs.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm",
+        "checksum": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.9",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm",
+        "checksum": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libgudev1",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libndp-1.2-9.el7.x86_64.rpm",
+        "checksum": "sha256:7567202eb027a1efb739092a6204307d735db326cf92a2c979201e36d841a284"
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm",
+        "checksum": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+      },
+      {
+        "name": "libnl",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.2.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-3.2.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:2e56f3449308538a955393ca85e4908d9022885fa34894cb365669b9d38de282"
+      },
+      {
+        "name": "libnl3-cli",
+        "epoch": 0,
+        "version": "3.2.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl3-cli-3.2.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:535aec9847767995152b43de3f8323e53c7c36decf894ca6e426742fb1507322"
+      },
+      {
+        "name": "libpciaccess",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpciaccess-0.14-1.el7.x86_64.rpm",
+        "checksum": "sha256:aeb22ef9ac260054a3641602a021740b6d0985cbddc60bc00ce2b3279017ca1c"
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm",
+        "checksum": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:da67098eeba3936506e2fcd15e5332d4afffe37e31b97f9170bea8ce9ceafd76"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm",
+        "checksum": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libteam",
+        "epoch": 0,
+        "version": "1.29",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libteam-1.29-3.el7.x86_64.rpm",
+        "checksum": "sha256:93503e6622050a007698e4649903b26f7c76b207461c5e97c9215437a33b031f"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libxml2-python",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+      },
+      {
+        "name": "libxslt",
+        "epoch": 0,
+        "version": "1.1.28",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm",
+        "checksum": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200421",
+        "release": "79.git78c0348.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm",
+        "checksum": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.8.6",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm",
+        "checksum": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.18",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+      },
+      {
+        "name": "lsscsi",
+        "epoch": 0,
+        "version": "0.27",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lsscsi-0.27-6.el7.x86_64.rpm",
+        "checksum": "sha256:ea6c84fe12b97fb5511ffee78b31a8ffb0444fd41da21932503568df14a95e98"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.06",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm",
+        "checksum": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+      },
+      {
+        "name": "m2crypto",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+      },
+      {
+        "name": "mariadb-libs",
+        "epoch": 1,
+        "version": "5.5.68",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mariadb-libs-5.5.68-1.el7.x86_64.rpm",
+        "checksum": "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644"
+      },
+      {
+        "name": "microcode_ctl",
+        "epoch": 2,
+        "version": "2.1",
+        "release": "73.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm",
+        "checksum": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+      },
+      {
+        "name": "mozjs17",
+        "epoch": 0,
+        "version": "17.0.0",
+        "release": "20.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm",
+        "checksum": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+      },
+      {
+        "name": "newt-python",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm",
+        "checksum": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.79",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm",
+        "checksum": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:4dc9a401c2514336e46adc87f5d05244ca743eb08bf6bcab1443a9eba6b81970"
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-core-libs-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:77a55f2182769815d41519b53ca15b54aa09cbe48249cd91487a091e81fdd7c2"
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.8.9",
+        "release": "0.34.20140113.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/plymouth-scripts-0.8.9-0.34.20140113.el7.x86_64.rpm",
+        "checksum": "sha256:19f7ca6bf9d8e762c376d0d8b52e2982e900a3d3e5fe7d3f095d1b27f4ab95aa"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.112",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm",
+        "checksum": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "postfix",
+        "epoch": 2,
+        "version": "2.10.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/postfix-2.10.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "pth",
+        "epoch": 0,
+        "version": "2.0.7",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm",
+        "checksum": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+      },
+      {
+        "name": "pyOpenSSL",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+      },
+      {
+        "name": "pygobject2",
+        "epoch": 0,
+        "version": "2.28.6",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm",
+        "checksum": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+      },
+      {
+        "name": "pygpgme",
+        "epoch": 0,
+        "version": "0.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+      },
+      {
+        "name": "pyliblzma",
+        "epoch": 0,
+        "version": "0.5.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-configobj",
+        "epoch": 0,
+        "version": "4.7.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm",
+        "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+      },
+      {
+        "name": "python-decorator",
+        "epoch": 0,
+        "version": "3.4.0",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm",
+        "checksum": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+      },
+      {
+        "name": "python-dmidecode",
+        "epoch": 0,
+        "version": "3.12.2",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm",
+        "checksum": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+      },
+      {
+        "name": "python-ethtool",
+        "epoch": 0,
+        "version": "0.8",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm",
+        "checksum": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+      },
+      {
+        "name": "python-firewall",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+      },
+      {
+        "name": "python-gobject-base",
+        "epoch": 0,
+        "version": "3.22.0",
+        "release": "1.el7_4.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm",
+        "checksum": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+      },
+      {
+        "name": "python-gudev",
+        "epoch": 0,
+        "version": "147.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+      },
+      {
+        "name": "python-hwdata",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm",
+        "checksum": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+      },
+      {
+        "name": "python-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm",
+        "checksum": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+      },
+      {
+        "name": "python-inotify",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm",
+        "checksum": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+      },
+      {
+        "name": "python-ipaddr",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm",
+        "checksum": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python-linux-procfs",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm",
+        "checksum": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+      },
+      {
+        "name": "python-lxml",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+      },
+      {
+        "name": "python-magic",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm",
+        "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+      },
+      {
+        "name": "python-perf",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+      },
+      {
+        "name": "python-pycurl",
+        "epoch": 0,
+        "version": "7.19.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+      },
+      {
+        "name": "python-pyudev",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm",
+        "checksum": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+      },
+      {
+        "name": "python-schedutils",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
+        "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-slip",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+      },
+      {
+        "name": "python-slip-dbus",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+      },
+      {
+        "name": "python-syspurpose",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+      },
+      {
+        "name": "python-urlgrabber",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm",
+        "checksum": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+      },
+      {
+        "name": "pyxattr",
+        "epoch": 0,
+        "version": "0.5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-logos",
+        "epoch": 0,
+        "version": "70.7.0",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-logos-70.7.0-1.el7.noarch.rpm",
+        "checksum": "sha256:2293799f84ccf36c681066a3aa0f7fe713b913e589c105713ecbb98e86966cc7"
+      },
+      {
+        "name": "redhat-release-eula",
+        "epoch": 0,
+        "version": "7.8",
+        "release": "0.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm",
+        "checksum": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "redhat-support-lib-python",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm",
+        "checksum": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+      },
+      {
+        "name": "redhat-support-tool",
+        "epoch": 0,
+        "version": "0.12.2",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm",
+        "checksum": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+      },
+      {
+        "name": "rhn-check",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+      },
+      {
+        "name": "rhn-client-tools",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+      },
+      {
+        "name": "rhn-setup",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+      },
+      {
+        "name": "rhnlib",
+        "epoch": 0,
+        "version": "2.5.65",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm",
+        "checksum": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+      },
+      {
+        "name": "rhnsd",
+        "epoch": 0,
+        "version": "5.0.13",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm",
+        "checksum": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm",
+        "checksum": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.24.0",
+        "release": "55.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm",
+        "checksum": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.2.4",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm",
+        "checksum": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "subscription-manager",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+      },
+      {
+        "name": "subscription-manager-rhsm",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+      },
+      {
+        "name": "subscription-manager-rhsm-certificates",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.23",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm",
+        "checksum": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "systemd-sysv",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+      },
+      {
+        "name": "sysvinit-tools",
+        "epoch": 0,
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm",
+        "checksum": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tcp_wrappers-libs",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+      },
+      {
+        "name": "teamd",
+        "epoch": 0,
+        "version": "1.29",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/teamd-1.29-3.el7.x86_64.rpm",
+        "checksum": "sha256:5487de1bac24442383d789e48ba61456ec1b28095b481ca87a2bd5a2a67b6c43"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm",
+        "checksum": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "usermode",
+        "epoch": 0,
+        "version": "1.111",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm",
+        "checksum": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm",
+        "checksum": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "wpa_supplicant",
+        "epoch": 1,
+        "version": "2.6",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/wpa_supplicant-2.6-12.el7.x86_64.rpm",
+        "checksum": "sha256:a61dcf3c31bc66497c86d007870305008e2ab6d11fc6a570af179afa19bfcbc2"
+      },
+      {
+        "name": "xdg-utils",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "0.17.20120809git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm",
+        "checksum": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "3.4.3",
+        "release": "168.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm",
+        "checksum": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+      },
+      {
+        "name": "yum-metadata-parser",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm",
+        "checksum": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+      },
+      {
+        "name": "yum-rhn-plugin",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm",
+        "checksum": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+      },
+      {
+        "name": "python2-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "1.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
+        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+      },
+      {
+        "name": "python2-setuptools",
+        "epoch": 0,
+        "version": "38.4.0",
+        "release": "3.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
+        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+      }
+    ],
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "boost-iostreams",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-iostreams-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:85fa0e5f90907e690d09657d67d2b018572bf1431797d0d95a51fcea49700647"
+      },
+      {
+        "name": "boost-random",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-random-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:90f6ea8bfec82a4f399cd2fbcc874253ee640771fe731b2190f813cb04014d91"
+      },
+      {
+        "name": "boost-system",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-system-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:d170c9cedf284d8936229e9b87a375419020b3b12879281e90d2cd9c50b8b848"
+      },
+      {
+        "name": "boost-thread",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/boost-thread-1.53.0-28.el7.x86_64.rpm",
+        "checksum": "sha256:af6727ccc4ede2692144409c642558a1db430c2282759d1b2a5c778827fa79b6"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:bc12d9d6875e2120680179861221139e3a34833a918300a1def89ff75c18e4a5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-event-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ab40914102cb36464420c18710524a41f32df9e7762ead4879de09986c3f85ad"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-persistent-data-0.8.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:178e4b4ccf193c065e54056bb1c6b997ae9bdd7a72415e92006146f7614a6a81"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "3.0.20",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dosfstools-3.0.20-10.el7.x86_64.rpm",
+        "checksum": "sha256:dcb6f790fb97f15bd012fb20c1e5dde94921a5404299f9d45f49ee9d05d502e8"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "0.8.10",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdisk-0.8.10-3.el7.x86_64.rpm",
+        "checksum": "sha256:c15705c3d68255baec8f68db1dabd64ad12a06bcc174e6588537a607c3f06c31"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "glusterfs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:c76f4b6ccd8f923c4959000f066edab9252405d1f2380d1da1d689d3d0a9063e"
+      },
+      {
+        "name": "glusterfs-api",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-api-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:a861a4df04827e0d2df97e1f45712f5b731534e3936b7922df918b01f963fe85"
+      },
+      {
+        "name": "glusterfs-client-xlators",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-client-xlators-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:54f222ba630c2ed15edd46f76229066c522cb6128020aaf651e44e5250663380"
+      },
+      {
+        "name": "glusterfs-libs",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glusterfs-libs-6.0-37.el7.x86_64.rpm",
+        "checksum": "sha256:fbbb3464002daf3d2a6ff8f94e456f2e9bb9cc78e4ea4b98be30f2d9261f3fc7"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gperftools-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gperftools-libs-2.6.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:267734897a4458d183f8fc74ea6db8f82143767371e752d896d189bd5b3c5b1a"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.109",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libaio-0.3.109-13.el7.x86_64.rpm",
+        "checksum": "sha256:bff924265c10c3e75cd5fadaf2e23910829a6e9f5482d4e43fb7c15e41eb48a0"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libiscsi",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libiscsi-1.9.0-7.el7.x86_64.rpm",
+        "checksum": "sha256:37a3ad5de5d13ad8cc8ef339d0c6194cfe3620f4655d27bf6727271031b67d52"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "librados2",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librados2-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:b8ddcbd481989d2b3e4b83b8f04167bdf0bc1f13bbe53d93a489d2a494845e9a"
+      },
+      {
+        "name": "librbd1",
+        "epoch": 1,
+        "version": "10.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/librbd1-10.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:91732d0ef6389f668ee93b1c853877632405915f21eb16a61ab8b9183975539e"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:8eab91b478d945b5992f5676754d1ca0f124bcee584de99e74bef3ed62a4a859"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 7,
+        "version": "2.02.187",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lvm2-libs-2.02.187-6.el7.x86_64.rpm",
+        "checksum": "sha256:1a9ca0f47677eab3e6ce4e98823cc29d2968d058b365d8c65f724f2c067ed14d"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e134d9993e8338376b8515ba0981ce4beaff8361f4a0bac18afe3c4f5c08f07"
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.6.8",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-libs-3.6.8-17.el7.x86_64.rpm",
+        "checksum": "sha256:3b14d5ccb94a8081659a520f0c3cf93c4b67b4b5e48c40ab2fcbad768ad62a52"
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "9.0.3",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-pip-9.0.3-8.el7.noarch.rpm",
+        "checksum": "sha256:51329fbaa60c04578e6c294a085e21c7113e8c47784220640bec5de833c47337"
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "39.2.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python3-setuptools-39.2.0-10.el7.noarch.rpm",
+        "checksum": "sha256:c3c3aa618f901b7335c4285dc04cf3cc6c5d1881f12bff2717a04f09af4289c2"
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 10,
+        "version": "1.5.3",
+        "release": "175.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qemu-img-1.5.3-175.el7.x86_64.rpm",
+        "checksum": "sha256:b9e899bfe34657aad5cef0545c738fcbcb984bc17aa56a8ee973f814dfc34405"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python3-PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/python3-PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:7afc73e6beb4fbb8a7202348667fef0470d2be106d759cf47f58f8e7973db602"
+      },
+      {
+        "name": "python3-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "31.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-iniparse/0.4/31.el7eng/noarch/python3-iniparse-0.4-31.el7eng.noarch.rpm",
+        "checksum": "sha256:4dc62c6a37d1014f3461a8f0dcaf139e900291441ef87623243722294ecb7364"
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python3-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3c8ca24634f598594d207d126a43d0890f3c92b3510116f2e28757856b00f3fc"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      }
+    ],
+    "packages": [
+      {
+        "name": "NetworkManager-config-server",
+        "epoch": 1,
+        "version": "1.18.8",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/NetworkManager-config-server-1.18.8-1.el7.noarch.rpm",
+        "checksum": "sha256:9ae89ba6e5533df2ee1af8cab3ed8fd6be99a432eff3519783095a37cd710a66"
+      },
+      {
+        "name": "Red_Hat_Enterprise_Linux-Release_Notes-7-en-US",
+        "epoch": 0,
+        "version": "7",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/Red_Hat_Enterprise_Linux-Release_Notes-7-en-US-7-2.el7.noarch.rpm",
+        "checksum": "sha256:3b7e15c04916e85c82a35b0c30f3134692d032f3c5184f9bd558b87ee742117c"
+      },
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/acl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:1370de73e8c66a91af841521ca143c72a704df1c54ee9b452b2354a54de7b9b4"
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:70afac8a0b797e1c8983fa18a831c519a9d1c668381f35d669c81ecb99cba358"
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:2f8d6d29f7f4b3e655bf00ffb0cb4be1ca46c042977e60dbc435ef999f76d323"
+      },
+      {
+        "name": "audit-libs-python",
+        "epoch": 0,
+        "version": "2.8.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/audit-libs-python-2.8.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:92e46e5f689ce45170b61d3db1285649601bc5a02e1ee9dd7c17e54cbd04d079"
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "10.0",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/basesystem-10.0-7.el7.noarch.rpm",
+        "checksum": "sha256:133df1ee1de627d3e07fcf15fe903696f94b051cf28dc0090178f5d1ec956057"
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "4.2.46",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bash-4.2.46-34.el7.x86_64.rpm",
+        "checksum": "sha256:164930af843a056c1ad18627fc4364d1f931d79145060aa47165d4e1edc6f2a4"
+      },
+      {
+        "name": "bc",
+        "epoch": 0,
+        "version": "1.06.95",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bc-1.06.95-13.el7.x86_64.rpm",
+        "checksum": "sha256:78f77d63649812e9bcc0cd27f303692e7414a13326265e10d1bbaab6036d3fec"
+      },
+      {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.4",
+        "release": "26.P2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bind-export-libs-9.11.4-26.P2.el7.x86_64.rpm",
+        "checksum": "sha256:28229a7723ccb13eeb47fa50325fbb1b2eed94a4def1f43ec878271eff2d956b"
+      },
+      {
+        "name": "binutils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "44.base.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/binutils-2.27-44.base.el7.x86_64.rpm",
+        "checksum": "sha256:09823f3edb9eb138b587366dcc29b54445bafeb5221664e4119254bd0cd0440a"
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "4.9.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/btrfs-progs-4.9.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:a6b159e029615e6b2ab7bb402ba762610a743b72ef8a1b161bd3dc03d16a3afe"
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/bzip2-libs-1.0.6-13.el7.x86_64.rpm",
+        "checksum": "sha256:7df3437c7bea53f7ed6db4f27165e8bcd88d33cc7bc965f49e80b2e4fb6f78c9"
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2020.2.41",
+        "release": "70.0.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ca-certificates-2020.2.41-70.0.el7_8.noarch.rpm",
+        "checksum": "sha256:4d4a191087d74621903e3d7a00297da398737c7b66735ef24d45facad0a7dd11"
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/checkpolicy-2.5-8.el7.x86_64.rpm",
+        "checksum": "sha256:12e460041a97232f4243675a9918763377a92cc56923023f610d5ea1848e431b"
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.7.6",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/chkconfig-1.7.6-1.el7.x86_64.rpm",
+        "checksum": "sha256:8517730ba35d7d4f47df5adc20d9c317ce16055da214576b60ceed86dcaadedc"
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "19.4",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-init-19.4-7.el7.x86_64.rpm",
+        "checksum": "sha256:413c3662c4532237979c888707d2acce4289fd4990fd3ea73d5d40fb6ebfd52b"
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.29",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cloud-utils-growpart-0.29-5.el7.noarch.rpm",
+        "checksum": "sha256:41365738eddbefb6b9aac6710780ad62b4ccfe00751e7ae4c7a66b990f5703cc"
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.22",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/coreutils-8.22-24.el7.x86_64.rpm",
+        "checksum": "sha256:d273b6dc11f28ced6db4c6545e245b1824deedddf3e386c935d8fb9f61836872"
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.11",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cpio-2.11-28.el7.x86_64.rpm",
+        "checksum": "sha256:ee9f7e005742702d8e10aa62f1c11683bde53e26adc170d038a7a2014119b72b"
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:57e86792013b2c3506383659876605cc016d3a6795487ae1c22eb8fb319a3527"
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.0",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cracklib-dicts-2.9.0-11.el7.x86_64.rpm",
+        "checksum": "sha256:0e480a04ed607a99b85041a20b14314f1a681bc95a518d34543dd10531bbbe72"
+      },
+      {
+        "name": "cronie",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:b4397a45fa289e5b53f09e4e12bdd1518f5e9b497b2cdbe49936aa43e51ad44f"
+      },
+      {
+        "name": "cronie-anacron",
+        "epoch": 0,
+        "version": "1.4.11",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cronie-anacron-1.4.11-23.el7.x86_64.rpm",
+        "checksum": "sha256:2e3bb02e9028cfcae4f9945fccb663ed54ffd3b26e77bceabb2328ba3b433ae6"
+      },
+      {
+        "name": "crontabs",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "6.20121102git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/crontabs-1.11-6.20121102git.el7.noarch.rpm",
+        "checksum": "sha256:f84e2988e167610c0a5807d8cfecb6f82490fe04558b066ffc90b5bfbeb9ffb1"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.0.3",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cryptsetup-libs-2.0.3-6.el7.x86_64.rpm",
+        "checksum": "sha256:57738063a487cfdc9da6f50c9ff467ef6b24c244f666ddca76d84df11206b6f3"
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/curl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:d71df169d5e155914ece85b1b4506c61238812a2ad331371e07950c09575093e"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.26",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/cyrus-sasl-lib-2.1.26-23.el7.x86_64.rpm",
+        "checksum": "sha256:52c58f3b6eeb69a9b77dda87eadb64b0c5f872c83bcb83fdca7a0e36f1d5d2db"
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:261ddb84d4530e0ed4a0f66b18622629091f674f69133909638aaa68eebd3c49"
+      },
+      {
+        "name": "dbus-glib",
+        "epoch": 0,
+        "version": "0.100",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-glib-0.100-7.el7.x86_64.rpm",
+        "checksum": "sha256:d9ebda818f23effdb4c90750b2d1e98248f6fe0203bbc09488f6deb867e06ec1"
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.10.24",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-libs-1.10.24-15.el7.x86_64.rpm",
+        "checksum": "sha256:ebf07223ff459f5441bec4857363ff4c623e34d333d9fd26eb794aa23db37da6"
+      },
+      {
+        "name": "dbus-python",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dbus-python-1.1.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:8bdcfd34fd406f1a12d984c02586630a55e8c036d72ab0728c855174870b7fc0"
+      },
+      {
+        "name": "desktop-file-utils",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/desktop-file-utils-0.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:6d001476ce893301e5a770f0f461161249099427ff8ea151fa9e64039d6b2189"
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:f5edbf09fbd69fd4985682a6bb2fdb8732d11c90f6f75977e77c225f846f6bc5"
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 7,
+        "version": "1.02.170",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/device-mapper-libs-1.02.170-6.el7.x86_64.rpm",
+        "checksum": "sha256:ceda9d24ef213658d34af8c53f891be32959398f7aa85b9bd4557a9ae9f797b9"
+      },
+      {
+        "name": "dhclient",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhclient-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:17b7d2ff8162ea7b9b3745b442ba71942be4e3d43b341a34d24be26fcd2be8bb"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-common-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:24d22c16e42254ecf34eab993177a614bb3cf4ee86529c5f9267db53b53f4aa8"
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.2.5",
+        "release": "82.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dhcp-libs-4.2.5-82.el7.x86_64.rpm",
+        "checksum": "sha256:2fcf0cdbc2af078e48997356493e01094d5464be9bf6b93b9fada75b83a18130"
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/diffutils-3.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:644bb4bb0d549837d1a5f9d65e02835290b538f123605070cbf93291b11d2812"
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dmidecode-3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:dde04dcb5cd8be2e931c4abd93b72efb024f540a9f21e939ddea6af0da4d0b47"
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:23e53944df86ed0b04fd39c8b0dd754e251c68179e44e2aa91b9e440b168df89"
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-config-generic-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:83417516af90dbff01c37715535ecbf349cdb6cf2a39a7addd1544c8fb939803"
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "033",
+        "release": "572.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/dracut-network-033-572.el7.x86_64.rpm",
+        "checksum": "sha256:b59aabfdc08262004e58dfd948e8232ed9368a0412d66bbeecea7b5b8aef3c40"
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:d3a3a4872f45d3a37871fb374a1a0bb4b8c83190ac1711d13b74c363b50aabdf"
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/e2fsprogs-libs-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:740a1af1718166f8145bcbd75a12684abdb2351674c99ebbc849cbc08d4b38a0"
+      },
+      {
+        "name": "ebtables",
+        "epoch": 0,
+        "version": "2.0.10",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ebtables-2.0.10-16.el7.x86_64.rpm",
+        "checksum": "sha256:094d087413bbb86acb550e417041bbbb755d8ee98d7c481f7d09ad077806ff51"
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "17",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efibootmgr-17-2.el7.x86_64.rpm",
+        "checksum": "sha256:fee9f3778bc407347c1f8d66c04e74c04af7fa702823e5049270e782dd5bfae6"
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "36",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/efivar-libs-36-12.el7.x86_64.rpm",
+        "checksum": "sha256:1d553f7f8c60e431bd5d502da615a1046ce0a89e85d46ef791ac48ba518aa16b"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-default-yama-scope-0.176-5.el7.noarch.rpm",
+        "checksum": "sha256:e8828c8e13cb65e1ee5e302411a8abd0c476517e87d102398a9b9b112d993edf"
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libelf-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:e432eb142cf558d61863f88e015fd99d222b606433f43f3850372de5188236cf"
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.176",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/elfutils-libs-0.176-5.el7.x86_64.rpm",
+        "checksum": "sha256:22bfc046fe32e83a85265743b28c774e31fbacf8cd454b34ce2ff4fdf9f26725"
+      },
+      {
+        "name": "emacs-filesystem",
+        "epoch": 1,
+        "version": "24.3",
+        "release": "23.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/emacs-filesystem-24.3-23.el7.noarch.rpm",
+        "checksum": "sha256:cd1e435a74209901055546f73ae7c192f9ed646b74ffec0f798f2fa4e7c00492"
+      },
+      {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "4.8",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ethtool-4.8-10.el7.x86_64.rpm",
+        "checksum": "sha256:7b2639a5b7d320e69d88f09428c9aa377ac091675928cfffa50710e02911aff8"
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/expat-2.1.0-12.el7.x86_64.rpm",
+        "checksum": "sha256:fb9878feb857be5b29d802cab4982689c32df47f63a9a3b7f2fc33e2886ad323"
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:a7334659feacb2b869b1b6b3b24e7c48445d65c40f5fea6568f32828478b1558"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/file-libs-5.11-37.el7.x86_64.rpm",
+        "checksum": "sha256:d62dc3d5a28dfcfc40c9f59f997656e28e00f62de319874ae28c162c4c9937da"
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/filesystem-3.2-25.el7.x86_64.rpm",
+        "checksum": "sha256:10a19a46b46f111536f4db43fe6a1adbf8f8ac24b316297b64db2aee892ae137"
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.5.11",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/findutils-4.5.11-6.el7.x86_64.rpm",
+        "checksum": "sha256:c4d66f83ac64a86c8b1d471bb85f7f3ddb126c6bd2d5f4a12c84da7c8ed178ad"
+      },
+      {
+        "name": "fipscheck",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:2a0b4b1fee52b3dc30c332a70ee8f787a03ccaa4ea59e484e47e2ef4b1365239"
+      },
+      {
+        "name": "fipscheck-lib",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/fipscheck-lib-1.4.1-6.el7.x86_64.rpm",
+        "checksum": "sha256:84f7abbf32791cfbfd6e21c2bc021f7adb76cfc1783fe22f8221c056e16ac7a5"
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:5af98557ef67c525908bb314f24d9ffe15dc9970f9e51875c10b0e68395d163c"
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/firewalld-filesystem-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:e6605139e0ad352b6a67dda76ba537e2801e09d83d1b9050c403d63a95041a6e"
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/freetype-2.8-14.el7.x86_64.rpm",
+        "checksum": "sha256:a3b5d4d9fed6506e43ac4de247a62fc13c0494ccfd618f854c99cefc1cfd8de5"
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gawk-4.0.2-4.el7_3.1.x86_64.rpm",
+        "checksum": "sha256:3db7deaf1a9a7a62ed322449230209d44167bdeb6529c8064421ab5ce26fe274"
+      },
+      {
+        "name": "gdbm",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gdbm-1.10-8.el7.x86_64.rpm",
+        "checksum": "sha256:fb080ff259faa1252f46c0f4ed4a49d086d1712333fbba0f6554759c4a976142"
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:026f8378b4bb725aafeb6bcec04883551f282bd7a561183c339eae442a374ec0"
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.19.8.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gettext-libs-0.19.8.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:43e8ee120caa4fd22b7f2b903a74d952dd9d97c9727c5310daa9381d98fa3605"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.56.1",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glib2-2.56.1-7.el7.x86_64.rpm",
+        "checksum": "sha256:3ce341bb037d0ca1189bcc51bb3f9bbb939bf47f799f1d834c1d9d907cb6f66d"
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:ec6571bb9ac645f3430a24f9826da46823761529feb7decc7a1668829987a7cd"
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.17",
+        "release": "317.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/glibc-common-2.17-317.el7.x86_64.rpm",
+        "checksum": "sha256:22afb742000128beaa4a42919531ec94eda22e8ceed7b5a5948584b90c106fc1"
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.0.0",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gmp-6.0.0-15.el7.x86_64.rpm",
+        "checksum": "sha256:ae220fa29366941ae2acab3006067bad40860a156bf67847a88935c8a354e926"
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.0.22",
+        "release": "5.el7_5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gnupg2-2.0.22-5.el7_5.x86_64.rpm",
+        "checksum": "sha256:c06f6adbbdbb714b831ed6fad4b88b9b3dcff5dfe5186c4a8d0e3c60a0f985d3"
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.56.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gobject-introspection-1.56.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:b22d91546662cebf2707f052f1ec8353980dd80ccdb66dca29e75ff3c63c9aac"
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gpgme-1.3.2-5.el7.x86_64.rpm",
+        "checksum": "sha256:91a28fec5e3d54e1fd375399be811bbdf692625befb8d95ef053bf31a511a826"
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grep-2.20-3.el7.x86_64.rpm",
+        "checksum": "sha256:005f4e86184775de9904a454e0cd70b524952810e5d9916e4721f089986d5cc8"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.2",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/groff-base-1.22.2-8.el7.x86_64.rpm",
+        "checksum": "sha256:e0e5409f044c98cab1ffce5cf8915a8eee43a37f723c59760469d306c7ae1cfe"
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-common-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:c6a71fa1259ede0363f12b1b538d4347c9db27882428156edad729a53f9c0182"
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-efi-x64-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:13ff673ebb8d412ac1895551acf29032e6f9f20dc8156fedec6bd38b6043d7b5"
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:31e2202826e0b5ad7b600253bdf630892608db600de9f6031ed725e76d03aa33"
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-pc-modules-2.02-0.87.el7.noarch.rpm",
+        "checksum": "sha256:6b96a6e983dc2679db4bfb278796e1e9c23779b87030ec06c752155d3847db1e"
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:f0ade86c1633a7faba1c09807e2d92ec6734c653ab7317e63a2af01b0bce3e44"
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-extra-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c377af1500caf60e32a7123975f38ed795acd0bc3db760029fd8cb8ee8c566e"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.02",
+        "release": "0.87.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grub2-tools-minimal-2.02-0.87.el7.x86_64.rpm",
+        "checksum": "sha256:1c351bfcc354aa61764725882cfe6ff36da092e7f10c70d3830bd596206af461"
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.28",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/grubby-8.28-26.el7.x86_64.rpm",
+        "checksum": "sha256:6ee12aa6e7b041aad0ac3d968b1ab18dacded8a489ad27b653242929af978e12"
+      },
+      {
+        "name": "gssproxy",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "29.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gssproxy-0.7.0-29.el7.x86_64.rpm",
+        "checksum": "sha256:92c0ed0230680e16bd5a6b4763cf3d6ae6069070fb2a18d690aa8ffe4f731904"
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/gzip-1.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:de398e6ad81cd87675053549c777bab89cd38729f1803087850a6b2afce213b7"
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hostname-3.13-3.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:df090ffbfb86d2d5bc3ed70e61876e8ba1ebc4d273773c657a16f514b1d83b66"
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.252",
+        "release": "9.7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/hwdata-0.252-9.7.el7.x86_64.rpm",
+        "checksum": "sha256:259dccd3801c5f2b41438236eca586f8caaf0ae9e9789acd61b2affee56e924d"
+      },
+      {
+        "name": "info",
+        "epoch": 0,
+        "version": "5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/info-5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:6f3de3629f79a6728b6fe9e9c5840170a7d4436d1a1150e4e2b39a2a9f923a64"
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "9.49.53",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/initscripts-9.49.53-1.el7.x86_64.rpm",
+        "checksum": "sha256:74f3d93caa5b80e431181ee02b0727db0240b35032b5cbadec3d3b01551f7c21"
+      },
+      {
+        "name": "insights-client",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/insights-client-3.0.13-1.el7.noarch.rpm",
+        "checksum": "sha256:0d2a47225e982af09c27b97e8ce24dce5cd3e45b3ce2550e47982ef94d19eb7d"
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "4.11.0",
+        "release": "30.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iproute-4.11.0-30.el7.x86_64.rpm",
+        "checksum": "sha256:a9a0f1078682a2e7b85967c4402672648e05802d2eccdae48dab33b47521adbc"
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:7af4e177936381d8a3d26db6dc66d8be32f80b4eefe4f0a2f43e4b938c148ac0"
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.1",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ipset-libs-7.1-1.el7.x86_64.rpm",
+        "checksum": "sha256:0bb2ac8f0d7a970cd1c318d9b810ba9c0f9540bd0d62d391ec47b5da9415fd2d"
+      },
+      {
+        "name": "iptables",
+        "epoch": 0,
+        "version": "1.4.21",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iptables-1.4.21-35.el7.x86_64.rpm",
+        "checksum": "sha256:ee91f2840155b3fbafe9059d4e3465ed12bee73cac15667f2dee4c5f9a52cf87"
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20160308",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/iputils-20160308-10.el7.x86_64.rpm",
+        "checksum": "sha256:92f5006e55ebf5dc518ad9e7498506063f0b6c889a925565117aa3fb550cd89c"
+      },
+      {
+        "name": "irqbalance",
+        "epoch": 3,
+        "version": "1.0.7",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/irqbalance-1.0.7-12.el7.x86_64.rpm",
+        "checksum": "sha256:c829e5532ab00017d914bff2ecf419ac68d57689bfb8662741bc9dde1dae8cef"
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.11",
+        "release": "4.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/json-c-0.11-4.el7_0.x86_64.rpm",
+        "checksum": "sha256:12d0d9348fb55a9e518a45b63db83b95b1e6c9d54551aa0ec288199f03cce5cd"
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-1.15.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:a82e52394f7d644bf930dae1994b190a219d0d8b39fd01b839d45384221bebf9"
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-legacy-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:428980a728da6f965068bbee26e6b688ca03d1b88deb6a24e88e033a220fd79a"
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "1.15.5",
+        "release": "15.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kbd-misc-1.15.5-15.el7.noarch.rpm",
+        "checksum": "sha256:7874e2d46c36407202a69e6fe8a9cdeb6629c92675d420aa1bf865346d638d1f"
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:ca7bbd8e05c26a6152e8da8b176b92ea63fd1410967ea4643e4e271c084e1324"
+      },
+      {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:c264f613eba75609c960c72ddaf52664c6b70fea1c5c7e87671d68d3bcf5fed6"
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kernel-tools-libs-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:6d3236f8d4a36f1f96412831705b0ecb78dc4a7b3f80bb97a0e7a1a815734ba9"
+      },
+      {
+        "name": "kexec-tools",
+        "epoch": 0,
+        "version": "2.0.15",
+        "release": "51.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kexec-tools-2.0.15-51.el7.x86_64.rpm",
+        "checksum": "sha256:5fe34f0b30d8ce28e407542bfc05c02837cf6ed7806475ce0d0298b26a5bb9fb"
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:595294bf52080fc92f19f49c757182851f7794c122c5a36425e79d4abb0df960"
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.5.8",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/keyutils-libs-1.5.8-3.el7.x86_64.rpm",
+        "checksum": "sha256:68d0b20162b3e1e250d83e3d7a147ee6ad5c1ae282cce15421e734b5abd41add"
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:c86cc42ecd0a14b233fe81252c0c8abcba2b67e981a36179a711c9bb241479e4"
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "20",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kmod-libs-20-28.el7.x86_64.rpm",
+        "checksum": "sha256:5016360d55f12a5548c1b504d8fdee0efb35eaf2b0815a3dc62afbba044cabc0"
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.4.9",
+        "release": "133.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/kpartx-0.4.9-133.el7.x86_64.rpm",
+        "checksum": "sha256:233f1262f771eac659f5e76524a701ff8993e738c462dd823f984d2b703ddfcb"
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "50.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/krb5-libs-1.15.1-50.el7.x86_64.rpm",
+        "checksum": "sha256:0c75f4193a32541ca250fc4dc41754350bbea7ac64e3cb50bfde9aa2bc0d9473"
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "458",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/less-458-9.el7.x86_64.rpm",
+        "checksum": "sha256:d8c446ed36175a359ddc118ce65325253a5196772dd0a9f791fb8786c6423a2f"
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.2.51",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libacl-2.2.51-15.el7.x86_64.rpm",
+        "checksum": "sha256:2a9bc37a1274ef0fd28a594bc83334b868bee0c87f19f5b413c8c81e2a43dddd"
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libassuan-2.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:0849869ef8adc05c8b90b93e3aaf1bac5afc4a1b1cc3efc594dceff96a123cf7"
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.4.46",
+        "release": "13.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libattr-2.4.46-13.el7.x86_64.rpm",
+        "checksum": "sha256:17a04e5cd7d2514904b203126a4273d63fe87a2871efa75ace5be72b992bd1e8"
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libbasicobjects-0.1.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:732503bcffcd921ba9b084090852726b5d443c82a2fc3bbe4a7928eb743c8061"
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libblkid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:54d8d52e4ec61256417b3dd708ff88dea8c2c43db0dc588528e2f78ba55ca043"
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.22",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-2.22-11.el7.x86_64.rpm",
+        "checksum": "sha256:899714773ed68807327e4f73f5d8ee6088b5e1f35f5fb2cea737e54b90c2a461"
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.7.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcap-ng-0.7.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:37f2b2b3ed3c45ac0caa7c5410a357dbcaef6bdb671cb511a15c9c46523e82f1"
+      },
+      {
+        "name": "libcgroup",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcgroup-0.41-21.el7.x86_64.rpm",
+        "checksum": "sha256:954f3481c97618e3ec90fab9e83da7a96cf94e1319f1594fe1d5029474272cd5"
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcollection-0.7.0-32.el7.x86_64.rpm",
+        "checksum": "sha256:09a9771e5577324f8ce9fb35c4d2def6bec5acbca1ad4c8db4972acffd496cf4"
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcom_err-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:2e89845aa49ddf70e2cec55f857bb9229164a7a17fc83343f6a9786e4e037477"
+      },
+      {
+        "name": "libcroco",
+        "epoch": 0,
+        "version": "0.6.12",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcroco-0.6.12-4.el7.x86_64.rpm",
+        "checksum": "sha256:9591b9b0de98a0944ddaafda812696c4bc8fda896b2be54dc03d949014df76ee"
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.29.0",
+        "release": "59.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libcurl-7.29.0-59.el7.x86_64.rpm",
+        "checksum": "sha256:a5ca0ac5ee32aa9c2ba4a02e37fb6cdb7d65df0a7df1a6b795c294b3ed6e242d"
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:6a778b6a2091b427b4196d704d00a92e47e8269d32eaa222c2c0e359e8394e8f"
+      },
+      {
+        "name": "libdb-utils",
+        "epoch": 0,
+        "version": "5.3.21",
+        "release": "25.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libdb-utils-5.3.21-25.el7.x86_64.rpm",
+        "checksum": "sha256:a6bd2f5457433ca2c45146aa547eec6642870bebb3e96ef75bed4d73fb246f32"
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "12.20121213cvs.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libedit-3.0-12.20121213cvs.el7.x86_64.rpm",
+        "checksum": "sha256:2a7721ccbaf5d43e1a813b267053fd38831f9aeb9c4eb8d8efb25c947082a1aa"
+      },
+      {
+        "name": "libestr",
+        "epoch": 0,
+        "version": "0.1.9",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libestr-0.1.9-2.el7.x86_64.rpm",
+        "checksum": "sha256:abab0980f49ec78b8a784bd20593f1d6aa6ec7f9a11575439542c47dc9524278"
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.0.21",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libevent-2.0.21-4.el7.x86_64.rpm",
+        "checksum": "sha256:dad3be774d4dce1bef8ec63cd5014dae987bd6c8cabcb340c69758d5ef16ae3e"
+      },
+      {
+        "name": "libfastjson",
+        "epoch": 0,
+        "version": "0.99.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libfastjson-0.99.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:a8b52c16775143c98927e81c56104d0ee422e05d8de72099f190f713af8ad027"
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.0.13",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libffi-3.0.13-19.el7.x86_64.rpm",
+        "checksum": "sha256:04d6ccafb0a07e09cef1312a6a892e4d3365b9a71b265f7afa5fc96303067af3"
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcc-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:23682b13bb03b7441413d2ba85bc26046fe836162049a92e6389ca57d729e020"
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgcrypt-1.5.3-14.el7.x86_64.rpm",
+        "checksum": "sha256:4905d8ba3634b4fe5ece50dfa31afb52cb1815a7ffdc4ea7d8bddfb8189aa299"
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgomp-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9090f0023a99186c0126085d8b4e6af9e600c4397f11e07b4b8a1c611fd5b1b4"
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgpg-error-1.12-3.el7.x86_64.rpm",
+        "checksum": "sha256:85b53f4c3206f7f7f171a85444c835fea90f4b09ab17734bc08bb20feac305f4"
+      },
+      {
+        "name": "libgudev1",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libgudev1-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:9bfc868c97a1998e18e7ff32657478d895e87a2d1d919ffeca60a4e9dc5cec43"
+      },
+      {
+        "name": "libidn",
+        "epoch": 0,
+        "version": "1.28",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libidn-1.28-4.el7.x86_64.rpm",
+        "checksum": "sha256:cff44fe84d096c0e6f082cb622f17149c3edde1421b32192307ef713d1f64790"
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libini_config-1.3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:ae1292f35b2b89016d0b51300b97beb59a92f48bef5d469ff5fdf2a951dae2ff"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmnl-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:28b57683dc8c1843ce1d28b92ddf3f68e997717e3184e2ae629ceb3a81acf05d"
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libmount-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:9908abc99788aa3e371c54a89d7236e9edd66ff7e8bc9b9f2cf4732ca86b4785"
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnetfilter_conntrack-1.0.6-1.el7_3.x86_64.rpm",
+        "checksum": "sha256:eb71af5a9b4665611dbd3cd17ecaa3437c2ad0961f40ff743fcf2fa7292cff05"
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfnetlink-1.0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:cfe92193511248e70f151a48715424f45dee559b3420d2930c266bd93d58fd06"
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 0,
+        "version": "0.25",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnfsidmap-0.25-19.el7.x86_64.rpm",
+        "checksum": "sha256:3fd04125208bed410e43eb49b18d09cbdaa6e6b27f86c9bfb156103ad14711a7"
+      },
+      {
+        "name": "libnl",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libnl-1.1.4-3.el7.x86_64.rpm",
+        "checksum": "sha256:d7ee2c5b5fda494b492a8c9e04b0ec06b24521d9debea706e0a3af8c716d9ea2"
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpath_utils-0.2.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:88e7108ff671d4e161a1fc1bd72c41c4cec8e80b74c5300b327183551824cc49"
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.5.3",
+        "release": "12.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpcap-1.5.3-12.el7.x86_64.rpm",
+        "checksum": "sha256:6bc289b6f664cebfb07703f279f28a2f69482c83f4b3718eb07e8028deb2a5fe"
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpipeline-1.2.3-3.el7.x86_64.rpm",
+        "checksum": "sha256:776c8e0ba56567e1fa9f9295afd305563ccc28d139ac2bfe04eb61a57a2d78a3"
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.5.13",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpng-1.5.13-8.el7.x86_64.rpm",
+        "checksum": "sha256:c02af4409de16a290cf1def06ee4759211dec264ef6b8c2c8a57dadcb7db6be1"
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libpwquality-1.2.3-5.el7.x86_64.rpm",
+        "checksum": "sha256:399631dd617fa4bc2ace90712b2e688fbbeea766286650bbbc019174c402475c"
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libref_array-0.1.5-32.el7.x86_64.rpm",
+        "checksum": "sha256:68e8132e5eda6b553ccbad7287dad2e8ab116eec95477002c84fcd9e1d7272ab"
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:207150c3207f1d5af39c66faf06b6578d80c880917525a0917111a0087fdeeee"
+      },
+      {
+        "name": "libselinux-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-python-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:60611444e46c1bf76261901a52f29dde5a4c0dc1d4b6916333b94563a074c86c"
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libselinux-utils-2.5-15.el7.x86_64.rpm",
+        "checksum": "sha256:75dba0c8b4ee186c0729b41b56679e3b60df02144a3d5a043a44133aa4d2c0f3"
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:863368533ab642f516054ac4f6a5368f8995229d1ad808478b5bf03d0c69472b"
+      },
+      {
+        "name": "libsemanage-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "14.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsemanage-python-2.5-14.el7.x86_64.rpm",
+        "checksum": "sha256:62d8fbd122be3460c0b915dca4e135bdabe7c529d4e5578856fa4c745f834dcc"
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsepol-2.5-10.el7.x86_64.rpm",
+        "checksum": "sha256:37942df220318ac6c91049adabaefe854ad9f83845907352aad7d66045f64b02"
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsmartcols-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:a0047e1ed0eb51fc41a74096559cfe67f1c01fa01cf668709ae54524db7cf414"
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.42.9",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libss-1.42.9-19.el7.x86_64.rpm",
+        "checksum": "sha256:c094fe217ef92710bea79c4060c127e585a72bbf0cfba61697cbb488adcc8a7e"
+      },
+      {
+        "name": "libssh2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libssh2-1.8.0-4.el7.x86_64.rpm",
+        "checksum": "sha256:4a9ac18573b971d88bd2acefbcc6cfad01c986d04b4b88ed705ae019b6a653a3"
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "4.8.5",
+        "release": "44.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libstdc++-4.8.5-44.el7.x86_64.rpm",
+        "checksum": "sha256:9048a971753ff997aeebc363a7d07e4c4d9dfbf32bfc7698bc9ea0aacfc7bfae"
+      },
+      {
+        "name": "libsysfs",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libsysfs-2.1.0-16.el7.x86_64.rpm",
+        "checksum": "sha256:a8e89f879bf0574031e19f285ff52c36f340b090bf3a7b4ba483dc7686795436"
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.10",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtasn1-4.10-1.el7.x86_64.rpm",
+        "checksum": "sha256:0522ab1034c4202c3ad9ff36807e55814ac366a4aac27a034b30b522cd4aeca9"
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libtirpc-0.2.4-0.16.el7.x86_64.rpm",
+        "checksum": "sha256:b2a89261d081d8740b01f9a4b8191efeaabb6391e078eb77cc52756c269f3efe"
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libunistring-0.9.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5df8bc04ab1f1abd1a7eb728f84c7f5eb661d5fe2b508fa85c016366e8c750a3"
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.60",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuser-0.60-9.el7.x86_64.rpm",
+        "checksum": "sha256:70244d0073f3e4a4fed3a0f64b1db29c3adc15e69ba953ed253e2719ffa6770d"
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.1.6",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libutempter-1.1.6-4.el7.x86_64.rpm",
+        "checksum": "sha256:921caeefffe3e048ad3adf874e60da4126487c16c1278997ffbc169c3fb47b14"
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libuuid-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:d36f82cb917ef79e1461704027a1fa97deeaf97fdeaacdb8882a1b6bebeba4fe"
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:ce2064e2a37929695ef045837bb7ea158ac6c33230874c956305d71da6ef3660"
+      },
+      {
+        "name": "libverto-libevent",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libverto-libevent-0.2.5-4.el7.x86_64.rpm",
+        "checksum": "sha256:7f24993c6ea30573c65f81132dee4de1947b24fd8c8e61abe1ce9dcf8dc03d25"
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:dac2ae10dbb0a09a7e6bd341044dfab1e63d8773c9b7582cbf2d40937180f7b0"
+      },
+      {
+        "name": "libxml2-python",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "6.el7.5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxml2-python-2.9.1-6.el7.5.x86_64.rpm",
+        "checksum": "sha256:80106cfbeb0b71d337022a01df8acc9dc4fc3205124be3db511ccf2d0b10c7c2"
+      },
+      {
+        "name": "libxslt",
+        "epoch": 0,
+        "version": "1.1.28",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libxslt-1.1.28-6.el7.x86_64.rpm",
+        "checksum": "sha256:ed3ec37460ed09d2ead9117dc16ddaa9747f2aecaedf6c5c496ea1d2fbb03cf2"
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/libyaml-0.1.4-11.el7_0.x86_64.rpm",
+        "checksum": "sha256:c46ca66c5a9b51f2e06cf301934c564c4d8e67395a379965e913ce7c95531322"
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20200421",
+        "release": "79.git78c0348.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/linux-firmware-20200421-79.git78c0348.el7.noarch.rpm",
+        "checksum": "sha256:9385bd952947ac44a78ed8652ac72eda744ff4fd16643f572deb099cba5ce91b"
+      },
+      {
+        "name": "logrotate",
+        "epoch": 0,
+        "version": "3.8.6",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/logrotate-3.8.6-19.el7.x86_64.rpm",
+        "checksum": "sha256:4607af33521aa996fac231f33a2cdd4803c57d421115ec246c61291aed84c35b"
+      },
+      {
+        "name": "lshw",
+        "epoch": 0,
+        "version": "B.02.18",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lshw-B.02.18-17.el7.x86_64.rpm",
+        "checksum": "sha256:1e34f348448890f16458dff676697b311e4bd3ff4ac463b643b32edad7106d3b"
+      },
+      {
+        "name": "lua",
+        "epoch": 0,
+        "version": "5.1.4",
+        "release": "15.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lua-5.1.4-15.el7.x86_64.rpm",
+        "checksum": "sha256:f2ee3238762ee4b1917cb7ed5d5e064dbae4d1804bdb65bd4bf6c56b785f8836"
+      },
+      {
+        "name": "lz4",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lz4-1.8.3-1.el7.x86_64.rpm",
+        "checksum": "sha256:547b7bb1b7791f9972f82f88c9931b9c754ad64a8113b733d6515b6edd1b970c"
+      },
+      {
+        "name": "lzo",
+        "epoch": 0,
+        "version": "2.06",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/lzo-2.06-8.el7.x86_64.rpm",
+        "checksum": "sha256:e867bd069a2e0d07b07593a6961cd7230817f92931219b355feff868d6a1ced0"
+      },
+      {
+        "name": "m2crypto",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/m2crypto-0.21.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:e06f9c964c16c8a1a5e556864a9d5c998369ed1b528d6331b48e517fe99c3187"
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/man-db-2.6.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:f227220f40dc32bf96941a62628fd2ad692dea3667bf28a6d6e2fed4992382b2"
+      },
+      {
+        "name": "mariadb-libs",
+        "epoch": 1,
+        "version": "5.5.68",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mariadb-libs-5.5.68-1.el7.x86_64.rpm",
+        "checksum": "sha256:33ff255b4c74d2ccb58bd1efa5f8f9928a108fefea9cc9831db764bf0aa1f644"
+      },
+      {
+        "name": "microcode_ctl",
+        "epoch": 2,
+        "version": "2.1",
+        "release": "73.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/microcode_ctl-2.1-73.el7.x86_64.rpm",
+        "checksum": "sha256:e7e5c3c4297d3002321a4bbc0e029972059a23a6835721aad84c836bb4e8dda0"
+      },
+      {
+        "name": "mokutil",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mokutil-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:fcb3438c32a13dd316dfb62880c537d2635d40a30538bc2a082b39f3fce2b2d9"
+      },
+      {
+        "name": "mozjs17",
+        "epoch": 0,
+        "version": "17.0.0",
+        "release": "20.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/mozjs17-17.0.0-20.el7.x86_64.rpm",
+        "checksum": "sha256:a2d948620a42eea5a00c2e859366b3d3a14a1577d5e598b00dfb742aa2c3ee54"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:936a7e2f7995baf47cbc485d4112e790d81e9fa28f0393551e52d12746842a31"
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-base-5.9-14.20130511.el7_4.noarch.rpm",
+        "checksum": "sha256:0e1e6a4125d13f1ddaa5a84df882c0bc4c3f5376dd854300589254c4a4e86ae1"
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ncurses-libs-5.9-14.20130511.el7_4.x86_64.rpm",
+        "checksum": "sha256:236e8b3ac8d8adfa9879c6a8dbdc161e7249dc82359ba778c9044c4d15b35d70"
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.25.20131004git.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/net-tools-2.0-0.25.20131004git.el7.x86_64.rpm",
+        "checksum": "sha256:a5b0a06d12fe198252253e582a0f2443df5e7aebc1db4134a2b3851a5556bfc8"
+      },
+      {
+        "name": "newt",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:6709447ee9542d56cfff47f3fbcd54739af451aea45beb6a0a74b6e01dcd8087"
+      },
+      {
+        "name": "newt-python",
+        "epoch": 0,
+        "version": "0.52.15",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/newt-python-0.52.15-4.el7.x86_64.rpm",
+        "checksum": "sha256:1f064dd0cd7373658b90056452124b14ae49617530319e0d8446dc8645d97efb"
+      },
+      {
+        "name": "nfs-utils",
+        "epoch": 1,
+        "version": "1.3.0",
+        "release": "0.68.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nfs-utils-1.3.0-0.68.el7.x86_64.rpm",
+        "checksum": "sha256:bd43d10fa68d2e908b7f628add47adcfc3185b1cec6785bc01301980321a053c"
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.21.0",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nspr-4.21.0-1.el7.x86_64.rpm",
+        "checksum": "sha256:d6a1658cd8506c820334d9ff9b37515153fd3f0921710c6b0ba232d994cf0928"
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:494d4861f429cb413db6fefda7ba0d86d54db5684bba34dfd0e111732ef2d6ef"
+      },
+      {
+        "name": "nss-pem",
+        "epoch": 0,
+        "version": "1.0.3",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-pem-1.0.3-7.el7.x86_64.rpm",
+        "checksum": "sha256:728834a32b4fe0645fc53f094d243d26aa98baa514fb704bda0760204779638b"
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:a4c288bf1d3475008236df696953dab9ca6bbfcebe8ff2e052024ae57fdc0096"
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-softokn-freebl-3.44.0-8.el7_7.x86_64.rpm",
+        "checksum": "sha256:4cc68a15a41483e29fbfe85829f26fedaddf9e19fe7c8673c499596f9b06103b"
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-sysinit-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:4a56cbf131d5416e594f70b158fc21540bd98e3a50b74cd714f66ab2fda85db8"
+      },
+      {
+        "name": "nss-tools",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-tools-3.44.0-7.el7_7.x86_64.rpm",
+        "checksum": "sha256:09f84377bb5398797c3b4d0a05b42aea85fa00892128e150ed54c0b2ccc3d78b"
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/nss-util-3.44.0-4.el7_7.x86_64.rpm",
+        "checksum": "sha256:596d946cd8d35332795898be6ce8b4e4b0dc2f65c151f673e1ca51b8489a7d43"
+      },
+      {
+        "name": "numactl-libs",
+        "epoch": 0,
+        "version": "2.0.12",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/numactl-libs-2.0.12-5.el7.x86_64.rpm",
+        "checksum": "sha256:bd4df28dbd6928faf3bc3bb48de9c511cf623c78d95c0af7cc4cdb5b1818ea7a"
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.44",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openldap-2.4.44-22.el7.x86_64.rpm",
+        "checksum": "sha256:1301457e09b0dbcd96d150d374829cad731faa3f9f9f6dbfa2cbff53740096a8"
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:290ccc1f3e22a77ce692e451a70d7483a358b38358f908b622e85ce93b9d12db"
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-clients-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:364fdd8fbeafbc36f07ba45d00a5f556a39f0386ee075ef00b9203dc496baf81"
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "7.4p1",
+        "release": "21.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssh-server-7.4p1-21.el7.x86_64.rpm",
+        "checksum": "sha256:d4b2de8f877b5c86b4c6751fbfba32d805bff4ecbb6183831888c833fb1af967"
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/openssl-libs-1.0.2k-19.el7.x86_64.rpm",
+        "checksum": "sha256:33b01edf15778994adee406ccb92221bb93c9076322443dde2922b758deebaac"
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.58",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/os-prober-1.58-9.el7.x86_64.rpm",
+        "checksum": "sha256:3b55059a209b0695b3c579d39be639ec413f57df2279a0b325cb2442e60d310a"
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:532c25b0c5b732c51ebf3fc0f363e9d72955a6c10b98752bbb321f914c87cb28"
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.5",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/p11-kit-trust-0.23.5-3.el7.x86_64.rpm",
+        "checksum": "sha256:26f1c092476e34c290350487f2229305a97aebdc0b096d6ca12ecae645c6416f"
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.1.8",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pam-1.1.8-23.el7.x86_64.rpm",
+        "checksum": "sha256:b0039bb73308f9af0562d7bfeb17d72d1e07a21f786eeed31e6470fb27476630"
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "32.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/parted-3.1-32.el7.x86_64.rpm",
+        "checksum": "sha256:222a97490d294758676db9ae9a0aca5684627a2750561aecf4d073f2849dd4bb"
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.79",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/passwd-0.79-6.el7.x86_64.rpm",
+        "checksum": "sha256:21224107f63cbbb08284a5d99c01f85041b455474de2a7e0475702d6dc34b1af"
+      },
+      {
+        "name": "pciutils",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:5c4a8c9993cae44b89f28e94a71d2fd1e6b7152b3e5057247713963a4e80b119"
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.5.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pciutils-libs-3.5.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:6a3c0f268e554bde444aba8f4ff5b4d09ff42f17f5f27c32843396dd9d1b1310"
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre-8.32-17.el7.x86_64.rpm",
+        "checksum": "sha256:61d51059a91e227d71ce1ed0a787797b740dbb80cc5d4aab9812cd3248178713"
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.23",
+        "release": "2.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pcre2-10.23-2.el7.x86_64.rpm",
+        "checksum": "sha256:ede1b4844bd8038e385b9fcf59e7b8ef7063a52600ab2e79cb56a1094ba4d19d"
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "0.8.1",
+        "release": "17.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pinentry-0.8.1-17.el7.x86_64.rpm",
+        "checksum": "sha256:f6b628ad8e07ea56d5dd75453611d680b959de24f3ea5552f6968d5282bce349"
+      },
+      {
+        "name": "pkgconfig",
+        "epoch": 1,
+        "version": "0.27.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pkgconfig-0.27.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b043d16e3d62f62e7589e93dfc0cebee5753d8f8ea225c0682e1fbeea5f1985a"
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:b63d899b20f7c113f17bb3815efaf12fb275b6ac6e0a73a8e11d885fd06c414e"
+      },
+      {
+        "name": "policycoreutils-python",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "34.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/policycoreutils-python-2.5-34.el7.x86_64.rpm",
+        "checksum": "sha256:8205a82a78e2c69335b4c0de5c0cf6ae401e5135b1e53044ebe5d2f51bec9af9"
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.112",
+        "release": "26.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-0.112-26.el7.x86_64.rpm",
+        "checksum": "sha256:f9850f761d7ba6d0e2b4a9b9270e17ae472a3ce05eaaa7ea09be5e8b30ffbe11"
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/polkit-pkla-compat-0.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:b7e5197b32c1d34996937e190ab08daebccf3875a8ab460c729df7165a02b6fe"
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/popt-1.13-16.el7.x86_64.rpm",
+        "checksum": "sha256:28e81ba93e4ba3f95d28850e26991200f1ec9f94e4a8a92279c885d9c1444115"
+      },
+      {
+        "name": "postfix",
+        "epoch": 2,
+        "version": "2.10.1",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/postfix-2.10.1-9.el7.x86_64.rpm",
+        "checksum": "sha256:cd3fbcae070f273060b79e5b16b831eb2342686ed56b33c62b3e65d8b8f9504d"
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.10",
+        "release": "28.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/procps-ng-3.3.10-28.el7.x86_64.rpm",
+        "checksum": "sha256:6587e5219f2ca2677e91abeceaa3e9c700b56108f395360f15ea84bffe118e4c"
+      },
+      {
+        "name": "pth",
+        "epoch": 0,
+        "version": "2.0.7",
+        "release": "23.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pth-2.0.7-23.el7.x86_64.rpm",
+        "checksum": "sha256:c7a614c7c472f428f309adc2edc0b1bf055c2d22d4d69eb63bdd9598f9fe47ae"
+      },
+      {
+        "name": "pyOpenSSL",
+        "epoch": 0,
+        "version": "0.13.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyOpenSSL-0.13.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:0e48bed2d46de70c6afcffd02cd282c20c7ced7508d0b8ec69d4c93976639ea8"
+      },
+      {
+        "name": "pygobject2",
+        "epoch": 0,
+        "version": "2.28.6",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygobject2-2.28.6-11.el7.x86_64.rpm",
+        "checksum": "sha256:b5bfd94252d1a853d2a2c55a22c30e736ea90c115b93d75cbdf855a7fdd39ea3"
+      },
+      {
+        "name": "pygpgme",
+        "epoch": 0,
+        "version": "0.3",
+        "release": "9.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pygpgme-0.3-9.el7.x86_64.rpm",
+        "checksum": "sha256:5c9922798c80f495e698799ba7f5175a8de1be142dde20a80c1098966cc6cc18"
+      },
+      {
+        "name": "pyliblzma",
+        "epoch": 0,
+        "version": "0.5.3",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyliblzma-0.5.3-11.el7.x86_64.rpm",
+        "checksum": "sha256:090919c1cadabe7b863a184c9f079e8e883f632f3c9a5a12a7e9ef6be092c492"
+      },
+      {
+        "name": "pyserial",
+        "epoch": 0,
+        "version": "2.6",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyserial-2.6-6.el7.noarch.rpm",
+        "checksum": "sha256:b4b0b298b74f2eeed034e8b671659fa2888c8e449f99c2ebe6e913fb55474845"
+      },
+      {
+        "name": "python",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:6d080d91f510a1af96e523be25a3355344721af038d95aad5d1a3cec139c951c"
+      },
+      {
+        "name": "python-IPy",
+        "epoch": 0,
+        "version": "0.75",
+        "release": "6.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-IPy-0.75-6.el7.noarch.rpm",
+        "checksum": "sha256:988502a71d620a49b989699c7c258015058866b4c29ee32a68d54bf948538211"
+      },
+      {
+        "name": "python-babel",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-babel-0.9.6-8.el7.noarch.rpm",
+        "checksum": "sha256:19129eebf5518347b0c1e7d6b67d831d03e60f11614b4800211b69e8a734b571"
+      },
+      {
+        "name": "python-backports",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-1.0-8.el7.x86_64.rpm",
+        "checksum": "sha256:34f37c79fef3d254198cbbf4b9c921c0f976e77bec9cf639ecddfed62d195d54"
+      },
+      {
+        "name": "python-backports-ssl_match_hostname",
+        "epoch": 0,
+        "version": "3.5.0.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-backports-ssl_match_hostname-3.5.0.1-1.el7.noarch.rpm",
+        "checksum": "sha256:8c391ed86df8cce373dfe235fa2836fdfcaf4b0c2a6dac792da0bece9803c983"
+      },
+      {
+        "name": "python-chardet",
+        "epoch": 0,
+        "version": "2.2.1",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-chardet-2.2.1-3.el7.noarch.rpm",
+        "checksum": "sha256:dc01e6c77ecabfe6374549f1513776ea86124ac4beb7ac89bcc01e72d748a7e8"
+      },
+      {
+        "name": "python-configobj",
+        "epoch": 0,
+        "version": "4.7.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-configobj-4.7.2-7.el7.noarch.rpm",
+        "checksum": "sha256:4e04cab11080f1ebc9b6003ed993a55dbf4db1c6dcc8dad75e3b2e124f768415"
+      },
+      {
+        "name": "python-decorator",
+        "epoch": 0,
+        "version": "3.4.0",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-decorator-3.4.0-3.el7.noarch.rpm",
+        "checksum": "sha256:047500594382798561653d0b20408180ee9de108330b00abb3812ae35d70930b"
+      },
+      {
+        "name": "python-dmidecode",
+        "epoch": 0,
+        "version": "3.12.2",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-dmidecode-3.12.2-4.el7.x86_64.rpm",
+        "checksum": "sha256:2bba49f3d27655dc966ac46c92773a61b06ba05e039c76b26622513d613acc69"
+      },
+      {
+        "name": "python-ethtool",
+        "epoch": 0,
+        "version": "0.8",
+        "release": "8.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ethtool-0.8-8.el7.x86_64.rpm",
+        "checksum": "sha256:be68fe77c5c5abbaac3734d520a5056f0752e35eb5c911cd85c34088bd99888e"
+      },
+      {
+        "name": "python-firewall",
+        "epoch": 0,
+        "version": "0.6.3",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-firewall-0.6.3-11.el7.noarch.rpm",
+        "checksum": "sha256:01bf7678344452ca4b3b0ade1854abb72ac5f64728d38f4c0107077e56d5a822"
+      },
+      {
+        "name": "python-gobject-base",
+        "epoch": 0,
+        "version": "3.22.0",
+        "release": "1.el7_4.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gobject-base-3.22.0-1.el7_4.1.x86_64.rpm",
+        "checksum": "sha256:67c1c7ddb6cd30db4a615aada6c5ffde8b633af490c2325ed74afa786116c2e2"
+      },
+      {
+        "name": "python-gudev",
+        "epoch": 0,
+        "version": "147.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-gudev-147.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:0fd5ecd7d98b8200431fbef4833c073dc69694b4d7a36ab9f71f32b70f9de487"
+      },
+      {
+        "name": "python-hwdata",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-hwdata-1.7.3-4.el7.noarch.rpm",
+        "checksum": "sha256:fe7d54ab5e4e85e10c1293081967d4400f20a93ec0c67dadd64b08790efaaed6"
+      },
+      {
+        "name": "python-iniparse",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-iniparse-0.4-9.el7.noarch.rpm",
+        "checksum": "sha256:9a65bb88497d256159ea07e4c5fe140421c4cab7a311319bd0b2df029e2a5b03"
+      },
+      {
+        "name": "python-inotify",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-inotify-0.9.4-4.el7.noarch.rpm",
+        "checksum": "sha256:f2994162ef1ef4713b9bb2e05bb208290fd88250df1f049663b1dfc24efe0eda"
+      },
+      {
+        "name": "python-ipaddr",
+        "epoch": 0,
+        "version": "2.1.11",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddr-2.1.11-2.el7.noarch.rpm",
+        "checksum": "sha256:bb750fe8ff5ce9a7a6e56c681c63f000e8d973b3ab87740eb56cde9ce0721bb8"
+      },
+      {
+        "name": "python-ipaddress",
+        "epoch": 0,
+        "version": "1.0.16",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-ipaddress-1.0.16-2.el7.noarch.rpm",
+        "checksum": "sha256:48ddf82dd8db6cca462f6c6e7a6642919743da08bbc034eca9180fcdb5bf9b68"
+      },
+      {
+        "name": "python-jsonpatch",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpatch-1.2-4.el7.noarch.rpm",
+        "checksum": "sha256:f6b19736ea764179ea7be0d949d3d54a8fc763100194b26819886503e07d8c13"
+      },
+      {
+        "name": "python-jsonpointer",
+        "epoch": 0,
+        "version": "1.9",
+        "release": "2.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-jsonpointer-1.9-2.el7.noarch.rpm",
+        "checksum": "sha256:84e938d0341e515ba742be77a43e65625622c16dffca82278072fad0d6d6a491"
+      },
+      {
+        "name": "python-kitchen",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "5.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-kitchen-1.1.1-5.el7.noarch.rpm",
+        "checksum": "sha256:adb7a6f124bdb5cb674d0bc09eecb512fb96e68f203479e891aa0ea407813f8a"
+      },
+      {
+        "name": "python-libs",
+        "epoch": 0,
+        "version": "2.7.5",
+        "release": "89.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-libs-2.7.5-89.el7.x86_64.rpm",
+        "checksum": "sha256:d57f9d7387c282c5f5dd86e4bb5c8718fa4405a3a596c63b3da1d2e8f14ef84f"
+      },
+      {
+        "name": "python-linux-procfs",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-linux-procfs-0.4.11-4.el7.noarch.rpm",
+        "checksum": "sha256:6c14c09e9a1287b07f62607f2d53259d850cd2bd6ee5f73cf2befac63fc2f6ff"
+      },
+      {
+        "name": "python-lxml",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-lxml-3.2.1-4.el7.x86_64.rpm",
+        "checksum": "sha256:571f921ab7697888c5d0ba75a5e5dde5f674d7c344b0085ab43c0ef148c5d2be"
+      },
+      {
+        "name": "python-magic",
+        "epoch": 0,
+        "version": "5.11",
+        "release": "37.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-magic-5.11-37.el7.noarch.rpm",
+        "checksum": "sha256:ee30a75a354783680bc6d46f8bdf3b2e18c7241d5af2d48abb150ca924b744bc"
+      },
+      {
+        "name": "python-perf",
+        "epoch": 0,
+        "version": "3.10.0",
+        "release": "1160.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-perf-3.10.0-1160.el7.x86_64.rpm",
+        "checksum": "sha256:8da1f1e2007d98f395befb666f18f9e26ab3009f638a566b985615b22e14fe13"
+      },
+      {
+        "name": "python-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "3.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-prettytable-0.7.2-3.el7.noarch.rpm",
+        "checksum": "sha256:786a816099b304eff8a21fc28929cf99158f37714cf5d2259b453bfa59c12535"
+      },
+      {
+        "name": "python-pycurl",
+        "epoch": 0,
+        "version": "7.19.0",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pycurl-7.19.0-19.el7.x86_64.rpm",
+        "checksum": "sha256:feff1a3d7b76871cf7dc0d8c94c8d2911a094d9d58155808da1debce19f40ee4"
+      },
+      {
+        "name": "python-pyudev",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-pyudev-0.15-9.el7.noarch.rpm",
+        "checksum": "sha256:5ef4bbfe39568843c5bd64942183d10bc11db265c4eb7a067ec8063814c5d174"
+      },
+      {
+        "name": "python-requests",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-requests-2.6.0-10.el7.noarch.rpm",
+        "checksum": "sha256:eba04f3f0730f046f0755439966a1a4dbf6101276d11b3ff0c37ec5575a47324"
+      },
+      {
+        "name": "python-schedutils",
+        "epoch": 0,
+        "version": "0.4",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-schedutils-0.4-6.el7.x86_64.rpm",
+        "checksum": "sha256:7f9376eac090765ae29166a5da1ca08c9571f492e8603cc13d2cce5786affb06"
+      },
+      {
+        "name": "python-slip",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:b449b7f89b8ffbaf72bf66e1b3c9c0e215faaacaca33b69bca5d44aeedaa6d20"
+      },
+      {
+        "name": "python-slip-dbus",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-slip-dbus-0.4.0-4.el7.noarch.rpm",
+        "checksum": "sha256:aaf24de9d4bb53663cfd848dbf458ffd4b0a5e55321d07251cce24cf386d1982"
+      },
+      {
+        "name": "python-syspurpose",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-syspurpose-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:32b70de1b779e3f551d8b00c0f0031c84725139f1f5f398ba80053f9c96a08a2"
+      },
+      {
+        "name": "python-urlgrabber",
+        "epoch": 0,
+        "version": "3.10",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urlgrabber-3.10-10.el7.noarch.rpm",
+        "checksum": "sha256:9ddd959c968b3fa18f95faf3606a3930ec626f20aeb182cca99e497b05278aa4"
+      },
+      {
+        "name": "python-urllib3",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "7.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/python-urllib3-1.10.2-7.el7.noarch.rpm",
+        "checksum": "sha256:a253b636cd0b1886099e49e33ea5a7a20c0f9a0e4e73d2f7887a04741ec9280d"
+      },
+      {
+        "name": "pyxattr",
+        "epoch": 0,
+        "version": "0.5.1",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/pyxattr-0.5.1-5.el7.x86_64.rpm",
+        "checksum": "sha256:4a13c0ad25f16e0736c1f578bbcb8dc071d0e0272631f3251e1a31c788f142f8"
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "3.4.1",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/qrencode-libs-3.4.1-3.el7.x86_64.rpm",
+        "checksum": "sha256:423c42c5eb216eb25c4d32a896f77cf28f735e7d07cd60d3678a2db5c904ac55"
+      },
+      {
+        "name": "quota",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-4.01-19.el7.x86_64.rpm",
+        "checksum": "sha256:38720b7d872b48a30d69b7cbd04c0f8bd4b9cf3a801c8b1d296785a67245cca1"
+      },
+      {
+        "name": "quota-nls",
+        "epoch": 1,
+        "version": "4.01",
+        "release": "19.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/quota-nls-4.01-19.el7.noarch.rpm",
+        "checksum": "sha256:591e0edb3504f1af7cbb51d99b559e1599610048904807dd7440b4bd20b5b02f"
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/readline-6.2-11.el7.x86_64.rpm",
+        "checksum": "sha256:d196a525d02f95d83eaa9a25a10f7d08c15c4cad7cb9aeac15c9fbae8bbb164c"
+      },
+      {
+        "name": "redhat-release-eula",
+        "epoch": 0,
+        "version": "7.8",
+        "release": "0.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-eula-7.8-0.el7.noarch.rpm",
+        "checksum": "sha256:65f0e22564f440caa9aad8404bce88bdef734bbfe78eb3909950a4ddd3280eb4"
+      },
+      {
+        "name": "redhat-release-server",
+        "epoch": 0,
+        "version": "7.9",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-release-server-7.9-3.el7.x86_64.rpm",
+        "checksum": "sha256:ff1e959ba052cc5ceda455206e27ebca8638b7ce7fbf2b7db8a91f61a72aec66"
+      },
+      {
+        "name": "redhat-support-lib-python",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-lib-python-0.12.1-1.el7.noarch.rpm",
+        "checksum": "sha256:6e54c37c51856a6be2dd8e22c0c8f9fbc82fd21f01c2f7c7295a29bbcdf1e824"
+      },
+      {
+        "name": "redhat-support-tool",
+        "epoch": 0,
+        "version": "0.12.2",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/redhat-support-tool-0.12.2-1.el7.noarch.rpm",
+        "checksum": "sha256:a1b2071fd093dc2ba2fa2fcd12c2a300ad789fdf22704305297d3f84a6e6fcf0"
+      },
+      {
+        "name": "rhn-check",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-check-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:5b9eecff66a0e3f70d43010f6fb2ce149a00a215c72b36f73fce2c6ba3982a43"
+      },
+      {
+        "name": "rhn-client-tools",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-client-tools-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:3aa6194da8f12809a83fde5453a1fdca5211e42e3022e0b924ff1376b49b9701"
+      },
+      {
+        "name": "rhn-setup",
+        "epoch": 0,
+        "version": "2.0.2",
+        "release": "24.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhn-setup-2.0.2-24.el7.x86_64.rpm",
+        "checksum": "sha256:a251219dbd9bf0d5022c2452bb75d23db132fa69ab3ce92759a5de64b4a697ea"
+      },
+      {
+        "name": "rhnlib",
+        "epoch": 0,
+        "version": "2.5.65",
+        "release": "8.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnlib-2.5.65-8.el7.noarch.rpm",
+        "checksum": "sha256:e12e796899851d7ac2dcfa011fb7e9d56358991e0fc0552949d6f1bc62350a97"
+      },
+      {
+        "name": "rhnsd",
+        "epoch": 0,
+        "version": "5.0.13",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rhnsd-5.0.13-10.el7.x86_64.rpm",
+        "checksum": "sha256:1a21af8faab93b4e4d828f4be9710abfc478a6c0b189bac4fb48ac1b6d638939"
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rootfiles-8.1-11.el7.noarch.rpm",
+        "checksum": "sha256:89f3c9576cab42749460f7736221728770cf0c622cfb319e2503b01e7f5a9ee8"
+      },
+      {
+        "name": "rpcbind",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "49.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rpcbind-0.2.0-49.el7.x86_64.rpm",
+        "checksum": "sha256:bd5e60ac179ede7efc997fe691c250b60bfa8a65cc82a3bcefc1ed1568110cc6"
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.1.2",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsync-3.1.2-10.el7.x86_64.rpm",
+        "checksum": "sha256:60fe39f8078b432730cf7830ced13421d0850289f7e27b74109a2efaa2665b0c"
+      },
+      {
+        "name": "rsyslog",
+        "epoch": 0,
+        "version": "8.24.0",
+        "release": "55.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/rsyslog-8.24.0-55.el7.x86_64.rpm",
+        "checksum": "sha256:10873eefaff164ae15ae2a9d02b57ae8018205f6824437796fb030c17def0fa7"
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.2.2",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sed-4.2.2-7.el7.x86_64.rpm",
+        "checksum": "sha256:edfbbdad51585941595f0a7f38cce55cff109c555245d66a2af08fe8f2642d04"
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:90970802248a6d3d908bb0dfa6b1fbd3c1ca70df15a880ef9a65851b1302d44b"
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "3.13.1",
+        "release": "268.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/selinux-policy-targeted-3.13.1-268.el7.noarch.rpm",
+        "checksum": "sha256:0206ad85f99f76af27e33e2c73a2d2a02c87f400e74a5baccf0c04561907e92d"
+      },
+      {
+        "name": "setools-libs",
+        "epoch": 0,
+        "version": "3.3.8",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setools-libs-3.3.8-4.el7.x86_64.rpm",
+        "checksum": "sha256:9799fa04f2533f639bc75e9582eb16532d477f117c63995fb7a4e5a64fe9556b"
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.8.71",
+        "release": "11.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/setup-2.8.71-11.el7.noarch.rpm",
+        "checksum": "sha256:66d16c27de575b7a34f7d811cb9b3df5262cdd1f65ea4d36bed0cdf25f2cc8cb"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:39d5b27e7b53308da7ac9900019b67e87222ac2645e415b8577f4db4fb3e821b"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 1,
+        "version": "1.37",
+        "release": "19.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sg3_utils-libs-1.37-19.el7.x86_64.rpm",
+        "checksum": "sha256:540d92c8b1aee1eb318afdc3f6c678c64e5a24ebb1db9317c7720c0864a7722e"
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.6",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shadow-utils-4.6-5.el7.x86_64.rpm",
+        "checksum": "sha256:63a2a2b5b6febf9e2cca8ffe69d36fbd700111a8c1e572d11e183df242a849e3"
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "5.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shared-mime-info-1.8-5.el7.x86_64.rpm",
+        "checksum": "sha256:46b5e7d3b453c12b8a40aec53d14e7529de17a999d45118809f6c1b83b151e1b"
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/shim-x64-15-11.el7.x86_64.rpm",
+        "checksum": "sha256:26451568240ea2a50a63ef7d0d29e81524511cfda396ebb107744d95e703c19f"
+      },
+      {
+        "name": "slang",
+        "epoch": 0,
+        "version": "2.2.4",
+        "release": "11.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/slang-2.2.4-11.el7.x86_64.rpm",
+        "checksum": "sha256:282f5cbb66c7df0b453652836314248bae9ca5d28ecd7ec08bb795ba5aff8951"
+      },
+      {
+        "name": "snappy",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "3.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/snappy-1.1.0-3.el7.x86_64.rpm",
+        "checksum": "sha256:b410972f8b141ed2c9e0c6f71d3cb479562c320a198f627b575a9c6619eb7dfa"
+      },
+      {
+        "name": "sqlite",
+        "epoch": 0,
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sqlite-3.7.17-8.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:d0a139643324cde3b1862adc5854bb915d66e2cc451f3608331a76ceef7e13fb"
+      },
+      {
+        "name": "subscription-manager",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:d968bf7f8073c68f646e6ba646e29cb6d233cec64ed5f9c420831290774c50ca"
+      },
+      {
+        "name": "subscription-manager-rhsm",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:4a28d86ae079986885c72cf09ec6fbd62ffacd8bb13b3c8855ace345bacbb6b0"
+      },
+      {
+        "name": "subscription-manager-rhsm-certificates",
+        "epoch": 0,
+        "version": "1.24.42",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/subscription-manager-rhsm-certificates-1.24.42-1.el7.x86_64.rpm",
+        "checksum": "sha256:19700bb2a20ef7c48f7193b24785b15edb7f1c06f3283f206fafe847343d7b54"
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.8.23",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sudo-1.8.23-10.el7.x86_64.rpm",
+        "checksum": "sha256:2662ba7b0af95a6f8f20cde932c66e9b670665890cd34fba3f70b8a5ff7e8848"
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:99d2f89951c958d69aaa04935001253b1d1ea781d44a3ba1db123fab15c5aab7"
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-libs-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:4062df96c0797801f4295a133df9a022e33ec13ae4516b29c936763f64a9b2f2"
+      },
+      {
+        "name": "systemd-sysv",
+        "epoch": 0,
+        "version": "219",
+        "release": "78.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/systemd-sysv-219-78.el7.x86_64.rpm",
+        "checksum": "sha256:a7e16898bcde09e76d873f2593810c9ebb4a9d36da992aede7c17155b1a5bc9d"
+      },
+      {
+        "name": "sysvinit-tools",
+        "epoch": 0,
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/sysvinit-tools-2.88-14.dsf.el7.x86_64.rpm",
+        "checksum": "sha256:7ad380191f90f8ef35f60104fdd2c5abbc390a3b42223c52de86a166852cdc75"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.26",
+        "release": "35.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tar-1.26-35.el7.x86_64.rpm",
+        "checksum": "sha256:18c52a40340d3e7221fc43e2ad698926b78505eac0f3b36d0f23dfea1e8c4934"
+      },
+      {
+        "name": "tcp_wrappers",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:90a45b3f5412646cf1812172ff75c9efd4ad94f3d3f9fe6cd276fce65d1c96b5"
+      },
+      {
+        "name": "tcp_wrappers-libs",
+        "epoch": 0,
+        "version": "7.6",
+        "release": "77.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcp_wrappers-libs-7.6-77.el7.x86_64.rpm",
+        "checksum": "sha256:0d8650ee08a36666aaeed4ee713d6067ccd3c7e5445e3d949ac2ee183c94921a"
+      },
+      {
+        "name": "tcpdump",
+        "epoch": 14,
+        "version": "4.9.2",
+        "release": "4.el7_7.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tcpdump-4.9.2-4.el7_7.1.x86_64.rpm",
+        "checksum": "sha256:09728df5b04e03f212a1a8be620b5ea3c97515c50e73cb079ec936ee174ba61d"
+      },
+      {
+        "name": "tuned",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "9.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tuned-2.11.0-9.el7.noarch.rpm",
+        "checksum": "sha256:2a03d83873a95f5a41224ef37b6abc396c04472aa3efc96835baae9f4596e018"
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2020a",
+        "release": "1.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/tzdata-2020a-1.el7.noarch.rpm",
+        "checksum": "sha256:a1f06bf1cbed7e05308f192c91856e81bbc988e1751efe6881bd7aca254d10ec"
+      },
+      {
+        "name": "usermode",
+        "epoch": 0,
+        "version": "1.111",
+        "release": "6.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/usermode-1.111-6.el7.x86_64.rpm",
+        "checksum": "sha256:76f63f8fe81ae05558de72c0123a2e4f4e6f2cc87fef29655ef40995bd2b704c"
+      },
+      {
+        "name": "ustr",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/ustr-1.0.4-16.el7.x86_64.rpm",
+        "checksum": "sha256:50573712702e041493f2faf28f55f527d9eef8338a8bc6b59d92e1f221a227b8"
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.23.2",
+        "release": "65.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/util-linux-2.23.2-65.el7.x86_64.rpm",
+        "checksum": "sha256:4fb6e7b6246f929ade40e70f5edc757956714684fefcac9e6d21215623e5d569"
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "7.4.629",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/vim-minimal-7.4.629-7.el7.x86_64.rpm",
+        "checksum": "sha256:9d2cc8c7e7fe129b9e5c1e057870c82522e3104c05bbba9ee6ece56ec92900bc"
+      },
+      {
+        "name": "virt-what",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/virt-what-1.18-4.el7.x86_64.rpm",
+        "checksum": "sha256:34810a66dca420b3b88f129e386c28c2cb13f6f494acf58eafb4d6037fdcc20e"
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "7.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/which-2.20-7.el7.x86_64.rpm",
+        "checksum": "sha256:06f674513dc3838eb76593777aa0a514eef44c85886ceb8b87779e69a9d00939"
+      },
+      {
+        "name": "xdg-utils",
+        "epoch": 0,
+        "version": "1.1.0",
+        "release": "0.17.20120809git.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xdg-utils-1.1.0-0.17.20120809git.el7.noarch.rpm",
+        "checksum": "sha256:6bb6d2e38b25cf61b1f78c8e224bba9d5adb10fa8c4db977cc06f7b19bbc4d9b"
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "4.5.0",
+        "release": "22.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xfsprogs-4.5.0-22.el7.x86_64.rpm",
+        "checksum": "sha256:dd79a2a2f87ed920f3a9401da58813fb9507cc94fd6130192be77a02c3fc448d"
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:3252cadf18993f9b73799625d8fc7e9be6efedf33ddc3efa035797f2db9d8894"
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/xz-libs-5.2.2-1.el7.x86_64.rpm",
+        "checksum": "sha256:aa391cfaba93d4b9f4f8959175fa2fcaf851b1e70d5f15c5b27e1a7ebfadf5fd"
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "3.4.3",
+        "release": "168.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-3.4.3-168.el7.noarch.rpm",
+        "checksum": "sha256:f59f37936ec9399161f49420340d460e909409b3018b55e348806a15ff063a72"
+      },
+      {
+        "name": "yum-metadata-parser",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "10.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-metadata-parser-1.1.4-10.el7.x86_64.rpm",
+        "checksum": "sha256:f783a96d524d0a38aa6041a4f4372df2ea662236ed4ddbc15115967ed32c6ca1"
+      },
+      {
+        "name": "yum-rhn-plugin",
+        "epoch": 0,
+        "version": "2.0.1",
+        "release": "10.el7",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-rhn-plugin-2.0.1-10.el7.noarch.rpm",
+        "checksum": "sha256:39a9ade0e44eb4856e70940e8d3d581ada5e6b122744d5e957729042d1b7ff0b"
+      },
+      {
+        "name": "yum-utils",
+        "epoch": 0,
+        "version": "1.1.31",
+        "release": "54.el7_8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/yum-utils-1.1.31-54.el7_8.noarch.rpm",
+        "checksum": "sha256:94ee019b2e9b513a80cf0b5335d33c0a9c5cf3a8e3fda5e8d81f7b2931d09b95"
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.7",
+        "release": "18.el7",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530/Packages/zlib-1.2.7-18.el7.x86_64.rpm",
+        "checksum": "sha256:db8dd5164d1177c2804a337199ad1f8ae6821f91d38d442c03ab15c318f27c97"
+      },
+      {
+        "name": "PyYAML",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/PyYAML/3.12/12.el7eng/x86_64/PyYAML-3.12-12.el7eng.x86_64.rpm",
+        "checksum": "sha256:c8bd1937344a714e81d238ccb9f05274336d510d8695c8e4ab4b96768b1c4a1b"
+      },
+      {
+        "name": "hardlink",
+        "epoch": 1,
+        "version": "1.3",
+        "release": "6.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/hardlink/1.3/6.el7eng/x86_64/hardlink-1.3-6.el7eng.x86_64.rpm",
+        "checksum": "sha256:c6d7e3e6d22005f0e302e209188081522cae87e8db86fbefb38815fb647e8f42"
+      },
+      {
+        "name": "python-jinja2",
+        "epoch": 0,
+        "version": "2.8",
+        "release": "2.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-jinja2/2.8/2.el7eng/noarch/python-jinja2-2.8-2.el7eng.noarch.rpm",
+        "checksum": "sha256:89406b879c4d4b1a91cd9d492cc5c35654c185b79ec9382635c8079c4ac2bc09"
+      },
+      {
+        "name": "python-six",
+        "epoch": 0,
+        "version": "1.9.0",
+        "release": "4.el7eng",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-six/1.9.0/4.el7eng/noarch/python-six-1.9.0-4.el7eng.noarch.rpm",
+        "checksum": "sha256:3f8fce412b3d5dd8cd96ab00a18cd793ce0b2a66718dcfe9b715b701f191d904"
+      },
+      {
+        "name": "python2-dateutil",
+        "epoch": 1,
+        "version": "2.6.1",
+        "release": "1.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-dateutil/2.6.1/1.el7ost/noarch/python2-dateutil-2.6.1-1.el7ost.noarch.rpm",
+        "checksum": "sha256:9ce3026d2c80057a19b3dbfecd2abab534ec364684e43b7b2041e321c073a267"
+      },
+      {
+        "name": "python2-markupsafe",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-markupsafe/1.0/2.el7eng/x86_64/python2-markupsafe-1.0-2.el7eng.x86_64.rpm",
+        "checksum": "sha256:2d8b3067d5460ba2b21977e615778064ffeda32f0cb3ec92fa082cf0c5dfa3f3"
+      },
+      {
+        "name": "python2-setuptools",
+        "epoch": 0,
+        "version": "38.4.0",
+        "release": "3.el7ost",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/python-setuptools/38.4.0/3.el7ost/noarch/python2-setuptools-38.4.0-3.el7ost.noarch.rpm",
+        "checksum": "sha256:2b90b44e0c41d233b6110575c4a442719b59f8f31d86dcb0b303451c70cfa4d0"
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c3f76a582b0de01668f2a0567458598f9914f792e79515713f2f7f00e2c1c788"
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-build-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:c285642978ec4bf9fc04ee3f94daa745deba518ee1bacc270d2a05f5286b448f"
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-libs-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:cfee456a0f3a2208ec1925cf1e699dd9ac9c5efb9ef4f27c5928670b57aa2bf1"
+      },
+      {
+        "name": "rpm-python",
+        "epoch": 0,
+        "version": "4.11.3",
+        "release": "45.zfix_sighdr.el7eng",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530/toplink/vol/rhel-7/packages/rpm/4.11.3/45.zfix_sighdr.el7eng/x86_64/rpm-python-4.11.3-45.zfix_sighdr.el7eng.x86_64.rpm",
+        "checksum": "sha256:6b335cd2811b48cfcd895189dab46969d5069150a92e4ef725976d5cf4bcbc50"
+      }
+    ]
+  }
+}

--- a/tools/test-case-generators/repos.json
+++ b/tools/test-case-generators/repos.json
@@ -145,6 +145,37 @@
       }
     ]
   },
+  "rhel-7": {
+    "x86_64": [
+      {
+        "name": "server",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-r7.9-20220530"
+      },
+      {
+        "name": "server-extras",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-extras-r7.9-20220530"
+      },
+      {
+        "name": "server-optional",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-optional-r7.9-20220530"
+      },
+      {
+        "name": "server-dotnet",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-server-dotnet-r1.1-20220530"
+      },
+      {
+        "name": "rhel-eng",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
+      },
+      {
+        "name": "azure-rhui-7",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-rhui-azure-20220530"
+      }
+    ]
+  },
   "rhel-8": {
     "aarch64": [
       {


### PR DESCRIPTION
Based on the RHEL 8.6 pipelines, needs a special buildroot with two
extra packages: python3-iniparse and python3-PyYAML.
Only x86_64 support for now.

This is based on to of #2537 