### PR TITLE
manifest/os: minor refactoring to make more arguments optional

### DIFF
--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -31,7 +31,7 @@ func MyManifest(m *manifest.Manifest, options *MyOptions, repos []rpmmd.RepoConf
 	build := manifest.NewBuildPipeline(m, runner, repos)
 
 	// create a non-bootable OS tree containing the `core` comps group
-	os := manifest.NewOSPipeline(m, build, repos, manifest.BOOTLOADER_GRUB, "")
+	os := manifest.NewOSPipeline(m, build, manifest.ARCH_X86_64, repos)
 	os.ExtraBasePackages = []string{
 		"@core",
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -31,7 +31,7 @@ func MyManifest(m *manifest.Manifest, options *MyOptions, repos []rpmmd.RepoConf
 	build := manifest.NewBuildPipeline(m, runner, repos)
 
 	// create a non-bootable OS tree containing the `core` comps group
-	os := manifest.NewOSPipeline(m, build, false, "", "", repos, nil, manifest.BOOTLOADER_GRUB, "", "")
+	os := manifest.NewOSPipeline(m, build, repos, nil, manifest.BOOTLOADER_GRUB, "", "")
 	os.ExtraBasePackages = []string{
 		"@core",
 	}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -31,7 +31,7 @@ func MyManifest(m *manifest.Manifest, options *MyOptions, repos []rpmmd.RepoConf
 	build := manifest.NewBuildPipeline(m, runner, repos)
 
 	// create a non-bootable OS tree containing the `core` comps group
-	os := manifest.NewOSPipeline(m, build, repos, nil, manifest.BOOTLOADER_GRUB, "", "")
+	os := manifest.NewOSPipeline(m, build, repos, manifest.BOOTLOADER_GRUB, "")
 	os.ExtraBasePackages = []string{
 		"@core",
 	}

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -83,7 +83,7 @@ var (
 		rpmOstree:        true,
 		pipelines:        iotCommitPipelines,
 		buildPipelines:   []string{"build"},
-		payloadPipelines: []string{"ostree-tree", "ostree-commit", "commit-archive"},
+		payloadPipelines: []string{"os", "ostree-commit", "commit-archive"},
 		exports:          []string{"commit-archive"},
 	}
 

--- a/internal/distro/fedora/manifests.go
+++ b/internal/distro/fedora/manifests.go
@@ -9,182 +9,192 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
-func qcow2Pipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet, rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func qcow2Manifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	pipelines = append(pipelines, treePipeline)
-
 	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	pipelines = append(pipelines, imagePipeline)
-
 	qcow2Pipeline := manifest.NewQCOW2Pipeline(m, buildPipeline, imagePipeline, t.filename)
 	qcow2Pipeline.Compat = "1.1"
-	pipelines = append(pipelines, qcow2Pipeline)
 
-	return pipelines, nil
+	return nil
 }
 
-func vhdPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet, rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func vhdManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	pipelines = append(pipelines, treePipeline)
-
 	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	pipelines = append(pipelines, imagePipeline)
+	manifest.NewVPCPipeline(m, buildPipeline, imagePipeline, t.filename)
 
-	vpcPipeline := manifest.NewVPCPipeline(m, buildPipeline, imagePipeline, t.filename)
-	pipelines = append(pipelines, vpcPipeline)
-	return pipelines, nil
+	return nil
 }
 
-func vmdkPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet, rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func vmdkManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	pipelines = append(pipelines, treePipeline)
-
 	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	pipelines = append(pipelines, imagePipeline)
+	manifest.NewVMDKPipeline(m, buildPipeline, imagePipeline, t.filename)
 
-	vmdkPipeline := manifest.NewVMDKPipeline(m, buildPipeline, imagePipeline, t.filename)
-	pipelines = append(pipelines, vmdkPipeline)
-	return pipelines, nil
+	return nil
 }
 
-func openstackPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet, rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func openstackManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	pipelines = append(pipelines, treePipeline)
-
 	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	pipelines = append(pipelines, imagePipeline)
+	manifest.NewQCOW2Pipeline(m, buildPipeline, imagePipeline, t.filename)
 
-	qcow2Pipeline := manifest.NewQCOW2Pipeline(m, buildPipeline, imagePipeline, t.filename)
-	pipelines = append(pipelines, qcow2Pipeline)
-	return pipelines, nil
+	return nil
 }
 
-func ec2CommonPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
-	repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet,
-	rng *rand.Rand, diskfile string) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func ec2CommonManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand,
+	diskfile string) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
 	if err != nil {
-		return nil, err
+		return nil
 	}
-	pipelines = append(pipelines, treePipeline)
+	manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, diskfile)
 
-	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, diskfile)
-	pipelines = append(pipelines, imagePipeline)
-	return pipelines, nil
+	return nil
 }
 
-// ec2Pipelines returns pipelines which produce uncompressed EC2 images which are expected to use RHSM for content
-func ec2Pipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
+// ec2Manifest returns a manifest which produce uncompressed EC2 images which are expected to use RHSM for content
+func ec2Manifest(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
 	repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet,
-	rng *rand.Rand) ([]manifest.Pipeline, error) {
-	return ec2CommonPipelines(m, t, customizations, options, repos, packageSetChains, rng, t.Filename())
+	rng *rand.Rand) error {
+	return ec2CommonManifest(m, t, customizations, options, repos, packageSetChains, rng, t.Filename())
 }
 
-func iotInstallerPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
-	repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet,
-	rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+func iotInstallerManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
 
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
 
 	d := t.arch.distro
 	ksUsers := len(customizations.GetUsers())+len(customizations.GetGroups()) > 0
 
-	anacondaTreePipeline := anacondaTreePipeline(m, buildPipeline, repos, t.Arch().Name(), d.product, d.osVersion, "IoT", ksUsers)
-	installerChain := packageSetChains[installerPkgsKey]
-	if len(installerChain) >= 1 {
-		anacondaTreePipeline.ExtraPackages = installerChain[0].Include
-	}
-	if len(installerChain) > 1 {
-		panic("unexpected number of package sets in installer chain")
-	}
+	anacondaTreePipeline := anacondaTreePipeline(m, buildPipeline, repos, packageSetChains[installerPkgsKey], t.Arch().Name(), d.product, d.osVersion, "IoT", ksUsers)
 	isoTreePipeline := bootISOTreePipeline(m, buildPipeline, anacondaTreePipeline, options, d.vendor, d.isolabelTmpl, customizations.GetUsers(), customizations.GetGroups())
-	isoPipeline := bootISOPipeline(m, buildPipeline, isoTreePipeline, t.Filename(), false)
+	bootISOPipeline(m, buildPipeline, isoTreePipeline, t.Filename(), false)
 
-	return append(pipelines, anacondaTreePipeline, isoTreePipeline, isoPipeline), nil
+	return nil
 }
 
-func iotCorePipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
-	repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet) (*manifest.BuildPipeline, *manifest.OSPipeline, *manifest.OSTreeCommitPipeline, error) {
+func iotCorePipelines(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet) (*manifest.BuildPipeline,
+	*manifest.OSTreeCommitPipeline,
+	error) {
 	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, nil)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	commitPipeline := ostreeCommitPipeline(m, buildPipeline, treePipeline, options, t.arch.distro.osVersion)
 
-	return buildPipeline, treePipeline, commitPipeline, nil
+	return buildPipeline, commitPipeline, nil
 }
 
-func iotCommitPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
+func iotCommitManifest(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions,
 	repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet,
-	rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
+	rng *rand.Rand) error {
 
-	buildPipeline, treePipeline, commitPipeline, err := iotCorePipelines(m, t, customizations, options, repos, packageSetChains)
+	buildPipeline, commitPipeline, err := iotCorePipelines(m, t, customizations, options, repos, packageSetChains)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	tarPipeline := manifest.NewTarPipeline(m, buildPipeline, &commitPipeline.BasePipeline, "commit-archive", t.Filename())
-	pipelines = append(pipelines, buildPipeline, treePipeline, commitPipeline, tarPipeline)
-	return pipelines, nil
+	manifest.NewTarPipeline(m, buildPipeline, &commitPipeline.BasePipeline, "commit-archive", t.Filename())
+
+	return nil
 }
 
-func iotContainerPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations,
+func iotContainerManifest(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations,
 	options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet,
-	rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
-
-	buildPipeline, treePipeline, commitPipeline, err := iotCorePipelines(m, t, customizations, options, repos, packageSetChains)
+	rng *rand.Rand) error {
+	buildPipeline, commitPipeline, err := iotCorePipelines(m, t, customizations, options, repos, packageSetChains)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	nginxConfigPath := "/etc/nginx.conf"
 	httpPort := "8080"
 	containerTreePipeline := containerTreePipeline(m, buildPipeline, commitPipeline, repos, packageSetChains[containerPkgsKey], options, customizations, nginxConfigPath, httpPort)
-	containerPipeline := containerPipeline(m, buildPipeline, &containerTreePipeline.BasePipeline, t, nginxConfigPath, httpPort)
+	containerPipeline(m, buildPipeline, &containerTreePipeline.BasePipeline, t, nginxConfigPath, httpPort)
 
-	pipelines = append(pipelines, buildPipeline, treePipeline, commitPipeline, containerTreePipeline, containerPipeline)
-	return pipelines, nil
+	return nil
+}
+
+func containerManifest(m *manifest.Manifest,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	repos []rpmmd.RepoConfig,
+	packageSetChains map[string][]rpmmd.PackageSet,
+	rng *rand.Rand) error {
+
+	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
+	if err != nil {
+		return err
+	}
+	manifest.NewOCIContainerPipeline(m, buildPipeline, &treePipeline.BasePipeline, t.Arch().Name(), t.Filename())
+
+	return nil
 }
 
 func osPipeline(m *manifest.Manifest,
@@ -342,13 +352,25 @@ func osPipeline(m *manifest.Manifest,
 	return pl, nil
 }
 
-func ostreeCommitPipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, treePipeline *manifest.OSPipeline, options distro.ImageOptions, osVersion string) *manifest.OSTreeCommitPipeline {
+func ostreeCommitPipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	treePipeline *manifest.OSPipeline,
+	options distro.ImageOptions,
+	osVersion string) *manifest.OSTreeCommitPipeline {
 	p := manifest.NewOSTreeCommitPipeline(m, buildPipeline, treePipeline, options.OSTree.Ref)
 	p.OSVersion = osVersion
 	return p
 }
 
-func containerTreePipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, commitPipeline *manifest.OSTreeCommitPipeline, repos []rpmmd.RepoConfig, containerChain []rpmmd.PackageSet, options distro.ImageOptions, c *blueprint.Customizations, nginxConfigPath, listenPort string) *manifest.OSTreeCommitServerTreePipeline {
+func containerTreePipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	commitPipeline *manifest.OSTreeCommitPipeline,
+	repos []rpmmd.RepoConfig,
+	containerChain []rpmmd.PackageSet,
+	options distro.ImageOptions,
+	c *blueprint.Customizations,
+	nginxConfigPath,
+	listenPort string) *manifest.OSTreeCommitServerTreePipeline {
 	p := manifest.NewOSTreeCommitServerTreePipeline(m, buildPipeline, repos, commitPipeline, nginxConfigPath, listenPort)
 	if len(containerChain) >= 1 {
 		p.ExtraPackages = containerChain[0].Include
@@ -363,22 +385,45 @@ func containerTreePipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPi
 	return p
 }
 
-func containerPipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, treePipeline *manifest.BasePipeline, t *imageType, nginxConfigPath, listenPort string) *manifest.OCIContainerPipeline {
+func containerPipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	treePipeline *manifest.BasePipeline,
+	t *imageType,
+	nginxConfigPath,
+	listenPort string) *manifest.OCIContainerPipeline {
 	p := manifest.NewOCIContainerPipeline(m, buildPipeline, treePipeline, t.Arch().Name(), t.Filename())
 	p.Cmd = []string{"nginx", "-c", nginxConfigPath}
 	p.ExposedPorts = []string{listenPort}
 	return p
 }
 
-func anacondaTreePipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, repos []rpmmd.RepoConfig, arch, product, osVersion, variant string, users bool) *manifest.AnacondaPipeline {
+func anacondaTreePipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	repos []rpmmd.RepoConfig,
+	chain []rpmmd.PackageSet,
+	arch, product, osVersion, variant string,
+	users bool) *manifest.AnacondaPipeline {
 	p := manifest.NewAnacondaPipeline(m, buildPipeline, repos, "kernel", arch, product, osVersion)
+	if len(chain) >= 1 {
+		p.ExtraPackages = chain[0].Include
+	}
+	if len(chain) > 1 {
+		panic("unexpected number of package sets in installer chain")
+	}
 	p.Users = users
 	p.Variant = variant
 	p.Biosdevname = (arch == distro.X86_64ArchName)
 	return p
 }
 
-func bootISOTreePipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, anacondaPipeline *manifest.AnacondaPipeline, options distro.ImageOptions, vendor, isoLabelTempl string, users []blueprint.UserCustomization, groups []blueprint.GroupCustomization) *manifest.ISOTreePipeline {
+func bootISOTreePipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	anacondaPipeline *manifest.AnacondaPipeline,
+	options distro.ImageOptions,
+	vendor,
+	isoLabelTempl string,
+	users []blueprint.UserCustomization,
+	groups []blueprint.GroupCustomization) *manifest.ISOTreePipeline {
 	p := manifest.NewISOTreePipeline(m, buildPipeline, anacondaPipeline, options.OSTree.Parent, options.OSTree.URL, options.OSTree.Ref, isoLabelTempl)
 	p.Release = "202010217.n.0"
 	p.OSName = "fedora"
@@ -389,26 +434,12 @@ func bootISOTreePipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipe
 	return p
 }
 
-func bootISOPipeline(m *manifest.Manifest, buildPipeline *manifest.BuildPipeline, treePipeline *manifest.ISOTreePipeline, filename string, isolinux bool) *manifest.ISOPipeline {
+func bootISOPipeline(m *manifest.Manifest,
+	buildPipeline *manifest.BuildPipeline,
+	treePipeline *manifest.ISOTreePipeline,
+	filename string,
+	isolinux bool) *manifest.ISOPipeline {
 	p := manifest.NewISOPipeline(m, buildPipeline, treePipeline, filename)
 	p.ISOLinux = isolinux
 	return p
-}
-
-func containerPipelines(m *manifest.Manifest, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, repos []rpmmd.RepoConfig, packageSetChains map[string][]rpmmd.PackageSet, rng *rand.Rand) ([]manifest.Pipeline, error) {
-	pipelines := make([]manifest.Pipeline, 0)
-
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
-	pipelines = append(pipelines, buildPipeline)
-
-	treePipeline, err := osPipeline(m, buildPipeline, t, repos, packageSetChains[osPkgsKey], customizations, options, rng)
-	if err != nil {
-		return nil, err
-	}
-	pipelines = append(pipelines, treePipeline)
-
-	ociPipeline := manifest.NewOCIContainerPipeline(m, buildPipeline, &treePipeline.BasePipeline, t.Arch().Name(), t.Filename())
-	pipelines = append(pipelines, ociPipeline)
-
-	return pipelines, nil
 }

--- a/internal/distro/fedora/pipelines.go
+++ b/internal/distro/fedora/pipelines.go
@@ -209,19 +209,19 @@ func osPipeline(m *manifest.Manifest,
 		}
 	}
 
-	var bootLoader manifest.BootLoader
-	if t.Arch().Name() == distro.S390xArchName {
-		bootLoader = manifest.BOOTLOADER_ZIPL
-	} else {
-		bootLoader = manifest.BOOTLOADER_GRUB
+	var arch manifest.Arch
+	switch t.Arch().Name() {
+	case distro.X86_64ArchName:
+		arch = manifest.ARCH_X86_64
+	case distro.Aarch64ArchName:
+		arch = manifest.ARCH_AARCH64
+	case distro.Ppc64leArchName:
+		arch = manifest.ARCH_PPC64LE
+	case distro.S390xArchName:
+		arch = manifest.ARCH_S390X
 	}
 
-	var kernelName string
-	if t.bootable {
-		kernelName = c.GetKernel().Name
-	}
-
-	pl := manifest.NewOSPipeline(m, buildPipeline, repos, bootLoader, kernelName)
+	pl := manifest.NewOSPipeline(m, buildPipeline, arch, repos)
 	pl.PartitionTable = pt
 
 	if t.rpmOstree {
@@ -254,6 +254,10 @@ func osPipeline(m *manifest.Manifest,
 	}
 
 	pl.BIOSPlatform = t.arch.legacy
+
+	if t.bootable {
+		pl.KernelName = c.GetKernel().Name
+	}
 
 	var kernelOptions []string
 	if t.kernelOptions != "" {

--- a/internal/distro/fedora/pipelines.go
+++ b/internal/distro/fedora/pipelines.go
@@ -221,7 +221,8 @@ func osPipeline(m *manifest.Manifest,
 		kernelName = c.GetKernel().Name
 	}
 
-	pl := manifest.NewOSPipeline(m, buildPipeline, repos, pt, bootLoader, t.arch.legacy, kernelName)
+	pl := manifest.NewOSPipeline(m, buildPipeline, repos, bootLoader, kernelName)
+	pl.PartitionTable = pt
 
 	if t.rpmOstree {
 		var parent *manifest.OSPipelineOSTreeParent
@@ -251,6 +252,8 @@ func osPipeline(m *manifest.Manifest,
 	if t.supportsUEFI() {
 		pl.UEFIVendor = t.arch.distro.vendor
 	}
+
+	pl.BIOSPlatform = t.arch.legacy
 
 	var kernelOptions []string
 	if t.kernelOptions != "" {

--- a/internal/distro/fedora/pipelines.go
+++ b/internal/distro/fedora/pipelines.go
@@ -221,7 +221,20 @@ func osPipeline(m *manifest.Manifest,
 		kernelName = c.GetKernel().Name
 	}
 
-	pl := manifest.NewOSPipeline(m, buildPipeline, t.rpmOstree, options.OSTree.Parent, options.OSTree.URL, repos, pt, bootLoader, t.arch.legacy, kernelName)
+	pl := manifest.NewOSPipeline(m, buildPipeline, repos, pt, bootLoader, t.arch.legacy, kernelName)
+
+	if t.rpmOstree {
+		var parent *manifest.OSPipelineOSTreeParent
+		if options.OSTree.Parent != "" && options.OSTree.URL != "" {
+			parent = &manifest.OSPipelineOSTreeParent{
+				Checksum: options.OSTree.Parent,
+				URL:      options.OSTree.URL,
+			}
+		}
+		pl.OSTree = &manifest.OSPipelineOSTree{
+			Parent: parent,
+		}
+	}
 
 	if len(osChain) >= 1 {
 		pl.ExtraBasePackages = osChain[0].Include

--- a/internal/manifest/commit.go
+++ b/internal/manifest/commit.go
@@ -43,6 +43,10 @@ func (p *OSTreeCommitPipeline) getBuildPackages() []string {
 func (p *OSTreeCommitPipeline) serialize() osbuild2.Pipeline {
 	pipeline := p.BasePipeline.serialize()
 
+	if p.treePipeline.OSTree == nil {
+		panic("tree is not ostree")
+	}
+
 	pipeline.AddStage(osbuild2.NewOSTreeInitStage(&osbuild2.OSTreeInitStageOptions{Path: "/repo"}))
 
 	commitStageInput := new(osbuild2.OSTreeCommitStageInput)
@@ -50,11 +54,15 @@ func (p *OSTreeCommitPipeline) serialize() osbuild2.Pipeline {
 	commitStageInput.Origin = "org.osbuild.pipeline"
 	commitStageInput.References = osbuild2.OSTreeCommitStageReferences{"name:" + p.treePipeline.Name()}
 
+	var parent string
+	if p.treePipeline.OSTree.Parent != nil {
+		parent = p.treePipeline.OSTree.Parent.Checksum
+	}
 	pipeline.AddStage(osbuild2.NewOSTreeCommitStage(
 		&osbuild2.OSTreeCommitStageOptions{
 			Ref:       p.ref,
 			OSVersion: p.OSVersion,
-			Parent:    p.treePipeline.osTreeParent,
+			Parent:    parent,
 		},
 		&osbuild2.OSTreeCommitStageInputs{Tree: commitStageInput}),
 	)

--- a/internal/manifest/live.go
+++ b/internal/manifest/live.go
@@ -51,14 +51,14 @@ func (p *LiveImgPipeline) serialize() osbuild2.Pipeline {
 		pipeline.AddStage(stage)
 	}
 
-	switch p.treePipeline.bootLoader {
-	case BOOTLOADER_GRUB:
+	switch p.treePipeline.arch {
+	case ARCH_S390X:
+		loopback := osbuild2.NewLoopbackDevice(&osbuild2.LoopbackDeviceOptions{Filename: p.filename})
+		pipeline.AddStage(osbuild2.NewZiplInstStage(osbuild2.NewZiplInstStageOptions(p.treePipeline.kernelVer, pt), loopback, copyDevices, copyMounts))
+	default:
 		if grubLegacy := p.treePipeline.BIOSPlatform; grubLegacy != "" {
 			pipeline.AddStage(osbuild2.NewGrub2InstStage(osbuild2.NewGrub2InstStageOption(p.filename, pt, grubLegacy)))
 		}
-	case BOOTLOADER_ZIPL:
-		loopback := osbuild2.NewLoopbackDevice(&osbuild2.LoopbackDeviceOptions{Filename: p.filename})
-		pipeline.AddStage(osbuild2.NewZiplInstStage(osbuild2.NewZiplInstStageOptions(p.treePipeline.kernelVer, pt), loopback, copyDevices, copyMounts))
 	}
 
 	return pipeline

--- a/internal/manifest/live.go
+++ b/internal/manifest/live.go
@@ -33,7 +33,7 @@ func NewLiveImgPipeline(m *Manifest,
 func (p *LiveImgPipeline) serialize() osbuild2.Pipeline {
 	pipeline := p.BasePipeline.serialize()
 
-	pt := p.treePipeline.partitionTable
+	pt := p.treePipeline.PartitionTable
 	if pt == nil {
 		panic("no partition table in live image")
 	}
@@ -53,7 +53,7 @@ func (p *LiveImgPipeline) serialize() osbuild2.Pipeline {
 
 	switch p.treePipeline.bootLoader {
 	case BOOTLOADER_GRUB:
-		if grubLegacy := p.treePipeline.grubLegacy; grubLegacy != "" {
+		if grubLegacy := p.treePipeline.BIOSPlatform; grubLegacy != "" {
 			pipeline.AddStage(osbuild2.NewGrub2InstStage(osbuild2.NewGrub2InstStageOption(p.filename, pt, grubLegacy)))
 		}
 	case BOOTLOADER_ZIPL:

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -9,6 +9,15 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
+type Arch uint64
+
+const (
+	ARCH_X86_64 Arch = iota
+	ARCH_AARCH64
+	ARCH_S390X
+	ARCH_PPC64LE
+)
+
 type osTreeCommit struct {
 	checksum string
 	url      string

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -112,12 +112,8 @@ func NewOSPipeline(m *Manifest,
 	bootLoader BootLoader,
 	grubLegacy string,
 	kernelName string) *OSPipeline {
-	name := "os"
-	if osTree {
-		name = "ostree-tree"
-	}
 	p := &OSPipeline{
-		BasePipeline:   NewBasePipeline(m, name, buildPipeline, nil),
+		BasePipeline:   NewBasePipeline(m, "os", buildPipeline, nil),
 		osTree:         osTree,
 		osTreeParent:   osTreeParent,
 		osTreeURL:      osTreeURL,

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_commit-boot.json
@@ -1888,7 +1888,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5421,7 +5421,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9081,7 +9081,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "acl",
         "epoch": 0,

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_container-boot.json
@@ -1888,7 +1888,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5421,7 +5421,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -12419,7 +12419,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "acl",
         "epoch": 0,

--- a/test/data/manifests/fedora_34-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-container-boot.json
@@ -1225,22 +1225,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -3391,9 +3375,6 @@
           "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm"
           },
-          "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm"
-          },
           "sha256:7d59ff94c9fa323e68c6f9d5b0ccc06075847d77775211f4acbee8f54d8975ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.x86_64.rpm"
           },
@@ -3690,9 +3671,6 @@
           },
           "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm"
-          },
-          "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm"
           },
           "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.x86_64.rpm"
@@ -5261,26 +5239,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
-        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
-        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -1912,7 +1912,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5533,7 +5533,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9256,7 +9256,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "acl",
         "epoch": 0,

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -1249,22 +1249,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -8453,26 +8437,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
-        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
-        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -1918,7 +1918,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5539,7 +5539,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9262,7 +9262,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "acl",
         "epoch": 0,

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -1255,22 +1255,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -8459,26 +8443,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
-        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
-        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
@@ -1912,7 +1912,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5533,7 +5533,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -12612,7 +12612,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "acl",
         "epoch": 0,

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
@@ -1249,22 +1249,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -10017,26 +10001,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
-        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "9.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
-        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
@@ -1928,7 +1928,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5445,7 +5445,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9152,7 +9152,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_container-boot.json
@@ -1928,7 +1928,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5445,7 +5445,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -12433,7 +12433,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_35-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-container-boot.json
@@ -1513,22 +1513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -3366,9 +3350,6 @@
           "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm"
           },
-          "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm"
-          },
           "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm"
           },
@@ -3626,9 +3607,6 @@
           },
           "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm"
-          },
-          "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
           },
           "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
@@ -5647,26 +5625,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
-        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
-        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -1545,22 +1545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -8844,26 +8828,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
-        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
-        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -1952,7 +1952,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5557,7 +5557,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9327,7 +9327,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -1551,22 +1551,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -8850,26 +8834,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
-        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
-        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -1958,7 +1958,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5563,7 +5563,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9333,7 +9333,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
@@ -1952,7 +1952,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5557,7 +5557,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -12626,7 +12626,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
@@ -1545,22 +1545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -10381,26 +10365,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
-        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "10.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
-        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_commit-boot.json
@@ -2128,7 +2128,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5635,7 +5635,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9609,7 +9609,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_container-boot.json
@@ -2128,7 +2128,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5635,7 +5635,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -12870,7 +12870,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_36-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-container-boot.json
@@ -555,22 +555,6 @@
                     }
                   },
                   {
-                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -3358,9 +3342,6 @@
           "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm"
           },
-          "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm"
-          },
           "sha256:4771a6fe8a310ca1cc93c10030909c526423d114dc5cc74c0332282d3f4ab914": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python-unversioned-command-3.10.3-1.fc37.noarch.rpm"
           },
@@ -3834,9 +3815,6 @@
           },
           "sha256:f2ba36563c305ae503625074dc41e6bac19b91846597db7e2d113e30b321800f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm"
-          },
-          "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm"
           },
           "sha256:f3550aa734404646dc0d050bbe645960113ac7696f35a99cfcf4d6924a350af0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/systemd-resolved-250.4-2.fc37.x86_64.rpm"
@@ -4522,26 +4500,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
-        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
-        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
@@ -643,22 +643,6 @@
                     }
                   },
                   {
-                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -7929,26 +7913,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
-        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
-        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
@@ -2160,7 +2160,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5755,7 +5755,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9802,7 +9802,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
@@ -2166,7 +2166,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5761,7 +5761,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -9808,7 +9808,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
@@ -649,22 +649,6 @@
                     }
                   },
                   {
-                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -7935,26 +7919,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
-        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
-        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
@@ -643,22 +643,6 @@
                     }
                   },
                   {
-                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -9464,26 +9448,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
-        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
-        "check_gpg": true
-      },
-      {
-        "name": "grub2-pc-modules",
-        "epoch": 1,
-        "version": "2.06",
-        "release": "28.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
-        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
@@ -2160,7 +2160,7 @@
         ]
       },
       {
-        "name": "ostree-tree",
+        "name": "os",
         "build": "name:build",
         "stages": [
           {
@@ -5755,7 +5755,7 @@
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
-                  "name:ostree-tree"
+                  "name:os"
                 ]
               }
             },
@@ -13099,7 +13099,7 @@
         "check_gpg": true
       }
     ],
-    "ostree-tree": [
+    "os": [
       {
         "name": "ModemManager",
         "epoch": 0,


### PR DESCRIPTION
All arguments that has reasonable defaults and where querying the package set chain as well as serialisation works without
the defaults being overridden, should be made public fields rather than arguments to the constructor.

It is the caller's responsibility not to change the parameters between querying the package set chains and serialising the
manifest, but otherwise they are free to reuse the pipeline objects and modify them freely.