### PR TITLE
worker: clean up the config and add tests

### DIFF
--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/sirupsen/logrus"
+)
+
+type workerConfig struct {
+	Composer *struct {
+		Proxy string `toml:"proxy"`
+	} `toml:"composer"`
+	Koji map[string]struct {
+		Kerberos *struct {
+			Principal string `toml:"principal"`
+			KeyTab    string `toml:"keytab"`
+		} `toml:"kerberos,omitempty"`
+		RelaxTimeoutFactor uint `toml:"relax_timeout_factor"`
+	} `toml:"koji"`
+	GCP *struct {
+		Credentials string `toml:"credentials"`
+	} `toml:"gcp"`
+	Azure *struct {
+		Credentials string `toml:"credentials"`
+	} `toml:"azure"`
+	AWS *struct {
+		Credentials string `toml:"credentials"`
+		Bucket      string `toml:"bucket"`
+	} `toml:"aws"`
+	GenericS3 *struct {
+		Credentials         string `toml:"credentials"`
+		Endpoint            string `toml:"endpoint"`
+		Region              string `toml:"region"`
+		Bucket              string `toml:"bucket"`
+		CABundle            string `toml:"ca_bundle"`
+		SkipSSLVerification bool   `toml:"skip_ssl_verification"`
+	} `toml:"generic_s3"`
+	Authentication *struct {
+		OAuthURL         string `toml:"oauth_url"`
+		OfflineTokenPath string `toml:"offline_token"`
+		ClientId         string `toml:"client_id"`
+		ClientSecretPath string `toml:"client_secret"`
+	} `toml:"authentication"`
+	// default value: /api/worker/v1
+	BasePath string `toml:"base_path"`
+	DNFJson  string `toml:"dnf-json"`
+}
+
+func parseConfig(file string) (*workerConfig, error) {
+	var config workerConfig
+	_, err := toml.DecodeFile(file, &config)
+	if err != nil {
+		// Return error only when we failed to decode the file.
+		// A non-existing config isn't an error, use defaults in this case.
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		logrus.Info("Configuration file not found, using defaults")
+	}
+	if config.BasePath == "" {
+		config.BasePath = "/api/worker/v1"
+	}
+
+	return &config, nil
+}

--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -7,41 +7,57 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type composerConfig struct {
+	Proxy string `toml:"proxy"`
+}
+
+type kerberosConfig struct {
+	Principal string `toml:"principal"`
+	KeyTab    string `toml:"keytab"`
+}
+
+type kojiServerConfig struct {
+	Kerberos           *kerberosConfig `toml:"kerberos,omitempty"`
+	RelaxTimeoutFactor uint            `toml:"relax_timeout_factor"`
+}
+
+type gcpConfig struct {
+	Credentials string `toml:"credentials"`
+}
+
+type azureConfig struct {
+	Credentials string `toml:"credentials"`
+}
+
+type awsConfig struct {
+	Credentials string `toml:"credentials"`
+	Bucket      string `toml:"bucket"`
+}
+
+type genericS3Config struct {
+	Credentials         string `toml:"credentials"`
+	Endpoint            string `toml:"endpoint"`
+	Region              string `toml:"region"`
+	Bucket              string `toml:"bucket"`
+	CABundle            string `toml:"ca_bundle"`
+	SkipSSLVerification bool   `toml:"skip_ssl_verification"`
+}
+
+type authenticationConfig struct {
+	OAuthURL         string `toml:"oauth_url"`
+	OfflineTokenPath string `toml:"offline_token"`
+	ClientId         string `toml:"client_id"`
+	ClientSecretPath string `toml:"client_secret"`
+}
+
 type workerConfig struct {
-	Composer *struct {
-		Proxy string `toml:"proxy"`
-	} `toml:"composer"`
-	Koji map[string]struct {
-		Kerberos *struct {
-			Principal string `toml:"principal"`
-			KeyTab    string `toml:"keytab"`
-		} `toml:"kerberos,omitempty"`
-		RelaxTimeoutFactor uint `toml:"relax_timeout_factor"`
-	} `toml:"koji"`
-	GCP *struct {
-		Credentials string `toml:"credentials"`
-	} `toml:"gcp"`
-	Azure *struct {
-		Credentials string `toml:"credentials"`
-	} `toml:"azure"`
-	AWS *struct {
-		Credentials string `toml:"credentials"`
-		Bucket      string `toml:"bucket"`
-	} `toml:"aws"`
-	GenericS3 *struct {
-		Credentials         string `toml:"credentials"`
-		Endpoint            string `toml:"endpoint"`
-		Region              string `toml:"region"`
-		Bucket              string `toml:"bucket"`
-		CABundle            string `toml:"ca_bundle"`
-		SkipSSLVerification bool   `toml:"skip_ssl_verification"`
-	} `toml:"generic_s3"`
-	Authentication *struct {
-		OAuthURL         string `toml:"oauth_url"`
-		OfflineTokenPath string `toml:"offline_token"`
-		ClientId         string `toml:"client_id"`
-		ClientSecretPath string `toml:"client_secret"`
-	} `toml:"authentication"`
+	Composer       *composerConfig             `toml:"composer"`
+	Koji           map[string]kojiServerConfig `toml:"koji"`
+	GCP            *gcpConfig                  `toml:"gcp"`
+	Azure          *azureConfig                `toml:"azure"`
+	AWS            *awsConfig                  `toml:"aws"`
+	GenericS3      *genericS3Config            `toml:"generic_s3"`
+	Authentication *authenticationConfig       `toml:"authentication"`
 	// default value: /api/worker/v1
 	BasePath string `toml:"base_path"`
 	DNFJson  string `toml:"dnf-json"`

--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -64,7 +64,11 @@ type workerConfig struct {
 }
 
 func parseConfig(file string) (*workerConfig, error) {
-	var config workerConfig
+	// set defaults
+	config := workerConfig{
+		BasePath: "/api/worker/v1",
+	}
+
 	_, err := toml.DecodeFile(file, &config)
 	if err != nil {
 		// Return error only when we failed to decode the file.
@@ -74,9 +78,6 @@ func parseConfig(file string) (*workerConfig, error) {
 		}
 
 		logrus.Info("Configuration file not found, using defaults")
-	}
-	if config.BasePath == "" {
-		config.BasePath = "/api/worker/v1"
 	}
 
 	return &config, nil

--- a/cmd/osbuild-worker/config_test.go
+++ b/cmd/osbuild-worker/config_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   *workerConfig
+	}{
+		{
+			name: "basic",
+			config: `
+# comment
+base_path = "/api/image-builder-worker/v1"
+dnf-json = "/usr/libexec/dnf-json"
+
+[composer]
+proxy = "http://proxy.example.com"
+
+[koji."kojihub.example.com"]
+relax_timeout_factor = 5
+
+[koji."kojihub.example.com".kerberos]
+principal = "toucan-automation@EXAMPLE.COM"
+keytab = "/etc/osbuild-worker/client.keytab"
+
+[koji."kojihub.stage.example.com"]
+relax_timeout_factor = 42
+
+[koji."kojihub.stage.example.com".kerberos]
+principal = "toucan-automation-stage@EXAMPLE.COM"
+keytab = "/etc/osbuild-worker/client-stage.keytab"
+
+[gcp]
+credentials = "/etc/osbuild-worker/gcp-creds"
+
+[azure]
+credentials = "/etc/osbuild-worker/azure-creds"
+
+[aws]
+credentials = "/etc/osbuild-worker/aws-creds"
+bucket = "buckethead"
+
+[generic_s3]
+credentials = "/etc/osbuild-worker/s3-creds"
+endpoint = "http://s3.example.com"
+region = "us-east-1"
+bucket = "slash"
+ca_bundle = "/etc/osbuild-worker/s3-ca-bundle"
+skip_ssl_verification = true
+
+[authentication]
+oauth_url = "https://example.com/token"
+client_id = "toucan"
+client_secret = "/etc/osbuild-worker/client_secret"
+offline_token = "/etc/osbuild-worker/offline_token"
+`,
+			want: &workerConfig{
+				BasePath: "/api/image-builder-worker/v1",
+				DNFJson:  "/usr/libexec/dnf-json",
+				Composer: &composerConfig{
+					Proxy: "http://proxy.example.com",
+				},
+				Koji: map[string]kojiServerConfig{
+					"kojihub.example.com": {
+						Kerberos: &kerberosConfig{
+							Principal: "toucan-automation@EXAMPLE.COM",
+							KeyTab:    "/etc/osbuild-worker/client.keytab",
+						},
+						RelaxTimeoutFactor: 5,
+					},
+					"kojihub.stage.example.com": {
+						Kerberos: &kerberosConfig{
+							Principal: "toucan-automation-stage@EXAMPLE.COM",
+							KeyTab:    "/etc/osbuild-worker/client-stage.keytab",
+						},
+						RelaxTimeoutFactor: 42,
+					},
+				},
+				GCP: &gcpConfig{
+					Credentials: "/etc/osbuild-worker/gcp-creds",
+				},
+				Azure: &azureConfig{
+					Credentials: "/etc/osbuild-worker/azure-creds",
+				},
+				AWS: &awsConfig{
+					Credentials: "/etc/osbuild-worker/aws-creds",
+					Bucket:      "buckethead",
+				},
+				GenericS3: &genericS3Config{
+					Credentials:         "/etc/osbuild-worker/s3-creds",
+					Endpoint:            "http://s3.example.com",
+					Region:              "us-east-1",
+					Bucket:              "slash",
+					CABundle:            "/etc/osbuild-worker/s3-ca-bundle",
+					SkipSSLVerification: true,
+				},
+				Authentication: &authenticationConfig{
+					OAuthURL:         "https://example.com/token",
+					OfflineTokenPath: "/etc/osbuild-worker/offline_token",
+					ClientId:         "toucan",
+					ClientSecretPath: "/etc/osbuild-worker/client_secret",
+				},
+			},
+		},
+		{
+			name:   "default",
+			config: ``,
+			want: &workerConfig{
+				BasePath: "/api/worker/v1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFile := prepareConfig(t, tt.config)
+			got, err := parseConfig(configFile)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("non-existing", func(t *testing.T) {
+		got, err := parseConfig("/osbuild/b19b8798-5f76-4b09-9e56-5978df8f6cde")
+		require.NoError(t, err)
+
+		// check that the defaults are loaded
+		require.Equal(t, tests[1].want, got)
+	})
+
+	t.Run("wrong config", func(t *testing.T) {
+		configFile := prepareConfig(t, `[unclosed_section`)
+
+		_, err := parseConfig(configFile)
+		require.Error(t, err)
+	})
+}
+
+func prepareConfig(t *testing.T, config string) string {
+	dir := t.TempDir()
+	configFile := path.Join(dir, "config.toml")
+	f, err := os.Create(configFile)
+	require.NoError(t, err)
+
+	_, err = f.WriteString(config)
+	require.NoError(t, err)
+
+	require.NoError(t, f.Close())
+	return configFile
+}

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -16,8 +16,7 @@ import (
 )
 
 type KojiFinalizeJobImpl struct {
-	KojiServers        map[string]kojiServer
-	relaxTimeoutFactor uint
+	KojiServers map[string]kojiServer
 }
 
 func (impl *KojiFinalizeJobImpl) kojiImport(
@@ -26,7 +25,6 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 	buildRoots []koji.BuildRoot,
 	images []koji.Image,
 	directory, token string) error {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -38,6 +36,7 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
+	transport := koji.CreateKojiTransport(kojiServer.relaxTimeoutFactor)
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return err
@@ -58,7 +57,6 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 }
 
 func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token string) error {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -70,6 +68,7 @@ func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token stri
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
+	transport := koji.CreateKojiTransport(kojiServer.relaxTimeoutFactor)
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return err

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -16,7 +16,7 @@ import (
 )
 
 type KojiFinalizeJobImpl struct {
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]kojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -33,12 +33,12 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 		return err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return err
 	}
@@ -65,12 +65,12 @@ func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token stri
 		return err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return err
 	}

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -12,7 +12,7 @@ import (
 )
 
 type KojiInitJobImpl struct {
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]kojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -24,12 +24,12 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 		return "", 0, err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -12,12 +12,10 @@ import (
 )
 
 type KojiInitJobImpl struct {
-	KojiServers        map[string]kojiServer
-	relaxTimeoutFactor uint
+	KojiServers map[string]kojiServer
 }
 
 func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (string, uint64, error) {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -29,6 +27,7 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
+	transport := koji.CreateKojiTransport(kojiServer.relaxTimeoutFactor)
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return "", 0, err

--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -18,7 +18,7 @@ import (
 type OSBuildKojiJobImpl struct {
 	Store              string
 	Output             string
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]kojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -30,12 +30,12 @@ func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, fil
 		return "", 0, err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.creds, transport)
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -16,14 +16,12 @@ import (
 )
 
 type OSBuildKojiJobImpl struct {
-	Store              string
-	Output             string
-	KojiServers        map[string]kojiServer
-	relaxTimeoutFactor uint
+	Store       string
+	Output      string
+	KojiServers map[string]kojiServer
 }
 
 func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, filename string) (string, uint64, error) {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -31,6 +29,7 @@ func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, fil
 	}
 
 	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
+	transport := koji.CreateKojiTransport(kojiServer.relaxTimeoutFactor)
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -39,15 +39,14 @@ type S3Configuration struct {
 }
 
 type OSBuildJobImpl struct {
-	Store                  string
-	Output                 string
-	KojiServers            map[string]kojiServer
-	KojiRelaxTimeoutFactor uint
-	GCPCreds               string
-	AzureCreds             *azure.Credentials
-	AWSCreds               string
-	AWSBucket              string
-	S3Config               S3Configuration
+	Store       string
+	Output      string
+	KojiServers map[string]kojiServer
+	GCPCreds    string
+	AzureCreds  *azure.Credentials
+	AWSCreds    string
+	AWSBucket   string
+	S3Config    S3Configuration
 }
 
 // Returns an *awscloud.AWS object with the credentials of the request. If they
@@ -734,7 +733,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				return nil
 			}
 
-			kojiTransport := koji.CreateKojiTransport(impl.KojiRelaxTimeoutFactor)
+			kojiTransport := koji.CreateKojiTransport(kojiServer.relaxTimeoutFactor)
 
 			kojiAPI, err := koji.NewFromGSSAPI(options.Server, &kojiServer.creds, kojiTransport)
 			if err != nil {

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -41,7 +41,7 @@ type S3Configuration struct {
 type OSBuildJobImpl struct {
 	Store                  string
 	Output                 string
-	KojiServers            map[string]koji.GSSAPICredentials
+	KojiServers            map[string]kojiServer
 	KojiRelaxTimeoutFactor uint
 	GCPCreds               string
 	AzureCreds             *azure.Credentials
@@ -728,7 +728,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				return nil
 			}
 
-			creds, exists := impl.KojiServers[kojiServerURL.Hostname()]
+			kojiServer, exists := impl.KojiServers[kojiServerURL.Hostname()]
 			if !exists {
 				osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, fmt.Sprintf("Koji server has not been configured: %s", kojiServerURL.Hostname()))
 				return nil
@@ -736,7 +736,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 
 			kojiTransport := koji.CreateKojiTransport(impl.KojiRelaxTimeoutFactor)
 
-			kojiAPI, err := koji.NewFromGSSAPI(options.Server, &creds, kojiTransport)
+			kojiAPI, err := koji.NewFromGSSAPI(options.Server, &kojiServer.creds, kojiTransport)
 			if err != nil {
 				osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, fmt.Sprintf("failed to authenticate with Koji server %q: %v", kojiServerURL.Hostname(), err))
 				return nil

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -37,6 +37,10 @@ type connectionConfig struct {
 	ClientCertFile string
 }
 
+type kojiServer struct {
+	creds koji.GSSAPICredentials
+}
+
 // Represents the implementation of a job type as defined by the worker API.
 type JobImplementation interface {
 	Run(job worker.Job) error
@@ -272,15 +276,17 @@ func main() {
 	output := path.Join(cacheDirectory, "output")
 	_ = os.Mkdir(output, os.ModeDir)
 
-	kojiServers := make(map[string]koji.GSSAPICredentials)
-	for server, creds := range config.Koji {
-		if creds.Kerberos == nil {
+	kojiServers := make(map[string]kojiServer)
+	for server, kojiConfig := range config.Koji {
+		if kojiConfig.Kerberos == nil {
 			// For now we only support Kerberos authentication.
 			continue
 		}
-		kojiServers[server] = koji.GSSAPICredentials{
-			Principal: creds.Kerberos.Principal,
-			KeyTab:    creds.Kerberos.KeyTab,
+		kojiServers[server] = kojiServer{
+			creds: koji.GSSAPICredentials{
+				Principal: kojiConfig.Kerberos.Principal,
+				KeyTab:    kojiConfig.Kerberos.KeyTab,
+			},
 		}
 	}
 

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -215,15 +215,15 @@ func main() {
 	}
 
 	config, err := parseConfig(configFile)
-	if err == nil {
-		logrus.Info("Composer configuration:")
-		encoder := toml.NewEncoder(logrus.StandardLogger().WriterLevel(logrus.InfoLevel))
-		err := encoder.Encode(&config)
-		if err != nil {
-			logrus.Fatalf("Could not print config: %v", err)
-		}
-	} else {
+	if err != nil {
 		logrus.Fatalf("Could not load config file '%s': %v", configFile, err)
+	}
+
+	logrus.Info("Composer configuration:")
+	encoder := toml.NewEncoder(logrus.StandardLogger().WriterLevel(logrus.InfoLevel))
+	err = encoder.Encode(&config)
+	if err != nil {
+		logrus.Fatalf("Could not print config: %v", err)
 	}
 
 	cacheDirectory, ok := os.LookupEnv("CACHE_DIRECTORY")

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -198,44 +198,6 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 }
 
 func main() {
-	var config struct {
-		Composer *struct {
-			Proxy string `toml:"proxy"`
-		} `toml:"composer"`
-		Koji map[string]struct {
-			Kerberos *struct {
-				Principal string `toml:"principal"`
-				KeyTab    string `toml:"keytab"`
-			} `toml:"kerberos,omitempty"`
-			RelaxTimeoutFactor uint `toml:"relax_timeout_factor"`
-		} `toml:"koji"`
-		GCP *struct {
-			Credentials string `toml:"credentials"`
-		} `toml:"gcp"`
-		Azure *struct {
-			Credentials string `toml:"credentials"`
-		} `toml:"azure"`
-		AWS *struct {
-			Credentials string `toml:"credentials"`
-			Bucket      string `toml:"bucket"`
-		} `toml:"aws"`
-		GenericS3 *struct {
-			Credentials         string `toml:"credentials"`
-			Endpoint            string `toml:"endpoint"`
-			Region              string `toml:"region"`
-			Bucket              string `toml:"bucket"`
-			CABundle            string `toml:"ca_bundle"`
-			SkipSSLVerification bool   `toml:"skip_ssl_verification"`
-		} `toml:"generic_s3"`
-		Authentication *struct {
-			OAuthURL         string `toml:"oauth_url"`
-			OfflineTokenPath string `toml:"offline_token"`
-			ClientId         string `toml:"client_id"`
-			ClientSecretPath string `toml:"client_secret"`
-		} `toml:"authentication"`
-		BasePath string `toml:"base_path"`
-		DNFJson  string `toml:"dnf-json"`
-	}
 	var unix bool
 	flag.BoolVar(&unix, "unix", false, "Interpret 'address' as a path to a unix domain socket instead of a network address")
 
@@ -252,7 +214,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	_, err := toml.DecodeFile(configFile, &config)
+	config, err := parseConfig(configFile)
 	if err == nil {
 		logrus.Info("Composer configuration:")
 		encoder := toml.NewEncoder(logrus.StandardLogger().WriterLevel(logrus.InfoLevel))
@@ -260,12 +222,8 @@ func main() {
 		if err != nil {
 			logrus.Fatalf("Could not print config: %v", err)
 		}
-	} else if !os.IsNotExist(err) {
+	} else {
 		logrus.Fatalf("Could not load config file '%s': %v", configFile, err)
-	}
-
-	if config.BasePath == "" {
-		config.BasePath = "/api/worker/v1"
 	}
 
 	cacheDirectory, ok := os.LookupEnv("CACHE_DIRECTORY")

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -196,7 +196,7 @@ func main() {
 	var config struct {
 		Composer *struct {
 			Proxy string `toml:"proxy"`
-		}
+		} `toml:"composer"`
 		Koji map[string]struct {
 			Kerberos *struct {
 				Principal string `toml:"principal"`


### PR DESCRIPTION
Breaking changes in the config:

- `Composer` section is renamed to `composer`
- `RelaxTimeoutFactor` is now moved under `koji.URL`  and renamed to `relax_timeout_factor`
- `base_path` explicitly set to an empty string is now correctly parsed as an empty string and not as `/api/worker/v1`

This only affects our internal deployment, and I can handle all of these changes without many issues there.

Otherwise, this PR:
- changes some config keys and defaults behaviour, see above
- moves the config struct and its parsing into a separate file
- adds tests for the parsing method

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
