### PR TITLE
distro/rhel90: remove skx_edac, intel_cstate from denylist again

### DIFF
--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -950,18 +950,6 @@ func newDistro(distroName string) distro.Distro {
 						osbuild.NewModprobeConfigCmdBlacklist("floppy"),
 					},
 				},
-				{
-					Filename: "blacklist-skylake-edac.conf",
-					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
-					},
-				},
-				{
-					Filename: "blacklist-intel-cstate.conf",
-					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
-					},
-				},
 			},
 			CloudInit: []*osbuild.CloudInitStageOptions{
 				{

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2729,30 +2729,6 @@
             }
           },
           {
-            "type": "org.osbuild.modprobe",
-            "options": {
-              "filename": "blacklist-skylake-edac.conf",
-              "commands": [
-                {
-                  "command": "blacklist",
-                  "modulename": "skx_edac"
-                }
-              ]
-            }
-          },
-          {
-            "type": "org.osbuild.modprobe",
-            "options": {
-              "filename": "blacklist-intel-cstate.conf",
-              "commands": [
-                {
-                  "command": "blacklist",
-                  "modulename": "intel_cstate"
-                }
-              ]
-            }
-          },
-          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6915,30 +6915,6 @@
             }
           },
           {
-            "type": "org.osbuild.modprobe",
-            "options": {
-              "filename": "blacklist-skylake-edac.conf",
-              "commands": [
-                {
-                  "command": "blacklist",
-                  "modulename": "skx_edac"
-                }
-              ]
-            }
-          },
-          {
-            "type": "org.osbuild.modprobe",
-            "options": {
-              "filename": "blacklist-intel-cstate.conf",
-              "commands": [
-                {
-                  "command": "blacklist",
-                  "modulename": "intel_cstate"
-                }
-              ]
-            }
-          },
-          {
             "type": "org.osbuild.systemd.unit",
             "options": {
               "unit": "nm-cloud-setup.service",


### PR DESCRIPTION
In commit 5c1530e we disabled `skx_edac` and `intel_cstate` but after further consultation with Prarit Bhargava it was agreed that  for RHEL 9 we should indeed allow them.
