### PR TITLE
manifest/os: move over bootloader packages

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -649,7 +649,9 @@ func (t *imageType) Exports() []string {
 func (t *imageType) getBootType() distro.BootType {
 	bootType := t.arch.bootType
 	if t.bootType != distro.UnsetBootType {
-		bootType = t.bootType
+		if bootType == distro.HybridBootType {
+			bootType = t.bootType
+		}
 	}
 	return bootType
 }

--- a/internal/distro/fedora/manifests.go
+++ b/internal/distro/fedora/manifests.go
@@ -229,7 +229,9 @@ func osPipeline(m *manifest.Manifest,
 			return nil, err
 		}
 		pl.PartitionTable = pt
+	}
 
+	if t.bootable || t.rpmOstree {
 		if t.supportsUEFI() {
 			pl.UEFIVendor = t.arch.distro.vendor
 		}

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -30,84 +30,6 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"geolite2-country",
 			"zram-generator-defaults",
 		},
-	}.Append(bootPackageSet(t))
-}
-
-// BOOT PACKAGE SETS
-
-func bootPackageSet(t *imageType) rpmmd.PackageSet {
-	if !t.bootable {
-		return rpmmd.PackageSet{}
-	}
-
-	var addLegacyBootPkg bool
-	var addUEFIBootPkg bool
-
-	switch bt := t.getBootType(); bt {
-	case distro.LegacyBootType:
-		addLegacyBootPkg = true
-	case distro.UEFIBootType:
-		addUEFIBootPkg = true
-	case distro.HybridBootType:
-		addLegacyBootPkg = true
-		addUEFIBootPkg = true
-	default:
-		panic(fmt.Sprintf("unsupported boot type: %q", bt))
-	}
-
-	ps := rpmmd.PackageSet{}
-
-	switch t.Arch().Name() {
-	case distro.X86_64ArchName:
-		if addLegacyBootPkg {
-			ps = ps.Append(x8664LegacyBootPackageSet(t))
-		}
-		if addUEFIBootPkg {
-			ps = ps.Append(x8664UEFIBootPackageSet(t))
-		}
-
-	case distro.Aarch64ArchName:
-		ps = ps.Append(aarch64UEFIBootPackageSet(t))
-
-	default:
-		panic(fmt.Sprintf("unsupported boot arch: %s", t.Arch().Name()))
-	}
-
-	return ps
-}
-
-// x86_64 Legacy arch-specific boot package set
-func x8664LegacyBootPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"dracut-config-generic",
-			"grub2-pc",
-		},
-	}
-}
-
-// x86_64 UEFI arch-specific boot package set
-func x8664UEFIBootPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"dracut-config-generic",
-			"efibootmgr",
-			"grub2-efi-x64",
-			"shim-x64",
-		},
-	}
-}
-
-// aarch64 UEFI arch-specific boot package set
-func aarch64UEFIBootPackageSet(t *imageType) rpmmd.PackageSet {
-	return rpmmd.PackageSet{
-		Include: []string{
-			"dracut-config-generic",
-			"efibootmgr",
-			"grub2-efi-aa64",
-			"grub2-tools",
-			"shim-aa64",
-		},
 	}
 }
 
@@ -132,7 +54,7 @@ func qcow2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"grubby-deprecated",
 			"extlinux-bootloader",
 		},
-	}.Append(bootPackageSet(t))
+	}
 
 	return ps
 }
@@ -157,7 +79,7 @@ func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"geolite2-country",
 			"zram-generator-defaults",
 		},
-	}.Append(bootPackageSet(t))
+	}
 
 	return ps
 }
@@ -183,7 +105,7 @@ func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"grubby-deprecated",
 			"extlinux-bootloader",
 		},
-	}.Append(bootPackageSet(t))
+	}
 
 	return ps
 }
@@ -207,7 +129,7 @@ func openstackCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"geolite2-country",
 			"zram-generator-defaults",
 		},
-	}.Append(bootPackageSet(t))
+	}
 
 	return ps
 }
@@ -223,7 +145,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"sssd-client",
 			"libsss_sudo",
 			"shadow-utils",
-			"dracut-config-generic",
 			"dracut-network",
 			"polkit",
 			"lvm2",
@@ -329,10 +250,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 func x8664IOTCommitPackageSet() rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
-			"grub2",
-			"grub2-efi-x64",
-			"efibootmgr",
-			"shim-x64",
 			"microcode_ctl",
 			"iwl1000-firmware",
 			"iwl100-firmware",
@@ -352,10 +269,6 @@ func x8664IOTCommitPackageSet() rpmmd.PackageSet {
 func aarch64IOTCommitPackageSet() rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
-			"grub2",
-			"grub2-efi-aa64",
-			"efibootmgr",
-			"shim-aa64",
 			"uboot-images-armv8",
 			"bcm283x-firmware",
 			"arm-image-installer"},

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -115,6 +115,7 @@ func NewOSPipeline(m *Manifest,
 	p := &OSPipeline{
 		BasePipeline: NewBasePipeline(m, "os", buildPipeline, nil),
 		repos:        repos,
+		arch:         arch,
 		Language:     "C.UTF-8",
 		Hostname:     "localhost.localdomain",
 		Timezone:     "UTC",
@@ -127,6 +128,34 @@ func NewOSPipeline(m *Manifest,
 
 func (p *OSPipeline) getPackageSetChain() []rpmmd.PackageSet {
 	packages := []string{}
+
+	switch p.arch {
+	case ARCH_X86_64:
+		if p.BIOSPlatform != "" {
+			packages = append(packages,
+				"dracut-config-generic",
+				"grub2-pc")
+		}
+		if p.UEFIVendor != "" {
+			packages = append(packages,
+				"dracut-config-generic",
+				"efibootmgr",
+				"grub2-efi-x64",
+				"shim-x64")
+		}
+	case ARCH_AARCH64:
+		if p.UEFIVendor != "" {
+			packages = append(packages,
+				"dracut-config-generic",
+				"efibootmgr",
+				"grub2-efi-aa64",
+				"grub2-tools",
+				"shim-aa64")
+		}
+	default:
+		panic("unsupported architecture")
+	}
+
 	chain := []rpmmd.PackageSet{
 		{
 			Include:      append(packages, p.ExtraBasePackages...),

--- a/test/data/manifests/fedora_34-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-ami-boot.json
@@ -4749,6 +4749,10 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-100.fc34.aarch64",
               "write_cmdline": false,
               "config": {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -1249,6 +1249,22 @@
                     }
                   },
                   {
+                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -8437,6 +8453,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -1255,6 +1255,22 @@
                     }
                   },
                   {
+                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -8443,6 +8459,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
@@ -1249,6 +1249,22 @@
                     }
                   },
                   {
+                    "id": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
                     "options": {
                       "metadata": {
@@ -10001,6 +10017,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
         "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -4893,6 +4893,10 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-200.fc35.aarch64",
               "write_cmdline": false,
               "config": {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -1545,6 +1545,22 @@
                     }
                   },
                   {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -8828,6 +8844,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -1551,6 +1551,22 @@
                     }
                   },
                   {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -8834,6 +8850,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
@@ -1545,6 +1545,22 @@
                     }
                   },
                   {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
                     "options": {
                       "metadata": {
@@ -10365,6 +10381,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
         "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-ami-boot.json
@@ -5211,6 +5211,10 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
               "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.0-0.rc5.40.fc37.aarch64",
               "write_cmdline": false,
               "config": {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
@@ -643,6 +643,22 @@
                     }
                   },
                   {
+                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -7913,6 +7929,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
+        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
+        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
@@ -649,6 +649,22 @@
                     }
                   },
                   {
+                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -7919,6 +7935,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
+        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
+        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
@@ -643,6 +643,22 @@
                     }
                   },
                   {
+                    "id": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ca6570e80b38f61221d622cab52390fa65a1fe9abfb402cc4ce4990a83f8d0f3",
                     "options": {
                       "metadata": {
@@ -9448,6 +9464,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-common-2.06-28.fc37.noarch.rpm",
         "checksum": "sha256:5bb35ae3935a110f929aacbe0e1b8c2176072fb9260a1bc1881a4ce8c578cb2e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm",
+        "checksum": "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "28.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-modules-2.06-28.fc37.noarch.rpm",
+        "checksum": "sha256:f30f4de190e9762199192165577e250d6a1b8936fdd99a7a14646c4154ece10f",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
Simplify the package sets definitions in the distribution by moving the required boot loader packages into the pipeline definitions.

Also fixes a bug, see individual patches.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
