### PR TITLE
Remove vhd image type from RHEL 7

### DIFF
--- a/internal/distro/rhel7/azure.go
+++ b/internal/distro/rhel7/azure.go
@@ -11,33 +11,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
-func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			// Defaults
-			"@Core",
-			"langpacks-en",
-
-			// From the lorax kickstart
-			"chrony",
-			"cloud-init",
-			"cloud-utils-growpart",
-			"gdisk",
-			"net-tools",
-			"python3",
-			"selinux-policy-targeted",
-			"WALinuxAgent",
-
-			// removed from defaults but required to boot in azure
-			"dhcp-client",
-		},
-		Exclude: []string{
-			"dracut-config-rescue",
-			"rng-tools",
-		},
-	}.Append(bootPackageSet(t))
-}
-
 func azureRhuiCommonPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
@@ -236,34 +209,6 @@ func vhdPipelines(compress bool) pipelinesFunc {
 	}
 }
 
-var vhdImgType = imageType{
-	name:     "vhd",
-	filename: "disk.vhd",
-	mimeType: "application/x-vhd",
-	packageSets: map[string]packageSetFunc{
-		buildPkgsKey: distroBuildPackageSet,
-		osPkgsKey:    vhdCommonPackageSet,
-	},
-	packageSetChains: map[string][]string{
-		osPkgsKey: {osPkgsKey, blueprintPkgsKey},
-	},
-	defaultImageConfig: &distro.ImageConfig{
-		EnabledServices: []string{
-			"sshd",
-			"waagent",
-		},
-		DefaultTarget: "multi-user.target",
-	},
-	kernelOptions:       "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y",
-	bootable:            true,
-	defaultSize:         4 * GigaByte,
-	pipelines:           vhdPipelines(false),
-	buildPipelines:      []string{"build"},
-	payloadPipelines:    []string{"os", "image", "vpc"},
-	exports:             []string{"vpc"},
-	basePartitionTables: defaultBasePartitionTables,
-}
-
 var azureRhuiImgType = imageType{
 	name:     "azure-rhui",
 	filename: "disk.vhd.xz",
@@ -441,7 +386,7 @@ var azureRhuiImgType = imageType{
 		},
 		DefaultTarget: "multi-user.target",
 	},
-	kernelOptions:       vhdImgType.kernelOptions,
+	kernelOptions:       "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y",
 	bootable:            true,
 	defaultSize:         68719476736,
 	pipelines:           vhdPipelines(true),

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -251,11 +251,6 @@ func (t *imageType) OSTreeRef() string {
 }
 
 func (t *imageType) Size(size uint64) uint64 {
-	const MegaByte = 1024 * 1024
-	// Microsoft Azure requires vhd images to be rounded up to the nearest MB
-	if t.name == "vhd" && size%MegaByte != 0 {
-		size = (size/MegaByte + 1) * MegaByte
-	}
 	if size == 0 {
 		size = t.defaultSize
 	}
@@ -493,7 +488,6 @@ func newDistro(distroName string) distro.Distro {
 
 	x86_64.addImageTypes(
 		qcow2ImgType,
-		vhdImgType,
 		azureRhuiImgType,
 	)
 

--- a/internal/distro/rhel7/distro_test.go
+++ b/internal/distro/rhel7/distro_test.go
@@ -47,14 +47,6 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
-			name: "vhd",
-			args: args{"vhd"},
-			want: wantResult{
-				filename: "disk.vhd",
-				mimeType: "application/x-vhd",
-			},
-		},
-		{
 			name: "azure-rhui",
 			args: args{"azure-rhui"},
 			want: wantResult{
@@ -144,7 +136,6 @@ func TestImageType_Name(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
-				"vhd",
 				"azure-rhui",
 			},
 		},
@@ -203,7 +194,6 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 			arch: "x86_64",
 			imgNames: []string{
 				"qcow2",
-				"vhd",
 				"azure-rhui",
 			},
 		},


### PR DESCRIPTION
1. Broken: specifies packages that aren't available in the repositories (langpacks-en and dhcp-client).
2. Not needed.
