### PR TITLE
Consolidate Koji target options values meaning

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -748,7 +748,8 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 					logWithId.Warnf("[Koji] logout failed: %v", err)
 				}
 			}()
-			file, err := os.Open(path.Join(outputDirectory, exportPath, args.ImageName))
+
+			file, err := os.Open(path.Join(outputDirectory, exportPath, options.Filename))
 			if err != nil {
 				osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorKojiBuild, fmt.Sprintf("failed to open the image for reading: %v", err))
 				return nil
@@ -756,7 +757,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			defer file.Close()
 
 			logWithId.Info("[Koji] ⬆ Uploading the image")
-			imageHash, imageSize, err := kojiAPI.Upload(file, options.UploadDirectory, options.Filename)
+			imageHash, imageSize, err := kojiAPI.Upload(file, options.UploadDirectory, args.Targets[0].ImageName)
 			if err != nil {
 				osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, err.Error())
 				return nil

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -177,18 +177,21 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 			ir.arch.Name(),
 			splitExtension(ir.imageType.Filename()),
 		)
+
+		kojiTarget := target.NewKojiTarget(&target.KojiTargetOptions{
+			Server:          server,
+			UploadDirectory: kojiDirectory,
+			Filename:        ir.imageType.Filename(),
+		})
+		kojiTarget.ImageName = kojiFilename
+
 		buildID, err := s.workers.EnqueueOSBuildAsDependency(ir.arch.Name(), &worker.OSBuildJob{
-			ImageName: ir.imageType.Filename(),
-			Exports:   ir.imageType.Exports(),
+			Exports: ir.imageType.Exports(),
 			PipelineNames: &worker.PipelineNames{
 				Build:   ir.imageType.BuildPipelines(),
 				Payload: ir.imageType.PayloadPipelines(),
 			},
-			Targets: []*target.Target{target.NewKojiTarget(&target.KojiTargetOptions{
-				Server:          server,
-				UploadDirectory: kojiDirectory,
-				Filename:        kojiFilename,
-			})},
+			Targets:            []*target.Target{kojiTarget},
 			ManifestDynArgsIdx: common.IntToPtr(1),
 		}, []uuid.UUID{initID, manifestJobID}, channel)
 		if err != nil {

--- a/internal/target/koji_target.go
+++ b/internal/target/koji_target.go
@@ -1,6 +1,7 @@
 package target
 
 type KojiTargetOptions struct {
+	// Filename of the image as produced by osbuild for a given export
 	Filename        string `json:"filename"`
 	UploadDirectory string `json:"upload_directory"`
 	Server          string `json:"server"`

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -794,11 +793,8 @@ func (h *apiHandlers) UploadJobArtifact(ctx echo.Context, tokenstr string, name 
 	request := ctx.Request()
 
 	if h.server.config.ArtifactsDir == "" {
-		_, err := io.Copy(ioutil.Discard, request.Body)
-		if err != nil {
-			return api.HTTPErrorWithInternal(api.ErrorDiscardingArtifact, err)
-		}
-		return ctx.NoContent(http.StatusOK)
+		// indicate to the worker that the server is not accepting any artifacts
+		return ctx.NoContent(http.StatusBadRequest)
 	}
 
 	f, err := os.Create(path.Join(h.server.config.ArtifactsDir, "tmp", token.String(), name))


### PR DESCRIPTION
When the Koji target support was added to the osbuild job, based on the osbuild-koji job, the meaning of target option values got messed up.

This PR is ensuring, that the Koji target interprets values set in target options in the same way as any other target.

In addition, ensure that the worker server returns "Bad Request" if the worker tries to upload an artifact to it, but the server is configured to not accept any artifacts from workers.

Please not that this change is backward incompatible. This was done intentionally after a discussion with @ondrejbudai, because the Koji composes via Cloud API are currently not used anywhere in production.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
