### PR TITLE
[rhel86/rhel90] blacklist skx_edac,intel_cstate kernel modules and enable nm-cloud-setup on azure 

### DIFF
--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -925,6 +925,8 @@ func newDistro(distroName string) distro.Distro {
 			},
 			EnabledServices: []string{
 				"firewalld",
+				"nm-cloud-setup.service",
+				"nm-cloud-setup.timer",
 				"sshd",
 				"systemd-resolved",
 				"waagent",
@@ -1055,6 +1057,17 @@ func newDistro(distroName string) distro.Distro {
 							{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
 						},
 					),
+				},
+			},
+			SystemdUnit: []*osbuild.SystemdUnitStageOptions{
+				{
+					Unit:   "nm-cloud-setup.service",
+					Dropin: "10-rh-enable-for-azure.conf",
+					Config: osbuild.SystemdServiceUnitDropin{
+						Service: &osbuild.SystemdUnitServiceSection{
+							Environment: "NM_CLOUD_SETUP_AZURE=yes",
+						},
+					},
 				},
 			},
 			DefaultTarget: "multi-user.target",

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -948,6 +948,18 @@ func newDistro(distroName string) distro.Distro {
 						osbuild.NewModprobeConfigCmdBlacklist("floppy"),
 					},
 				},
+				{
+					Filename: "blacklist-skylake-edac.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
+					},
+				},
+				{
+					Filename: "blacklist-intel-cstate.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+					},
+				},
 			},
 			CloudInit: []*osbuild.CloudInitStageOptions{
 				{

--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -346,6 +346,7 @@ func azureRhuiCommonPackageSet(t *imageType) rpmmd.PackageSet {
 		Include: []string{
 			"@Server",
 			"NetworkManager",
+			"NetworkManager-cloud-setup",
 			"kernel",
 			"kernel-core",
 			"kernel-modules",

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -926,6 +926,8 @@ func newDistro(distroName string) distro.Distro {
 			},
 			EnabledServices: []string{
 				"firewalld",
+				"nm-cloud-setup.service",
+				"nm-cloud-setup.timer",
 				"sshd",
 				"waagent",
 			},
@@ -1055,6 +1057,17 @@ func newDistro(distroName string) distro.Distro {
 							{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
 						},
 					),
+				},
+			},
+			SystemdUnit: []*osbuild.SystemdUnitStageOptions{
+				{
+					Unit:   "nm-cloud-setup.service",
+					Dropin: "10-rh-enable-for-azure.conf",
+					Config: osbuild.SystemdServiceUnitDropin{
+						Service: &osbuild.SystemdUnitServiceSection{
+							Environment: "NM_CLOUD_SETUP_AZURE=yes",
+						},
+					},
 				},
 			},
 			DefaultTarget: "multi-user.target",

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -948,6 +948,18 @@ func newDistro(distroName string) distro.Distro {
 						osbuild.NewModprobeConfigCmdBlacklist("floppy"),
 					},
 				},
+				{
+					Filename: "blacklist-skylake-edac.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
+					},
+				},
+				{
+					Filename: "blacklist-intel-cstate.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+					},
+				},
 			},
 			CloudInit: []*osbuild.CloudInitStageOptions{
 				{

--- a/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
@@ -2850,6 +2850,30 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-skylake-edac.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "skx_edac"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.sshd.config",
             "options": {
               "config": {

--- a/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
@@ -2331,6 +2331,9 @@
                     "id": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
                   },
                   {
+                    "id": "sha256:f72fbc39bd861fd5a0f6d38b0c2d3f2f12e07dd91f70b5288ca03c30ff77a431"
+                  },
+                  {
                     "id": "sha256:a842bbdfe4e3f24ef55acd0ed6930639ccaa5980a2774235bc4c6c2a95ab421c"
                   },
                   {
@@ -2751,6 +2754,8 @@
             "options": {
               "enabled_services": [
                 "firewalld",
+                "nm-cloud-setup.service",
+                "nm-cloud-setup.timer",
                 "sshd",
                 "systemd-resolved",
                 "waagent"
@@ -2871,6 +2876,18 @@
                   "modulename": "intel_cstate"
                 }
               ]
+            }
+          },
+          {
+            "type": "org.osbuild.systemd.unit",
+            "options": {
+              "unit": "nm-cloud-setup.service",
+              "dropin": "10-rh-enable-for-azure.conf",
+              "config": {
+                "Service": {
+                  "Environment": "NM_CLOUD_SETUP_AZURE=yes"
+                }
+              }
             }
           },
           {
@@ -5338,6 +5355,9 @@
           },
           "sha256:f72118d72067987ac1eeded4b04e95e709b263c27877f3eb1112859db33cb403": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/dracut-049-191.git20210920.el8.x86_64.rpm"
+          },
+          "sha256:f72fbc39bd861fd5a0f6d38b0c2d3f2f12e07dd91f70b5288ca03c30ff77a431": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/NetworkManager-cloud-setup-1.32.10-4.el8.x86_64.rpm"
           },
           "sha256:f753d133921c84b44694d63869ff20e35e47cd09db7d190eda15f2cca953033f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/libkcapi-1.2.0-2.el8.x86_64.rpm"
@@ -12195,6 +12215,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/zlib-1.2.11-17.el8.x86_64.rpm",
         "checksum": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
+      },
+      {
+        "name": "NetworkManager-cloud-setup",
+        "epoch": 1,
+        "version": "1.32.10",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/NetworkManager-cloud-setup-1.32.10-4.el8.x86_64.rpm",
+        "checksum": "sha256:f72fbc39bd861fd5a0f6d38b0c2d3f2f12e07dd91f70b5288ca03c30ff77a431"
       },
       {
         "name": "PackageKit",

--- a/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
@@ -2328,6 +2328,9 @@
                     "id": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
                   },
                   {
+                    "id": "sha256:071bac3dd97dc1e6942a93f0d77d41c218a381ef02608dafce633441ca1f7d79"
+                  },
+                  {
                     "id": "sha256:a842bbdfe4e3f24ef55acd0ed6930639ccaa5980a2774235bc4c6c2a95ab421c"
                   },
                   {
@@ -2748,6 +2751,8 @@
             "options": {
               "enabled_services": [
                 "firewalld",
+                "nm-cloud-setup.service",
+                "nm-cloud-setup.timer",
                 "sshd",
                 "systemd-resolved",
                 "waagent"
@@ -2868,6 +2873,18 @@
                   "modulename": "intel_cstate"
                 }
               ]
+            }
+          },
+          {
+            "type": "org.osbuild.systemd.unit",
+            "options": {
+              "unit": "nm-cloud-setup.service",
+              "dropin": "10-rh-enable-for-azure.conf",
+              "config": {
+                "Service": {
+                  "Environment": "NM_CLOUD_SETUP_AZURE=yes"
+                }
+              }
             }
           },
           {
@@ -3526,6 +3543,9 @@
           },
           "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-pc-2.02-106.el8.x86_64.rpm"
+          },
+          "sha256:071bac3dd97dc1e6942a93f0d77d41c218a381ef02608dafce633441ca1f7d79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/NetworkManager-cloud-setup-1.36.0-0.4.el8.x86_64.rpm"
           },
           "sha256:07203935df37fa76185f71ab353897ad31276cc5535ad5c604848425a3b8f477": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/psacct-6.6.3-4.el8.x86_64.rpm"
@@ -12177,6 +12197,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/zlib-1.2.11-17.el8.x86_64.rpm",
         "checksum": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
+      },
+      {
+        "name": "NetworkManager-cloud-setup",
+        "epoch": 1,
+        "version": "1.36.0",
+        "release": "0.4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/NetworkManager-cloud-setup-1.36.0-0.4.el8.x86_64.rpm",
+        "checksum": "sha256:071bac3dd97dc1e6942a93f0d77d41c218a381ef02608dafce633441ca1f7d79"
       },
       {
         "name": "PackageKit",

--- a/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
@@ -2847,6 +2847,30 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-skylake-edac.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "skx_edac"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.sshd.config",
             "options": {
               "config": {

--- a/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
@@ -2847,6 +2847,30 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-skylake-edac.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "skx_edac"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.sshd.config",
             "options": {
               "config": {

--- a/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
@@ -2328,6 +2328,9 @@
                     "id": "sha256:6bf8c03ef185b79579f42ce3404d01b0444772cc476081807002124e0331661e"
                   },
                   {
+                    "id": "sha256:714de349188ecb98716b6db76f84d4d900cef9684adf9ca3bfbb8f579e574eb4"
+                  },
+                  {
                     "id": "sha256:a842bbdfe4e3f24ef55acd0ed6930639ccaa5980a2774235bc4c6c2a95ab421c"
                   },
                   {
@@ -2748,6 +2751,8 @@
             "options": {
               "enabled_services": [
                 "firewalld",
+                "nm-cloud-setup.service",
+                "nm-cloud-setup.timer",
                 "sshd",
                 "systemd-resolved",
                 "waagent"
@@ -2868,6 +2873,18 @@
                   "modulename": "intel_cstate"
                 }
               ]
+            }
+          },
+          {
+            "type": "org.osbuild.systemd.unit",
+            "options": {
+              "unit": "nm-cloud-setup.service",
+              "dropin": "10-rh-enable-for-azure.conf",
+              "config": {
+                "Service": {
+                  "Environment": "NM_CLOUD_SETUP_AZURE=yes"
+                }
+              }
             }
           },
           {
@@ -4324,6 +4341,9 @@
           },
           "sha256:714557927e1ed71adfb1acdff8e92a8700d30957a3407daecc59d5ad465170a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/dnf-4.7.0-8.el8.noarch.rpm"
+          },
+          "sha256:714de349188ecb98716b6db76f84d4d900cef9684adf9ca3bfbb8f579e574eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/NetworkManager-cloud-setup-1.39.0-1.el8.x86_64.rpm"
           },
           "sha256:714f1fc52a9579e3a81544ba372bbabfc46bb8bc06f86552150e1937eea07f2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/kmod-kvdo-6.2.6.14-84.el8.x86_64.rpm"
@@ -12177,6 +12197,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/zlib-1.2.11-18.el8_5.x86_64.rpm",
         "checksum": "sha256:6bf8c03ef185b79579f42ce3404d01b0444772cc476081807002124e0331661e"
+      },
+      {
+        "name": "NetworkManager-cloud-setup",
+        "epoch": 1,
+        "version": "1.39.0",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/NetworkManager-cloud-setup-1.39.0-1.el8.x86_64.rpm",
+        "checksum": "sha256:714de349188ecb98716b6db76f84d4d900cef9684adf9ca3bfbb8f579e574eb4"
       },
       {
         "name": "PackageKit",

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2629,6 +2629,8 @@
             "options": {
               "enabled_services": [
                 "firewalld",
+                "nm-cloud-setup.service",
+                "nm-cloud-setup.timer",
                 "sshd",
                 "waagent"
               ],
@@ -2748,6 +2750,18 @@
                   "modulename": "intel_cstate"
                 }
               ]
+            }
+          },
+          {
+            "type": "org.osbuild.systemd.unit",
+            "options": {
+              "unit": "nm-cloud-setup.service",
+              "dropin": "10-rh-enable-for-azure.conf",
+              "config": {
+                "Service": {
+                  "Environment": "NM_CLOUD_SETUP_AZURE=yes"
+                }
+              }
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2727,6 +2727,30 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-skylake-edac.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "skx_edac"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.sshd.config",
             "options": {
               "config": {

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6815,6 +6815,8 @@
             "options": {
               "enabled_services": [
                 "firewalld",
+                "nm-cloud-setup.service",
+                "nm-cloud-setup.timer",
                 "sshd",
                 "waagent"
               ],
@@ -6934,6 +6936,18 @@
                   "modulename": "intel_cstate"
                 }
               ]
+            }
+          },
+          {
+            "type": "org.osbuild.systemd.unit",
+            "options": {
+              "unit": "nm-cloud-setup.service",
+              "dropin": "10-rh-enable-for-azure.conf",
+              "config": {
+                "Service": {
+                  "Environment": "NM_CLOUD_SETUP_AZURE=yes"
+                }
+              }
             }
           },
           {

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6913,6 +6913,30 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-skylake-edac.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "skx_edac"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.sshd.config",
             "options": {
               "config": {


### PR DESCRIPTION
Disable kernel modules as they are disabled in the MSFT images. Properly install, enable and configure the nm-cloud-setup service and timer on Azure.

Closes #2680
Closes #2645