### PR TITLE
dbjobqueue: Alter foreign key constraints

### DIFF
--- a/internal/jobqueue/dbjobqueue/schemas/003_dependencies_cascade.sql
+++ b/internal/jobqueue/dbjobqueue/schemas/003_dependencies_cascade.sql
@@ -1,0 +1,11 @@
+ALTER TABLE job_dependencies
+
+DROP CONSTRAINT job_dependencies_dependency_id_fkey,
+
+DROP CONSTRAINT job_dependencies_job_id_fkey,
+
+ADD CONSTRAINT job_dependencies_dependency_id_fkey
+FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+
+ADD CONSTRAINT job_dependencies_job_id_fkey
+FOREIGN KEY (dependency_id) REFERENCES jobs(id) ON DELETE CASCADE;

--- a/internal/jobqueue/dbjobqueue/schemas/004_heartbeats_cascade.sql
+++ b/internal/jobqueue/dbjobqueue/schemas/004_heartbeats_cascade.sql
@@ -1,0 +1,6 @@
+ALTER TABLE heartbeats
+
+DROP CONSTRAINT heartbeats_id_fkey,
+
+ADD CONSTRAINT heartbeats_id_fkey
+FOREIGN KEY (id) REFERENCES jobs(id) ON DELETE CASCADE;


### PR DESCRIPTION
When deleting rows from the job table, make sure the delete is cascaded
to the dependencies table.

---

We should be able to clear rows from the stage database using scheduled queries, for production we can keep stuff around for longer of course. But no point in letting the stage db grow (rds doesn't allow you to shrink after the fact).

This is independent from #2707, that PR zeros out manifests which can contain sensitive-ish data.