### PR TITLE
image-tests: skip azure-rhui test on rhel-86

### DIFF
--- a/test/cases/image_tests.sh
+++ b/test/cases/image_tests.sh
@@ -49,7 +49,14 @@ get_test_cases () {
     TEST_CASE_SELECTOR="${DISTRO_CODE/-/_}-${ARCH}"
     pushd $IMAGE_TEST_CASES_PATH > /dev/null
         ALL_CASES=$(ls "$TEST_CASE_SELECTOR"*.json)
-        SKIP_CASES=$(jq -r 'if (.manifest.sources."org.osbuild.ostree" != null) then input_filename else empty end' "${TEST_CASE_SELECTOR}"*.json)
+        SKIP_OSTREE=$(jq -r 'if (.manifest.sources."org.osbuild.ostree" != null) then input_filename else empty end' "${TEST_CASE_SELECTOR}"*.json)
+        # skip azure_rhui test on RHEL-8.6 only
+        if [[ "$DISTRO_CODE" =~ "rhel-86" ]]; then
+            SKIP_AZURE=$(grep azure_rhui <<< "$ALL_CASES")
+            SKIP_CASES=("${SKIP_OSTREE[@]}" "$SKIP_AZURE")
+        else
+            SKIP_CASES=("${SKIP_OSTREE[@]}")
+        fi
         mapfile -t TEST_CASES < <(grep -vxFf <(printf '%s\n' "${SKIP_CASES[@]}") <(printf '%s\n' "${ALL_CASES[@]}"))
         echo "${TEST_CASES[@]}"
     popd > /dev/null


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
