### PR TITLE
Fedora - Use vendor instead of rpm dependencies

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,7 @@ upstream_tag_template: v{version}
 srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
+  post-upstream-clone: "./tools/rpm_spec_add_provides_bundle.sh"
 
 jobs:
 - job: koji_build

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ RPM_TARBALL=rpmbuild/SOURCES/osbuild-composer-$(COMMIT).tar.gz
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
 	git show HEAD:osbuild-composer.spec > $(RPM_SPECFILE)
+	./tools/rpm_spec_add_provides_bundle.sh $(RPM_SPECFILE)
 
 $(RPM_TARBALL):
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -42,34 +42,9 @@ BuildRequires:  make
 %if 0%{?fedora}
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  git
-BuildRequires:  golang(github.com/aws/aws-sdk-go)
-BuildRequires:  golang(github.com/Azure/azure-sdk-for-go)
-BuildRequires:  golang(github.com/Azure/azure-storage-blob-go/azblob)
-BuildRequires:  golang(github.com/BurntSushi/toml)
-BuildRequires:  golang(github.com/coreos/go-semver/semver)
-BuildRequires:  golang(github.com/coreos/go-systemd/activation)
-BuildRequires:  golang(github.com/deepmap/oapi-codegen/pkg/codegen)
-BuildRequires:  golang(github.com/go-chi/chi)
-BuildRequires:  golang(github.com/golang-jwt/jwt/v4)
-BuildRequires:  golang(github.com/google/uuid)
-BuildRequires:  golang(github.com/hashicorp/go-retryablehttp)
-BuildRequires:  golang(github.com/jackc/pgx/v4)
-BuildRequires:  golang(github.com/julienschmidt/httprouter)
-BuildRequires:  golang(github.com/getkin/kin-openapi/openapi3)
-BuildRequires:  golang(github.com/kolo/xmlrpc)
-BuildRequires:  golang(github.com/labstack/echo/v4)
-BuildRequires:  golang(github.com/gobwas/glob)
-BuildRequires:  golang(github.com/google/go-cmp/cmp)
-BuildRequires:  golang(github.com/gophercloud/gophercloud)
-BuildRequires:  golang(github.com/prometheus/client_golang/prometheus/promhttp)
-BuildRequires:  golang(github.com/openshift-online/ocm-sdk-go)
-BuildRequires:  golang(github.com/segmentio/ksuid)
-BuildRequires:  golang(github.com/stretchr/testify/assert)
-BuildRequires:  golang(github.com/ubccr/kerby)
-BuildRequires:  golang(github.com/vmware/govmomi)
-BuildRequires:  golang(github.com/oracle/oci-go-sdk/v54)
-BuildRequires:  golang(cloud.google.com/go)
-BuildRequires:  golang(gopkg.in/ini.v1)
+# DO NOT REMOVE the BUNDLE_START and BUNDLE_END markers as they are used by 'tools/rpm_spec_add_provides_bundle.sh' to generate the Provides: bundled list
+# BUNDLE_START
+# BUNDLE_END
 %endif
 
 Requires: %{name}-core = %{version}-%{release}
@@ -99,7 +74,7 @@ Obsoletes: osbuild-composer-koji <= 23
 %if 0%{?rhel}
 %forgeautosetup -p1
 %else
-%goprep
+%goprep -k
 %endif
 
 %build

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -103,6 +103,7 @@ template_override
 
 greenprint "🔧 Building source RPM"
 git archive --prefix "osbuild-composer-${COMMIT}/" --output "osbuild-composer-${COMMIT}.tar.gz" HEAD
+./tools/rpm_spec_add_provides_bundle.sh
 sudo mock -r "$MOCK_CONFIG" --buildsrpm \
   --define "commit ${COMMIT}" \
   --spec ./osbuild-composer.spec \

--- a/tools/rpm_spec_add_provides_bundle.sh
+++ b/tools/rpm_spec_add_provides_bundle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+SPEC_FILE=${1:-"osbuild-composer.spec"}
+
+# Save the list of bundled packages into a file
+WORKDIR=$(mktemp -d)
+BUNDLES_FILE=${WORKDIR}/bundles.txt
+grep "^# " vendor/modules.txt | awk '{print "Provides: bundled(golang("$2")) = "$3}' | sort --ignore-case | uniq | sed -e 's/-/_/g' > "${BUNDLES_FILE}"
+
+# Remove the current bundle lines
+sed -i '/^# BUNDLE_START/,/^# BUNDLE_END/{//p;d;}' "${SPEC_FILE}"
+# Add the new bundle lines
+sed -i "/^# BUNDLE_START/r ${BUNDLES_FILE}" "${SPEC_FILE}"


### PR DESCRIPTION
## RPM Spec
Remove all Go dependecies
Add Start and End marker comments for bundling information
Add '-k' to goprep to preserve the vendor directory
    
## tools
Add script to update the RPM spec file to generate the indication lines based on vendor/modules.txt
    
## Packit
Run the new script as a post-upstream-clone hook
    
## Makefile
Run the new script on the generated spec file before generating the RPM

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
