### PR TITLE
set a job error when a heartbeat fails & fix koji-finalize job

### DIFF
--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -230,7 +230,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 				return fmt.Errorf("error: Koji compose OSBuild job result doesn't contain exactly one target result")
 			}
 			kojiTarget := buildArgs.TargetResults[0]
-			kojiTargetOptions := kojiTarget.Options.(target.KojiTargetResultOptions)
+			kojiTargetOptions := kojiTarget.Options.(*target.KojiTargetResultOptions)
 
 			buildRoots = append(buildRoots, koji.BuildRoot{
 				ID: uint64(i),

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -27,6 +27,7 @@ const (
 	ErrorEmptyPackageSpecs    ClientErrorCode = 24
 	ErrorDNFRepoError         ClientErrorCode = 25
 	ErrorJobDependency        ClientErrorCode = 26
+	ErrorJobMissingHeartbeat  ClientErrorCode = 27
 )
 
 type ClientErrorCode int


### PR DESCRIPTION
See the individual commits.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
