### PR TITLE
Fedora - Use vendor instead of rpm dependencies

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,6 +5,7 @@ specfile_path: osbuild-composer.spec
 synced_files:
     - osbuild-composer.spec
     - .packit.yaml
+    - vendor/modules.txt
 
 upstream_package_name: osbuild-composer
 downstream_package_name: osbuild-composer

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
-  post-upstream-clone: bash -c "mkdir -p $HOME/rpmbuild && cp vendor/modules.txt $HOME/rpmbuild/modules.txt"
+  post-upstream-clone: bash -c "mkdir -p $HOME/build && cp vendor/modules.txt $HOME/build/modules.txt"
 
 jobs:
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
-  post-upstream-clone: bash -c "mkdir -p $HOME/build && cp vendor/modules.txt $HOME/build/modules.txt"
+  post-upstream-clone: bash -c "mkdir -p $HOME/build/SPECS && cp vendor/modules.txt $HOME/build/SPECS/go-vendor-modules.txt"
 
 jobs:
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
-  post-upstream-clone: bash -c "mkdir -p $HOME/build/SPECS && cp vendor/modules.txt $HOME/build/SPECS/go-vendor-modules.txt"
+  post-upstream-clone: bash -c "mkdir -p $HOME/build/SPECS/vendor && cp vendor/modules.txt $HOME/build/SPECS/vendor/modules.txt"
 
 jobs:
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,9 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
-  post-upstream-clone: bash -c "pwd && ls -l vendor/modules.txt"
-  create-patches: bash -c "pwd"
-  fix-spec-file: bash -c "pwd"
+  post-upstream-clone: bash -c "printenv"
 
 jobs:
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,6 @@ specfile_path: osbuild-composer.spec
 synced_files:
     - osbuild-composer.spec
     - .packit.yaml
-    - vendor/modules.txt
 
 upstream_package_name: osbuild-composer
 downstream_package_name: osbuild-composer

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
-  post-upstream-clone: bash -c "printenv"
+  post-upstream-clone: bash -c "mkdir -p $HOME/rpmbuild && cp vendor/modules.txt $HOME/rpmbuild/modules.txt"
 
 jobs:
 - job: koji_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,9 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
+  post-upstream-clone: bash -c "pwd && ls -l vendor/modules.txt"
+  create-patches: bash -c "pwd"
+  fix-spec-file: bash -c "pwd"
 
 jobs:
 - job: koji_build

--- a/Makefile
+++ b/Makefile
@@ -208,16 +208,17 @@ worker-key-pair: ca
 # ./rpmbuild, using rpmbuild's usual directory structure.
 #
 
-RPM_SPECFILE=rpmbuild/SPECS/osbuild-composer.spec
-GO_MODULES_FILE=rpmbuild/SPECS/go-vendor-modules.txt
+SPECS_DIR=rpmbuild/SPECS
+RPM_SPECFILE=$(SPECS_DIR)/osbuild-composer.spec
+GO_MODULES_FILE=$(SPECS_DIR)/vendor/modules.txt
 RPM_TARBALL=rpmbuild/SOURCES/osbuild-composer-$(COMMIT).tar.gz
 
 $(GO_MODULES_FILE):
-	mkdir -p $(CURDIR)/rpmbuild/SPECS
+	mkdir -p $(CURDIR)/$(SPECS_DIR)/vendor
 	git show HEAD:vendor/modules.txt > $(GO_MODULES_FILE)
 
 $(RPM_SPECFILE):
-	mkdir -p $(CURDIR)/rpmbuild/SPECS
+	mkdir -p $(CURDIR)/$(SPECS_DIR)
 	git show HEAD:osbuild-composer.spec > $(RPM_SPECFILE)
 
 $(RPM_TARBALL):

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,12 @@ worker-key-pair: ca
 #
 
 RPM_SPECFILE=rpmbuild/SPECS/osbuild-composer.spec
+GO_MODULES_FILE=rpmbuild/SPECS/go-vendor-modules.txt
 RPM_TARBALL=rpmbuild/SOURCES/osbuild-composer-$(COMMIT).tar.gz
+
+$(GO_MODULES_FILE):
+	mkdir -p $(CURDIR)/rpmbuild/SPECS
+	git show HEAD:vendor/modules.txt > $(GO_MODULES_FILE)
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
@@ -220,7 +225,7 @@ $(RPM_TARBALL):
 	git archive --prefix=osbuild-composer-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
 
 .PHONY: srpm
-srpm: $(RPM_SPECFILE) $(RPM_TARBALL)
+srpm: $(RPM_SPECFILE) $(GO_MODULES_FILE) $(RPM_TARBALL)
 	rpmbuild -bs \
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		--define "commit $(COMMIT)" \
@@ -228,7 +233,7 @@ srpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 		$(RPM_SPECFILE)
 
 .PHONY: rpm
-rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
+rpm: $(RPM_SPECFILE) $(GO_MODULES_FILE) $(RPM_TARBALL)
 	rpmbuild -bb \
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		--define "commit $(COMMIT)" \
@@ -236,7 +241,7 @@ rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 		$(RPM_SPECFILE)
 
 .PHONY: scratch
-scratch: $(RPM_SPECFILE) $(RPM_TARBALL)
+scratch: $(RPM_SPECFILE) $(GO_MODULES_FILE) $(RPM_TARBALL)
 	rpmbuild -bb \
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		--define "commit $(COMMIT)" \

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_builddir}/vendor/modules.txt"))
+process_file("vendor/modules.txt")
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file("vendor/modules.txt")
+process_file(rpm.expand("%{_topdir}/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -69,6 +69,7 @@ local function find_file()
     local files = {
         rpm.expand("%{_specdir}/go-vendor-modules.txt"),
         rpm.expand("%{_specdir}/vendor/modules.txt"),
+        rpm.expand("%{_sourcedir}/vendor/modules.txt"),
         "vendor/modules.txt"
     }
     for index, file in ipairs(files) do

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,22 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_specdir}/go-vendor-modules.txt"))
+local function find_file()
+    local files = {
+        rpm.expand("%{_specdir}/go-vendor-modules.txt"),
+        "vendor/modules.txt"
+    }
+    for index, file in ipairs(files) do
+        local f = io.open(file, "r")
+        if f ~= nil then
+            io.close(f)
+            return file
+        end
+    end
+    return ""
+end
+
+process_file(find_file())
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_topdir}/vendor/modules.txt"))
+process_file(rpm.expand("%{buildroot}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_topdir}/modules.txt"))
+process_file(rpm.expand("%{_specdir}/go-vendor-modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -67,10 +67,7 @@ end
 
 local function find_file()
     local files = {
-        rpm.expand("%{_specdir}/go-vendor-modules.txt"),
         rpm.expand("%{_specdir}/vendor/modules.txt"),
-        rpm.expand("%{_sourcedir}/vendor/modules.txt"),
-        "vendor/modules.txt"
     }
     for index, file in ipairs(files) do
         local f = io.open(file, "r")

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -68,6 +68,7 @@ end
 local function find_file()
     local files = {
         rpm.expand("%{_specdir}/go-vendor-modules.txt"),
+        rpm.expand("%{_specdir}/vendor/modules.txt"),
         "vendor/modules.txt"
     }
     for index, file in ipairs(files) do

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -68,6 +68,7 @@ end
 local function find_file()
     local files = {
         rpm.expand("%{_specdir}/vendor/modules.txt"),
+        rpm.expand("%{_specdir}/../SOURCES/vendor/modules.txt"),
         "vendor/modules.txt"
     }
     for index, file in ipairs(files) do

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{buildroot}/vendor/modules.txt"))
+process_file(rpm.expand("%{_srcdir}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -42,34 +42,31 @@ BuildRequires:  make
 %if 0%{?fedora}
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  git
-BuildRequires:  golang(github.com/aws/aws-sdk-go)
-BuildRequires:  golang(github.com/Azure/azure-sdk-for-go)
-BuildRequires:  golang(github.com/Azure/azure-storage-blob-go/azblob)
-BuildRequires:  golang(github.com/BurntSushi/toml)
-BuildRequires:  golang(github.com/coreos/go-semver/semver)
-BuildRequires:  golang(github.com/coreos/go-systemd/activation)
-BuildRequires:  golang(github.com/deepmap/oapi-codegen/pkg/codegen)
-BuildRequires:  golang(github.com/go-chi/chi)
-BuildRequires:  golang(github.com/golang-jwt/jwt/v4)
-BuildRequires:  golang(github.com/google/uuid)
-BuildRequires:  golang(github.com/hashicorp/go-retryablehttp)
-BuildRequires:  golang(github.com/jackc/pgx/v4)
-BuildRequires:  golang(github.com/julienschmidt/httprouter)
-BuildRequires:  golang(github.com/getkin/kin-openapi/openapi3)
-BuildRequires:  golang(github.com/kolo/xmlrpc)
-BuildRequires:  golang(github.com/labstack/echo/v4)
-BuildRequires:  golang(github.com/gobwas/glob)
-BuildRequires:  golang(github.com/google/go-cmp/cmp)
-BuildRequires:  golang(github.com/gophercloud/gophercloud)
-BuildRequires:  golang(github.com/prometheus/client_golang/prometheus/promhttp)
-BuildRequires:  golang(github.com/openshift-online/ocm-sdk-go)
-BuildRequires:  golang(github.com/segmentio/ksuid)
-BuildRequires:  golang(github.com/stretchr/testify/assert)
-BuildRequires:  golang(github.com/ubccr/kerby)
-BuildRequires:  golang(github.com/vmware/govmomi)
-BuildRequires:  golang(github.com/oracle/oci-go-sdk/v54)
-BuildRequires:  golang(cloud.google.com/go)
-BuildRequires:  golang(gopkg.in/ini.v1)
+%{lua:
+local function starts_with(s, subs)
+    return string.sub(s, 0, string.len(subs)) == subs
+end
+
+local function split_line(s, delimiter)
+    result = {};
+    for match in (s..delimiter):gmatch("(.-)"..delimiter) do
+        table.insert(result, match);
+    end
+    return result;
+end
+
+local function process_file(file)
+    for line in io.lines(file) do
+        if starts_with(line, "# ") then
+            module_version = split_line(string.sub(line, 3, string.len(line)), " ")
+            module_version[2] = string.gsub(module_version[2], "-", "_")
+            print("Provides: bundled(golang("..module_version[1]..")) = "..module_version[2].."\n")
+        end
+    end
+end
+
+process_file("vendor/modules.txt")
+}
 %endif
 
 Requires: %{name}-core = %{version}-%{release}
@@ -99,7 +96,7 @@ Obsoletes: osbuild-composer-koji <= 23
 %if 0%{?rhel}
 %forgeautosetup -p1
 %else
-%goprep
+%goprep -k
 %endif
 
 %build

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{buildroot}/vendor/modules.txt"))
+process_file(rpm.expand("%{_topdir}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_builddir}/vendor/modules.txt"))
+process_file(rpm.expand("%{_srcdir}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_srcdir}/vendor/modules.txt"))
+process_file(rpm.expand("%{buildroot}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -68,6 +68,7 @@ end
 local function find_file()
     local files = {
         rpm.expand("%{_specdir}/vendor/modules.txt"),
+        "vendor/modules.txt"
     }
     for index, file in ipairs(files) do
         local f = io.open(file, "r")

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file("vendor/modules.txt")
+process_file(rpm.expand("%{_builddir}/vendor/modules.txt"))
 }
 %endif
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -65,7 +65,7 @@ local function process_file(file)
     end
 end
 
-process_file(rpm.expand("%{_srcdir}/vendor/modules.txt"))
+process_file(rpm.expand("%{_builddir}/vendor/modules.txt"))
 }
 %endif
 


### PR DESCRIPTION
Remove all Go BuildRequires dependecies
Add '-k' to goprep to preserve the vendor directory
Generate 'Provides: bundled' lines by processing vendor/modules.txt in lua

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>