### PR TITLE
Blacklist amdgpu module on Azure images

### DIFF
--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -938,10 +938,15 @@ func newDistro(distroName string) distro.Distro {
 			},
 			Modprobe: []*osbuild.ModprobeStageOptions{
 				{
-					Filename: "blacklist-nouveau.conf",
+					Filename: "blacklist-amdgpu.conf",
 					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-						osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
+						osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+					},
+				},
+				{
+					Filename: "blacklist-intel-cstate.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
 					},
 				},
 				{
@@ -951,15 +956,16 @@ func newDistro(distroName string) distro.Distro {
 					},
 				},
 				{
-					Filename: "blacklist-skylake-edac.conf",
+					Filename: "blacklist-nouveau.conf",
 					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
+						osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+						osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
 					},
 				},
 				{
-					Filename: "blacklist-intel-cstate.conf",
+					Filename: "blacklist-skylake-edac.conf",
 					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+						osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
 					},
 				},
 			},

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -938,16 +938,22 @@ func newDistro(distroName string) distro.Distro {
 			},
 			Modprobe: []*osbuild.ModprobeStageOptions{
 				{
-					Filename: "blacklist-nouveau.conf",
+					Filename: "blacklist-amdgpu.conf",
 					Commands: osbuild.ModprobeConfigCmdList{
-						osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-						osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
+						osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
 					},
 				},
 				{
 					Filename: "blacklist-floppy.conf",
 					Commands: osbuild.ModprobeConfigCmdList{
 						osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+					},
+				},
+				{
+					Filename: "blacklist-nouveau.conf",
+					Commands: osbuild.ModprobeConfigCmdList{
+						osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+						osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
 					},
 				},
 			},

--- a/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
@@ -16,7 +16,7 @@
       },
       {
         "name": "rhui-azure",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220227",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220504",
         "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF\n0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF\n0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c\nu7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh\nXGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H\n5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW\n9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj\n/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1\nPcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY\nHVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF\nbuhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK\nCRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC\n2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf\nC/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5\nun3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E\n0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE\nIGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh\n8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL\nGht5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki\nJUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25\nOFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq\ndzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==\n=zbHE\n-----END PGP PUBLIC KEY BLOCK-----\n-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFsy23UBEACUKSphFEIEvNpy68VeW4Dt6qv+mU6am9a2AAl10JANLj1oqWX+\noYk3en1S6cVe2qehSL5DGVa3HMUZkP3dtbD4SgzXzxPodebPcr4+0QNWigkUisri\nXGL5SCEcOP30zDhZvg+4mpO2jMi7Kc1DLPzBBkgppcX91wa0L1pQzBcvYMPyV/Dh\nKbQHR75WdkP6OA2JXdfC94nxYq+2e0iPqC1hCP3Elh+YnSkOkrawDPmoB1g4+ft/\nxsiVGVy/W0ekXmgvYEHt6si6Y8NwXgnTMqxeSXQ9YUgVIbTpsxHQKGy76T5lMlWX\n4LCOmEVomBJg1SqF6yi9Vu8TeNThaDqT4/DddYInd0OO69s0kGIXalVgGYiW2HOD\nx2q5R1VGCoJxXomz+EbOXY+HpKPOHAjU0DB9MxbU3S248LQ69nIB5uxysy0PSco1\nsdZ8sxRNQ9Dw6on0Nowx5m6Thefzs5iK3dnPGBqHTT43DHbnWc2scjQFG+eZhe98\nEll/kb6vpBoY4bG9/wCG9qu7jj9Z+BceCNKeHllbezVLCU/Hswivr7h2dnaEFvPD\nO4GqiWiwOF06XaBMVgxA8p2HRw0KtXqOpZk+o+sUvdPjsBw42BB96A1yFX4jgFNA\nPyZYnEUdP6OOv9HSjnl7k/iEkvHq/jGYMMojixlvXpGXhnt5jNyc4GSUJQARAQAB\ntDNSZWQgSGF0LCBJbmMuIChhdXhpbGlhcnkga2V5KSA8c2VjdXJpdHlAcmVkaGF0\nLmNvbT6JAjkEEwECACMFAlsy23UCGwMHCwkIBwMCAQYVCAIJCgsEFgIDAQIeAQIX\ngAAKCRD3b2bD1AgnknqOD/9fB2ASuG2aJIiap4kK58R+RmOVM4qgclAnaG57+vjI\nnKvyfV3NH/keplGNRxwqHekfPCqvkpABwhdGEXIE8ILqnPewIMr6PZNZWNJynZ9i\neSMzVuCG7jDoGyQ5/6B0f6xeBtTeBDiRl7+Alehet1twuGL1BJUYG0QuLgcEzkaE\n/gkuumeVcazLzz7L12D22nMk66GxmgXfqS5zcbqOAuZwaA6VgSEgFdV2X2JU79zS\nBQJXv7NKc+nDXFG7M7EHjY3Rma3HXkDbkT8bzh9tJV7Z7TlpT829pStWQyoxKCVq\nsEX8WsSapTKA3P9YkYCwLShgZu4HKRFvHMaIasSIZWzLu+RZH/4yyHOhj0QB7XMY\neHQ6fGSbtJ+K6SrpHOOsKQNAJ0hVbSrnA1cr5+2SDfel1RfYt0W9FA6DoH/S5gAR\ndzT1u44QVwwp3U+eFpHphFy//uzxNMtCjjdkpzhYYhOCLNkDrlRPb+bcoL/6ePSr\n016PA7eEnuC305YU1Ml2WcCn7wQV8x90o33klJmEkWtXh3X39vYtI4nCPIvZn1eP\nVy+F+wWt4vN2b8oOdlzc2paOembbCo2B+Wapv5Y9peBvlbsDSgqtJABfK8KQq/jK\nYl3h5elIa1I3uNfczeHOnf1enLOUOlq630yeM/yHizz99G1g+z/guMh5+x/OHraW\niA==\n=+Gxh\n-----END PGP PUBLIC KEY BLOCK-----\n",
         "image_type_tags": [
           "azure-rhui"
@@ -2829,15 +2829,23 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-nouveau.conf",
+              "filename": "blacklist-amdgpu.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "nouveau"
-                },
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "lbm-nouveau"
+                  "modulename": "intel_cstate"
                 }
               ]
             }
@@ -2857,11 +2865,15 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-skylake-edac.conf",
+              "filename": "blacklist-nouveau.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "skx_edac"
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
                 }
               ]
             }
@@ -2869,11 +2881,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-intel-cstate.conf",
+              "filename": "blacklist-skylake-edac.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "intel_cstate"
+                  "modulename": "skx_edac"
                 }
               ]
             }
@@ -3614,7 +3626,7 @@
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/gobject-introspection-1.56.1-1.el8.x86_64.rpm"
           },
           "sha256:10e429e047cea577ade1d52422a39af6349b4427b6aba8865dc4eba169c142ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220227/rhui-azure-rhel8-2.2-198.noarch.rpm"
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220504/rhui-azure-rhel8-2.2-198.noarch.rpm"
           },
           "sha256:1136323a37c5940055c3891a260b26782b75ea986fb5fe02ad80364f60527450": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/grub2-common-2.02-106.el8.noarch.rpm"
@@ -13338,7 +13350,7 @@
         "version": "2.2",
         "release": "198",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220227/rhui-azure-rhel8-2.2-198.noarch.rpm",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20220504/rhui-azure-rhel8-2.2-198.noarch.rpm",
         "checksum": "sha256:10e429e047cea577ade1d52422a39af6349b4427b6aba8865dc4eba169c142ce"
       }
     ]

--- a/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
@@ -2826,15 +2826,23 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-nouveau.conf",
+              "filename": "blacklist-amdgpu.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "nouveau"
-                },
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "lbm-nouveau"
+                  "modulename": "intel_cstate"
                 }
               ]
             }
@@ -2854,11 +2862,15 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-skylake-edac.conf",
+              "filename": "blacklist-nouveau.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "skx_edac"
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
                 }
               ]
             }
@@ -2866,11 +2878,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-intel-cstate.conf",
+              "filename": "blacklist-skylake-edac.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "intel_cstate"
+                  "modulename": "skx_edac"
                 }
               ]
             }

--- a/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
@@ -2826,15 +2826,23 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-nouveau.conf",
+              "filename": "blacklist-amdgpu.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "nouveau"
-                },
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "lbm-nouveau"
+                  "modulename": "intel_cstate"
                 }
               ]
             }
@@ -2854,11 +2862,15 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-skylake-edac.conf",
+              "filename": "blacklist-nouveau.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "skx_edac"
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
                 }
               ]
             }
@@ -2866,11 +2878,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-intel-cstate.conf",
+              "filename": "blacklist-skylake-edac.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "intel_cstate"
+                  "modulename": "skx_edac"
                 }
               ]
             }

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2703,15 +2703,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-nouveau.conf",
+              "filename": "blacklist-amdgpu.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "nouveau"
-                },
-                {
-                  "command": "blacklist",
-                  "modulename": "lbm-nouveau"
+                  "modulename": "amdgpu"
                 }
               ]
             }
@@ -2724,6 +2720,22 @@
                 {
                   "command": "blacklist",
                   "modulename": "floppy"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-nouveau.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
                 }
               ]
             }

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6889,15 +6889,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-nouveau.conf",
+              "filename": "blacklist-amdgpu.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "nouveau"
-                },
-                {
-                  "command": "blacklist",
-                  "modulename": "lbm-nouveau"
+                  "modulename": "amdgpu"
                 }
               ]
             }
@@ -6910,6 +6906,22 @@
                 {
                   "command": "blacklist",
                   "modulename": "floppy"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-nouveau.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "nouveau"
+                },
+                {
+                  "command": "blacklist",
+                  "modulename": "lbm-nouveau"
                 }
               ]
             }


### PR DESCRIPTION
The `amdgpu` module causes issues on certain GPU-enabled instances on Azure and it must not be loaded by default.

Fixes: osbuild/osbuild-composer#2711

_(I also alphabetized the list of blacklisted modules because I am weird and that bothered me. If you want me to revert to the old order, just let me know.)_ 🙃

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
