### PR TITLE
osbuild-worker: Correct cast of dnfjson error in depsolve job

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -46,7 +46,7 @@ func (impl *DepsolveJobImpl) Run(job worker.Job) error {
 	result.PackageSpecs, err = impl.depsolve(args.PackageSets, args.ModulePlatformID, args.Arch, args.Releasever)
 	if err != nil {
 		switch e := err.(type) {
-		case *dnfjson.Error:
+		case dnfjson.Error:
 			// Error originates from dnf-json
 			switch e.Kind {
 			case "DepsolveError":


### PR DESCRIPTION
This error is failing to parse correctly on the workers as a
dnfjson.Error. The old rpmmd.DNFError returned a pointer, however the
internal/dnfjson module returns the Error by value.


----

Logs:

> rpmmd error in depsolve job: DNF error occurred: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: packit" jobId=...

This error should be parsed as a dnfjson.Error, but is cast as a generic rpmmd error instead, which triggers alerts on our side.