### PR TITLE
test/cases: remove test skip

### DIFF
--- a/test/cases/image_tests.sh
+++ b/test/cases/image_tests.sh
@@ -49,10 +49,7 @@ get_test_cases () {
     TEST_CASE_SELECTOR="${DISTRO_CODE/-/_}-${ARCH}"
     pushd $IMAGE_TEST_CASES_PATH > /dev/null
         ALL_CASES=$(ls "$TEST_CASE_SELECTOR"*.json)
-        SKIP_OSTREE=$(jq -r 'if (.manifest.sources."org.osbuild.ostree" != null) then input_filename else empty end' "${TEST_CASE_SELECTOR}"*.json)
-        # temporarily skip azure-rhui image, see COMPOSER-1397 for details
-        SKIP_TMP=$(grep azure_rhui <<< "$ALL_CASES")
-        SKIP_CASES=("${SKIP_OSTREE[@]}" "$SKIP_TMP")
+        SKIP_CASES=$(jq -r 'if (.manifest.sources."org.osbuild.ostree" != null) then input_filename else empty end' "${TEST_CASE_SELECTOR}"*.json)
         mapfile -t TEST_CASES < <(grep -vxFf <(printf '%s\n' "${SKIP_CASES[@]}") <(printf '%s\n' "${ALL_CASES[@]}"))
         echo "${TEST_CASES[@]}"
     popd > /dev/null


### PR DESCRIPTION
COMPOSER-1397 temporarily skipped azure-rhui image. Now that we test on
rhel 8.7, this skip can be removed.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/