### PR TITLE
distro: move isMountpointAllowed

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -3,6 +3,8 @@ package distro
 import (
 	"encoding/json"
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/disk"
@@ -256,4 +258,23 @@ func MakePackageSetChains(t ImageType, packageSets map[string]rpmmd.PackageSet, 
 	}
 
 	return chainedSets
+}
+
+func IsMountpointAllowed(mountpoint string, allowlist []string) bool {
+	for _, allowed := range allowlist {
+		match, _ := path.Match(allowed, mountpoint)
+		if match {
+			return true
+		}
+		// ensure that only clean mountpoints
+		// are valid
+		if strings.Contains(mountpoint, "//") {
+			return false
+		}
+		match = strings.HasPrefix(mountpoint, allowed+"/")
+		if allowed != "/" && match {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"path"
 	"sort"
 	"strings"
 
@@ -733,25 +732,6 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 	return manifest.Serialize(packageSets)
 }
 
-func isMountpointAllowed(mountpoint string) bool {
-	for _, allowed := range mountpointAllowList {
-		match, _ := path.Match(allowed, mountpoint)
-		if match {
-			return true
-		}
-		// ensure that only clean mountpoints
-		// are valid
-		if strings.Contains(mountpoint, "//") {
-			return false
-		}
-		match = strings.HasPrefix(mountpoint, allowed+"/")
-		if allowed != "/" && match {
-			return true
-		}
-	}
-	return false
-}
-
 // checkOptions checks the validity and compatibility of options and customizations for the image type.
 func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions) error {
 	if t.bootISO && t.rpmOstree {
@@ -779,7 +759,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if !isMountpointAllowed(m.Mountpoint) {
+		if !distro.IsMountpointAllowed(m.Mountpoint, mountpointAllowList) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}
 	}

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"path"
 	"sort"
 	"strings"
 
@@ -427,25 +426,6 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 	)
 }
 
-func isMountpointAllowed(mountpoint string) bool {
-	for _, allowed := range mountpointAllowList {
-		match, _ := path.Match(allowed, mountpoint)
-		if match {
-			return true
-		}
-		// ensure that only clean mountpoints
-		// are valid
-		if strings.Contains(mountpoint, "//") {
-			return false
-		}
-		match = strings.HasPrefix(mountpoint, allowed+"/")
-		if allowed != "/" && match {
-			return true
-		}
-	}
-	return false
-}
-
 // checkOptions checks the validity and compatibility of options and customizations for the image type.
 func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions) error {
 
@@ -453,7 +433,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if !isMountpointAllowed(m.Mountpoint) {
+		if !distro.IsMountpointAllowed(m.Mountpoint, mountpointAllowList) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}
 	}

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"path"
 	"sort"
 	"strings"
 
@@ -546,25 +545,6 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 	)
 }
 
-func isMountpointAllowed(mountpoint string) bool {
-	for _, allowed := range mountpointAllowList {
-		match, _ := path.Match(allowed, mountpoint)
-		if match {
-			return true
-		}
-		// ensure that only clean mountpoints
-		// are valid
-		if strings.Contains(mountpoint, "//") {
-			return false
-		}
-		match = strings.HasPrefix(mountpoint, allowed+"/")
-		if allowed != "/" && match {
-			return true
-		}
-	}
-	return false
-}
-
 // checkOptions checks the validity and compatibility of options and customizations for the image type.
 func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions) error {
 	if t.bootISO && t.rpmOstree {
@@ -623,7 +603,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if !isMountpointAllowed(m.Mountpoint) {
+		if !distro.IsMountpointAllowed(m.Mountpoint, mountpointAllowList) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}
 	}

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"path"
 	"sort"
 	"strings"
 
@@ -492,25 +491,6 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 	)
 }
 
-func isMountpointAllowed(mountpoint string) bool {
-	for _, allowed := range mountpointAllowList {
-		match, _ := path.Match(allowed, mountpoint)
-		if match {
-			return true
-		}
-		// ensure that only clean mountpoints
-		// are valid
-		if strings.Contains(mountpoint, "//") {
-			return false
-		}
-		match = strings.HasPrefix(mountpoint, allowed+"/")
-		if allowed != "/" && match {
-			return true
-		}
-	}
-	return false
-}
-
 // checkOptions checks the validity and compatibility of options and customizations for the image type.
 func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions) error {
 	if t.bootISO && t.rpmOstree {
@@ -569,7 +549,7 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if !isMountpointAllowed(m.Mountpoint) {
+		if !distro.IsMountpointAllowed(m.Mountpoint, mountpointAllowList) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}
 	}


### PR DESCRIPTION
This is a micro pr to move the `isMountpointAllowed` function to the common distro package since this function is shared used in multiple distro packages.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
