### PR TITLE
dbjobqueue: use background context when closing listener

### DIFF
--- a/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
+++ b/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package main

--- a/pkg/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/pkg/jobqueue/dbjobqueue/dbjobqueue.go
@@ -182,7 +182,8 @@ func (q *DBJobQueue) listen(ctx context.Context, ready chan<- struct{}) {
 		panic(fmt.Errorf("error connecting to database: %v", err))
 	}
 	defer func() {
-		_, err := conn.Exec(ctx, sqlUnlisten)
+		// use the empty context as the listening context is already cancelled at this point
+		_, err := conn.Exec(context.Background(), sqlUnlisten)
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			logrus.Error("Error unlistening for jobs in dequeue: ", err)
 		}


### PR DESCRIPTION
Hello,

when `Close()` is called in all cases it ends up with "Error unlistening for jobs in dequeue" because in the defer block then driver performs `Exec` call with the caller's context, it is already done.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
