### PR TITLE
distro: don't enable fdo-client service on RHEL 8.5

### DIFF
--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -691,8 +691,14 @@ func newDistro(distroName string) distro.Distro {
 
 	// Shared Services
 	edgeServices := []string{
+		"NetworkManager.service", "firewalld.service", "sshd.service",
+	}
+
+	if !(rd.isRHEL() && versionLessThan(rd.osVersion, "8.6")) {
+		// enable fdo-client only on RHEL 8.6+ and CS8
+
 		// TODO(runcom): move fdo-client-linuxapp.service to presets?
-		"NetworkManager.service", "firewalld.service", "sshd.service", "fdo-client-linuxapp.service",
+		edgeServices = append(edgeServices, "fdo-client-linuxapp.service")
 	}
 
 	// Image Definitions

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -1945,8 +1945,7 @@
               "enabled_services": [
                 "NetworkManager.service",
                 "firewalld.service",
-                "sshd.service",
-                "fdo-client-linuxapp.service"
+                "sshd.service"
               ]
             }
           },

--- a/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
@@ -1945,8 +1945,7 @@
               "enabled_services": [
                 "NetworkManager.service",
                 "firewalld.service",
-                "sshd.service",
-                "fdo-client-linuxapp.service"
+                "sshd.service"
               ]
             }
           },

--- a/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
@@ -2024,8 +2024,7 @@
               "enabled_services": [
                 "NetworkManager.service",
                 "firewalld.service",
-                "sshd.service",
-                "fdo-client-linuxapp.service"
+                "sshd.service"
               ]
             }
           },

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
@@ -2096,8 +2096,7 @@
               "enabled_services": [
                 "NetworkManager.service",
                 "firewalld.service",
-                "sshd.service",
-                "fdo-client-linuxapp.service"
+                "sshd.service"
               ]
             }
           },

--- a/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
@@ -2014,8 +2014,7 @@
               "enabled_services": [
                 "NetworkManager.service",
                 "firewalld.service",
-                "sshd.service",
-                "fdo-client-linuxapp.service"
+                "sshd.service"
               ]
             }
           },


### PR DESCRIPTION
RHEL 8.5 doesn't have FDO and it's not installed, but we were enabling the service for it in edge.
