### PR TITLE
Create multiple aws images from a single compose

### DIFF
--- a/cmd/osbuild-service-maintenance/db_test.go
+++ b/cmd/osbuild-service-maintenance/db_test.go
@@ -58,7 +58,7 @@ func testDeleteJob(t *testing.T, d db, q *dbjobqueue.DBJobQueue) {
 	err = q.FinishJob(id, res)
 	require.NoError(t, err)
 
-	_, _, r, _, _, _, _, _, err := q.JobStatus(id)
+	_, _, r, _, _, _, _, _, _, err := q.JobStatus(id)
 	require.NoError(t, err)
 
 	var r1 Result
@@ -78,7 +78,7 @@ func testDeleteJob(t *testing.T, d db, q *dbjobqueue.DBJobQueue) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
-	_, _, _, _, _, _, _, _, err = q.JobStatus(id)
+	_, _, _, _, _, _, _, _, _, err = q.JobStatus(id)
 	require.Error(t, err)
 }
 

--- a/cmd/osbuild-worker/jobimpl-awsec2.go
+++ b/cmd/osbuild-worker/jobimpl-awsec2.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/osbuild-composer/internal/cloud/awscloud"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+func getAWS(awsCreds, region string) (*awscloud.AWS, error) {
+	if awsCreds != "" {
+		return awscloud.NewFromFile(awsCreds, region)
+	}
+	return awscloud.NewDefault(region)
+}
+
+type AWSEC2CopyJobImpl struct {
+	AWSCreds string
+}
+
+func (impl *AWSEC2CopyJobImpl) Run(job worker.Job) error {
+	logWithId := logrus.WithField("jobId", job.Id())
+	result := worker.AWSEC2CopyJobResult{}
+
+	defer func() {
+		err := job.Update(&result)
+		if err != nil {
+			logWithId.Errorf("Error reporting job result: %v", err)
+		}
+	}()
+
+	var args worker.AWSEC2CopyJob
+	err := job.Args(&args)
+	if err != nil {
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorParsingJobArgs, fmt.Sprintf("Error parsing arguments: %v", err), nil)
+		return err
+	}
+
+	aws, err := getAWS(impl.AWSCreds, args.TargetRegion)
+	if err != nil {
+		logWithId.Errorf("Error creating aws client: %v", err)
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, "Invalid worker config", nil)
+		return err
+	}
+
+	ami, err := aws.CopyImage(args.TargetName, args.Ami, args.SourceRegion)
+	if err != nil {
+		logWithId.Errorf("Error copying ami: %v", err)
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Error copying ami %s", args.Ami), nil)
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "InvalidRegion":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Invalid source region '%s'", args.SourceRegion), nil)
+			case "InvalidAMIID.Malformed":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Malformed source ami id '%s'", args.Ami), nil)
+			case "InvalidAMIID.NotFound":
+				fallthrough // CopyImage returns InvalidRequest instead of InvalidAMIID.NotFound
+			case "InvalidRequest":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Source ami '%s' not found", args.Ami), nil)
+			}
+		}
+		return err
+	}
+
+	result.Ami = ami
+	result.Region = args.TargetRegion
+	return nil
+}
+
+type AWSEC2ShareJobImpl struct {
+	AWSCreds string
+}
+
+func (impl *AWSEC2ShareJobImpl) Run(job worker.Job) error {
+	logWithId := logrus.WithField("jobId", job.Id())
+	result := worker.AWSEC2ShareJobResult{}
+
+	defer func() {
+		err := job.Update(&result)
+		if err != nil {
+			logWithId.Errorf("Error reporting job result: %v", err)
+		}
+	}()
+
+	var args worker.AWSEC2ShareJob
+	err := job.Args(&args)
+	if err != nil {
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorParsingJobArgs, fmt.Sprintf("Error parsing arguments: %v", err), nil)
+		return err
+	}
+
+	if args.Ami == "" || args.Region == "" {
+		if job.NDynamicArgs() != 1 {
+			logWithId.Error("No arguments given and dynamic args empty")
+			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorNoDynamicArgs, "An ec2 share job should have args or depend on an ec2 copy job", nil)
+			return nil
+		}
+		var cjResult worker.AWSEC2CopyJobResult
+		err = job.DynamicArgs(0, &cjResult)
+		if err != nil {
+			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorParsingDynamicArgs, "Error parsing dynamic args as ec2 copy job", nil)
+			return err
+		}
+		if cjResult.JobError != nil {
+			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorJobDependency, "AWSEC2CopyJob dependency failed", nil)
+			return nil
+		}
+
+		args.Ami = cjResult.Ami
+		args.Region = cjResult.Region
+	}
+
+	aws, err := getAWS(impl.AWSCreds, args.Region)
+	if err != nil {
+		logWithId.Errorf("Error creating aws client: %v", err)
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, "Invalid worker config", nil)
+		return err
+	}
+
+	err = aws.ShareImage(args.Ami, args.ShareWithAccounts)
+	if err != nil {
+		logWithId.Errorf("Error sharing image: %v", err)
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Error sharing image with target %v", args.ShareWithAccounts), nil)
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "InvalidAMIID.Malformed":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Malformed ami id '%s'", args.Ami), nil)
+			case "InvalidAMIID.NotFound":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Ami '%s' not found in region '%s'", args.Ami, args.Region), nil)
+			case "InvalidAMIAttributeItemValue":
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Invalid user id to share ami with: %v", args.ShareWithAccounts), nil)
+			}
+		}
+		return err
+	}
+
+	result.Ami = args.Ami
+	result.Region = args.Region
+	return nil
+}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -464,6 +464,12 @@ func main() {
 		worker.JobTypeContainerResolve: &ContainerResolveJobImpl{
 			AuthFilePath: containersAuthFilePath,
 		},
+		worker.JobTypeAWSEC2Copy: &AWSEC2CopyJobImpl{
+			AWSCreds: awsCredentials,
+		},
+		worker.JobTypeAWSEC2Share: &AWSEC2ShareJobImpl{
+			AWSCreds: awsCredentials,
+		},
 	}
 
 	acceptedJobTypes := []string{}

--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -44,6 +44,10 @@ const (
 	ErrorTenantNotFound               ServiceErrorCode = 28
 	ErrorNoGPGKey                     ServiceErrorCode = 29
 	ErrorValidationFailed             ServiceErrorCode = 30
+	ErrorComposeBadState              ServiceErrorCode = 31
+	ErrorUnsupportedImage             ServiceErrorCode = 32
+	ErrorInvalidImageFromComposeId    ServiceErrorCode = 33
+	ErrorImageNotFound                ServiceErrorCode = 34
 
 	// Internal errors, these are bugs
 	ErrorFailedToInitializeBlueprint              ServiceErrorCode = 1000
@@ -63,6 +67,9 @@ const (
 	ErrorDepsolveJobCanceled                      ServiceErrorCode = 1014
 	ErrorUnexpectedNumberOfImageBuilds            ServiceErrorCode = 1015
 	ErrorGettingBuildDependencyStatus             ServiceErrorCode = 1016
+	ErrorGettingOSBuildJobStatus                  ServiceErrorCode = 1017
+	ErrorGettingAWSEC2JobStatus                   ServiceErrorCode = 1018
+	ErrorGettingJobType                           ServiceErrorCode = 1019
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -106,12 +113,16 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorMethodNotAllowed, http.StatusMethodNotAllowed, "Requested method isn't supported for resource"},
 		serviceError{ErrorNotAcceptable, http.StatusNotAcceptable, "Only 'application/json' content is supported"},
 		serviceError{ErrorNoBaseURLInPayloadRepository, http.StatusBadRequest, "BaseURL must be specified for payload repositories"},
-		serviceError{ErrorInvalidJobType, http.StatusNotFound, "Requested job has invalid type"},
+		serviceError{ErrorInvalidJobType, http.StatusNotFound, "Job with given id has an invalid type"},
 		serviceError{ErrorInvalidNumberOfImageBuilds, http.StatusBadRequest, "Compose request has unsupported number of image builds"},
 		serviceError{ErrorInvalidOSTreeParams, http.StatusBadRequest, "Invalid OSTree parameters or parameter combination"},
 		serviceError{ErrorTenantNotFound, http.StatusBadRequest, "Tenant not found in JWT claims"},
 		serviceError{ErrorNoGPGKey, http.StatusBadRequest, "Invalid repository, when check_gpg is set, gpgkey must be specified"},
 		serviceError{ErrorValidationFailed, http.StatusBadRequest, "Request could not be validated"},
+		serviceError{ErrorComposeBadState, http.StatusBadRequest, "Compose is running or has failed"},
+		serviceError{ErrorUnsupportedImage, http.StatusBadRequest, "This compose doesn't support the creation of multiple images"},
+		serviceError{ErrorInvalidImageFromComposeId, http.StatusBadRequest, "Invalid format for image id"},
+		serviceError{ErrorImageNotFound, http.StatusBadRequest, "Image with given id not found"},
 
 		serviceError{ErrorFailedToInitializeBlueprint, http.StatusInternalServerError, "Failed to initialize blueprint"},
 		serviceError{ErrorFailedToGenerateManifestSeed, http.StatusInternalServerError, "Failed to generate manifest seed"},
@@ -130,6 +141,9 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorDepsolveJobCanceled, http.StatusInternalServerError, "Depsolve job was cancelled"},
 		serviceError{ErrorUnexpectedNumberOfImageBuilds, http.StatusInternalServerError, "Compose has unexpected number of image builds"},
 		serviceError{ErrorGettingBuildDependencyStatus, http.StatusInternalServerError, "Error checking status of build job dependencies"},
+		serviceError{ErrorGettingOSBuildJobStatus, http.StatusInternalServerError, "Unable to get osbuild job status"},
+		serviceError{ErrorGettingAWSEC2JobStatus, http.StatusInternalServerError, "Unable to get ec2 job status"},
+		serviceError{ErrorGettingJobType, http.StatusInternalServerError, "Unable to get job type of existing job"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/cloudapi/v2/openapi.v2.yml
+++ b/internal/cloudapi/v2/openapi.v2.yml
@@ -211,6 +211,101 @@ paths:
               schema:
                 type: string
 
+  /composes/{id}/clone:
+    post:
+      operationId: postCloneCompose
+      summary: Clone an existing compose
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of the compose
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneComposeBody'
+      responses:
+        '201':
+          description: The new image is being created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloneComposeResponse'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /clones/{id}:
+    get:
+      operationId: getCloneStatus
+      summary: The status of a cloned compose
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: ID of image status to get
+      description: |-
+        Get the status of a running or completed image from a compose.
+        This includes whether or not the image creation succeeded.
+      responses:
+        '200':
+          description: image status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloneStatus'
+        '400':
+          description: Invalid compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /compose:
     post:
       operationId: postCompose
@@ -1029,6 +1124,40 @@ components:
             type: string
             format: uuid
             example: '123e4567-e89b-12d3-a456-426655440000'
+
+    CloneComposeBody:
+      oneOf:
+      - $ref: '#/components/schemas/AWSEC2CloneCompose'
+
+    AWSEC2CloneCompose:
+      type: object
+      required:
+        - region
+      properties:
+        region:
+          type: string
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          items:
+            type: string
+
+    CloneComposeResponse:
+      allOf:
+      - $ref: '#/components/schemas/ObjectReference'
+      - type: object
+        required:
+          - id
+        properties:
+          id:
+            type: string
+            format: uuid
+            example: '123e4567-e89b-12d3-a456-426655440000'
+
+    CloneStatus:
+      allOf:
+      - $ref: '#/components/schemas/ObjectReference'
+      - $ref: '#/components/schemas/UploadStatus'
 
   parameters:
     page:

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -539,7 +539,7 @@ func TestKojiJobTypeValidation(t *testing.T) {
 		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%s%s", finalizeID, path), ``, http.StatusOK, "*")
 
 		// The other IDs should fail
-		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%s%s", initID, path), ``, http.StatusNotFound, `{"code":"IMAGE-BUILDER-COMPOSER-26", "details": "", "href":"/api/image-builder-composer/v2/errors/26","id":"26","kind":"Error","reason":"Requested job has invalid type"}`, `operation_id`)
+		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%s%s", initID, path), ``, http.StatusNotFound, `{"code":"IMAGE-BUILDER-COMPOSER-26", "details": "", "href":"/api/image-builder-composer/v2/errors/26","id":"26","kind":"Error","reason":"Job with given id has an invalid type"}`, `operation_id`)
 
 		for _, buildID := range buildJobIDs {
 			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%s%s", buildID, path), ``, http.StatusOK, "*")

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -256,6 +256,33 @@ type ContainerResolveJobResult struct {
 	JobResult
 }
 
+type AWSEC2ShareJob struct {
+	Ami               string   `json:"ami"`
+	Region            string   `json:"region"`
+	ShareWithAccounts []string `json:"shareWithAccounts"`
+}
+
+type AWSEC2ShareJobResult struct {
+	JobResult
+
+	Ami    string `json:"ami"`
+	Region string `json:"region"`
+}
+
+type AWSEC2CopyJob struct {
+	Ami          string `json:"ami"`
+	SourceRegion string `json:"source_region"`
+	TargetRegion string `json:"target_region"`
+	TargetName   string `json:"target_name"`
+}
+
+type AWSEC2CopyJobResult struct {
+	JobResult
+
+	Ami    string `json:"ami"`
+	Region string `json:"region"`
+}
+
 //
 // JSON-serializable types for the client
 //

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -53,10 +53,11 @@ type JobStatus struct {
 }
 
 type JobInfo struct {
-	JobType   string
-	Channel   string
-	JobStatus *JobStatus
-	Deps      []uuid.UUID
+	JobType    string
+	Channel    string
+	JobStatus  *JobStatus
+	Deps       []uuid.UUID
+	Dependents []uuid.UUID
 }
 
 var ErrInvalidToken = errors.New("token does not exist")
@@ -396,7 +397,7 @@ func (s *Server) AWSEC2ShareJobInfo(id uuid.UUID, result *AWSEC2ShareJobResult) 
 }
 
 func (s *Server) jobInfo(id uuid.UUID, result interface{}) (*JobInfo, error) {
-	jobType, channel, rawResult, queued, started, finished, canceled, deps, _, err := s.jobs.JobStatus(id)
+	jobType, channel, rawResult, queued, started, finished, canceled, deps, dependents, err := s.jobs.JobStatus(id)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,8 @@ func (s *Server) jobInfo(id uuid.UUID, result interface{}) (*JobInfo, error) {
 			Finished: finished,
 			Canceled: canceled,
 		},
-		Deps: deps,
+		Deps:       deps,
+		Dependents: dependents,
 	}, nil
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -396,7 +396,7 @@ func (s *Server) AWSEC2ShareJobInfo(id uuid.UUID, result *AWSEC2ShareJobResult) 
 }
 
 func (s *Server) jobInfo(id uuid.UUID, result interface{}) (*JobInfo, error) {
-	jobType, channel, rawResult, queued, started, finished, canceled, deps, err := s.jobs.JobStatus(id)
+	jobType, channel, rawResult, queued, started, finished, canceled, deps, _, err := s.jobs.JobStatus(id)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 		// TODO: include type of arguments
 		var result json.RawMessage
 		var finished time.Time
-		_, _, result, _, _, finished, _, _, err = s.jobs.JobStatus(depID)
+		_, _, result, _, _, finished, _, _, _, err = s.jobs.JobStatus(depID)
 		if err != nil {
 			return
 		}

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -64,7 +64,7 @@ type JobQueue interface {
 	// finished, respectively.
 	//
 	// Lastly, the IDs of the jobs dependencies are returned.
-	JobStatus(id uuid.UUID) (jobType string, channel string, result json.RawMessage, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, err error)
+	JobStatus(id uuid.UUID) (jobType string, channel string, result json.RawMessage, queued, started, finished time.Time, canceled bool, deps []uuid.UUID, dependents []uuid.UUID, err error)
 
 	// Job returns all the parameters that define a job (everything provided during Enqueue).
 	Job(id uuid.UUID) (jobType string, args json.RawMessage, dependencies []uuid.UUID, channel string, err error)


### PR DESCRIPTION
TODO:
- [x] transfer sharing attributes to the copied image
- [x] transfer tags needed? - decided to just tag similarly to the registration in the osbuild job, but with the new Name => no transfer of original tags
- [x] don't copy an image to a new region if it was already copied there - with the caveat that if 2 jobs are queued at the same time with the same target region the copy will happen twice :/ Could also look at job inputs and chain the share job on the existing copy job that way.


questions:
- [ ] allow to add these on top of a running osbuild job? => use dynargs rather than static ones?
- [ ] split across 2 jobs rn, should be just the 1? Only downside of using 1 job is that you lose the ability to optimize this further, if a copy job has already been queued (but not completed), you could attach multiple share jobs to it.