### PR TITLE
dnf-json: fix depsolve error handling

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -212,9 +212,13 @@ def solve(request, cache_dir):
             }
         except dnf.exceptions.DepsolveError as e:
             printe("error depsolve")
+            # collect list of packages for error
+            pkgs = []
+            for t in transactions:
+                pkgs.extend(t["package-specs"])
             return None, {
                 "kind": "DepsolveError",
-                "reason": f"There was a problem depsolving {arguments['package-specs']}: {e}"
+                "reason": f"There was a problem depsolving {', '.join(pkgs)}: {e}"
             }
         except dnf.exceptions.RepoError as e:
             return None, {


### PR DESCRIPTION
When a DepsolveError exception occurs, the error message would print the packages in the request.  When the request arguments changed, the error message handling wasn't updated and would fail to produce the correct error message.

Compile a list of packages from all transactions and print them in the error message as a comma-separated list.

## Output
Before:
```
$ composer-cli blueprints show conflict
name = "conflict"
description = ""
version = "0.0.1"
modules = []
groups = []
distro = ""

[[packages]]
name = "mysql"

[[packages]]
name = "mariadb"

$ composer-cli compose start conflict qcow2
ERROR: DepsolveError: DNF error occurred: InternalError: Failed to unmarshal dnf-json error output "": unexpected end of JSON input
code
```

After:
```
$ composer-cli compose start conflict qcow2
ERROR: DepsolveError: DNF error occurred: DepsolveError: There was a problem depsolving authselect-compat, chrony, cloud-init, cloud-utils-growpart, cockpit-system, cockpit-ws, dnf-utils, dosfstools, nfs-utils, oddjob, oddjob-mkhomedir, psmisc, python3-jsonschema, qemu-guest-agent, redhat-release, redhat-release-eula, rsync, tar, tcpdump, dracut-config-generic, grub2-pc, dracut-config-generic, efibootmgr, grub2-efi-x64, shim-x64, audit, basesystem, bash, coreutils, cronie, crypto-policies, crypto-policies-scripts, curl, dnf, yum, e2fsprogs, filesystem, glibc, grubby, hostname, iproute, iproute-tc, iputils, kbd, kexec-tools, less, logrotate, man-db, ncurses, openssh-clients, openssh-server, p11-kit, parted, passwd, policycoreutils, procps-ng, rootfiles, rpm, rpm-plugin-audit, rsyslog, selinux-policy-targeted, setup, shadow-utils, sssd-common, sssd-kcm, sudo, systemd, tuned, util-linux, vim-minimal, xfsprogs, authselect, prefixdevname, dnf-plugins-core, NetworkManager, NetworkManager-team, NetworkManager-tui, libsysfs, linux-firmware, lshw, lsscsi, kernel-tools, sg3_utils, sg3_utils-libs, python3-libselinux, irqbalance, microcode_ctl, kernel, mysql, mariadb, kernel:
 Problem: package mariadb-3:10.5.16-2.el9.x86_64 conflicts with mysql provided by mysql-8.0.28-1.el9.x86_64
  - package mysql-8.0.28-1.el9.x86_64 conflicts with mariadb provided by mariadb-3:10.5.16-2.el9.x86_64
  - conflicting requests
```