### PR TITLE
packer: use 8.6 as a base for RHEL images

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -153,20 +153,6 @@
       }
     ]
   },
-  "rhel-8.4": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "86123da599efa117c0a8c079212becb54b304724"
-      }
-    }
-  },
-  "rhel-8.5": {
-    "dependencies": {
-      "osbuild": {
-        "commit": "86123da599efa117c0a8c079212becb54b304724"
-      }
-    }
-  },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -28,8 +28,8 @@ build {
   source "amazon-ebs.image_builder" {
     name = "rhel-8-x86_64"
 
-    # Use a static RHEL 8.5 Cloud Access Image.
-    source_ami = "ami-06f1e6f8b3457ae7c"
+    # Use a static RHEL 8.6 Cloud Access Image.
+    source_ami = "ami-03debf3ebf61b20cd"
     ssh_username = "ec2-user"
     instance_type = "c6a.large"
 

--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -79,7 +79,7 @@ mkdir -p "$RPMBUILD_DIR"
 aws ec2 create-key-pair --key-name "$KEY_NAME" --query 'KeyMaterial' --output text > /osbuild-composer/keypair.pem
 chmod 600 /osbuild-composer/keypair.pem
 # rhel 8.5 AMI
-aws ec2 run-instances --image-id ami-06f1e6f8b3457ae7c --instance-type c5.large --key-name "$KEY_NAME" \
+aws ec2 run-instances --image-id ami-03debf3ebf61b20cd --instance-type c5.large --key-name "$KEY_NAME" \
     --tag-specifications "ResourceType=instance,Tags=[{Key=commit,Value=$COMMIT_SHA},{Key=name,Value=rpm-builder-$COMMIT_SHA}]" \
     > ./rpminstance.json
 AWS_INSTANCE_ID=$(jq -r '.Instances[].InstanceId' "rpminstance.json")
@@ -104,7 +104,7 @@ ansible-playbook \
     -i /osbuild-composer/tools/appsre-ansible/inventory \
     /osbuild-composer/tools/appsre-ansible/rpmbuild.yml \
     -e "COMPOSER_COMMIT=$COMMIT_SHA" \
-    -e "OSBUILD_COMMIT=$(jq -r '.["rhel-8.5"].dependencies.osbuild.commit' /osbuild-composer/Schutzfile)" \
+    -e "OSBUILD_COMMIT=$(jq -r '.["rhel-8.6"].dependencies.osbuild.commit' /osbuild-composer/Schutzfile)" \
     -e "RH_ACTIVATION_KEY=$RH_ACTIVATION_KEY" \
     -e "RH_ORG_ID=$RH_ORG_ID"
 EOF
@@ -165,7 +165,7 @@ EOF
         # get distro name for schutzfile
         local schutzfile_distro="$distro"
         if [[ $schutzfile_distro == rhel-8 ]]; then
-            schutzfile_distro=rhel-8.5
+            schutzfile_distro=rhel-8.6
         fi
 
         # get osbuild_commit from schutzfile


### PR DESCRIPTION
Let's stay updated!

Also, let's remove 8.4 and 8.5 from Schutzfile, I strongly believe that it's
not used anywhere.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
