### PR TITLE
osbuild-service-maintenance:  vacuum  analyze after update

### DIFF
--- a/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
+++ b/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
@@ -74,7 +74,7 @@ func setFinishedAt(t *testing.T, q *dbjobqueue.DBJobQueue, id uuid.UUID, finishe
 	started := finished.Add(-time.Second)
 	queued := started.Add(-time.Second)
 
-	_, err = conn.Exec(context.Background(), "UPDATE jobs SET queued_at = $1, started_at = $2, finished_at = $3 WHERE id = $4", queued, started, finished, id)
+	_, err = conn.Exec(context.Background(), "UPDATE jobs SET queued_at = $1, started_at = $2, finished_at = $3, result = '{\"result\": \"success\" }' WHERE id = $4", queued, started, finished, id)
 	require.NoError(t, err)
 }
 

--- a/internal/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/internal/jobqueue/dbjobqueue/dbjobqueue.go
@@ -104,7 +104,7 @@ const (
 	sqlQueryJobsUptoByType = `
                 SELECT array_agg(id), type
                 FROM jobs
-                WHERE type = ANY($1) AND finished_at < $2
+                WHERE type = ANY($1) AND finished_at < $2 AND result IS NOT NULL
                 GROUP BY type`
 	sqlDeleteJobResult = `
                 UPDATE jobs


### PR DESCRIPTION
A few notes:

1. nulling results doesn't clear disk space without vacuum full, in fact it increases disk usage of the table
2. Vacuum analyze does free up space within the table, meaning there's room for additional inserts without disk space increasing.

---

exapmle stats: https://bpa.st/raw/X6CA

