### PR TITLE
Introduce logging adapter for jobqueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 
 .vscode
 .DS_Store
+/.idea
 
 /containers/config/
 /bin

--- a/internal/common/slogger/logrus.go
+++ b/internal/common/slogger/logrus.go
@@ -1,0 +1,38 @@
+package slogger
+
+import (
+	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
+	"github.com/sirupsen/logrus"
+)
+
+type simpleLogrus struct {
+	logger *logrus.Logger
+}
+
+func NewLogrusLogger(logger *logrus.Logger) jobqueue.SimpleLogger {
+	return &simpleLogrus{logger: logger}
+}
+
+func (s *simpleLogrus) log(level logrus.Level, err error, msg string, args ...string) {
+	if len(args)%2 != 0 {
+		panic("log arguments must be even (key value pairs)")
+	}
+	var fields = make(logrus.Fields, len(args)/2+1)
+	for i := 0; i < len(args); i += 2 {
+		k := args[i]
+		v := args[i+1]
+		fields[k] = v
+	}
+	if err != nil {
+		fields["error"] = err.Error()
+	}
+	s.logger.WithFields(fields).Log(level, msg)
+}
+
+func (s *simpleLogrus) Info(msg string, args ...string) {
+	s.log(logrus.InfoLevel, nil, msg, args...)
+}
+
+func (s *simpleLogrus) Error(err error, msg string, args ...string) {
+	s.log(logrus.ErrorLevel, err, msg, args...)
+}

--- a/internal/common/slogger/logrus_test.go
+++ b/internal/common/slogger/logrus_test.go
@@ -1,0 +1,63 @@
+package slogger
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func makeLogrus(buf *bytes.Buffer) *logrus.Logger {
+	return &logrus.Logger{
+		Out: buf,
+		Formatter: &logrus.TextFormatter{
+			DisableTimestamp: true,
+			DisableColors:    true,
+		},
+		Hooks: make(logrus.LevelHooks),
+		Level: logrus.DebugLevel,
+	}
+
+}
+
+func TestInfo(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	sl := NewLogrusLogger(l)
+	sl.Info("test")
+	require.Equal(t, "level=info msg=test\n", buf.String())
+}
+
+func TestError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	sl := NewLogrusLogger(l)
+	sl.Error(errors.New("e"), "test")
+	require.Equal(t, "level=error msg=test error=e\n", buf.String())
+}
+
+func TestErrorIsNil(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	sl := NewLogrusLogger(l)
+	sl.Error(nil, "test")
+	require.Equal(t, "level=error msg=test\n", buf.String())
+}
+
+func TestInfoWithFields(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	sl := NewLogrusLogger(l)
+	sl.Info("test", "key", "value")
+	require.Equal(t, "level=info msg=test key=value\n", buf.String())
+}
+
+func TestErrorWithFields(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	sl := NewLogrusLogger(l)
+	sl.Error(errors.New("e"), "test", "key", "value")
+	require.Equal(t, "level=error msg=test error=e key=value\n", buf.String())
+}

--- a/internal/common/slogger/noop.go
+++ b/internal/common/slogger/noop.go
@@ -1,0 +1,18 @@
+package slogger
+
+import (
+	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
+)
+
+type noopLogger struct {
+}
+
+func NewNoopLogger() jobqueue.SimpleLogger {
+	return &noopLogger{}
+}
+
+func (s *noopLogger) Info(_ string, _ ...string) {
+}
+
+func (s *noopLogger) Error(_ error, _ string, _ ...string) {
+}

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -79,6 +79,18 @@ type JobQueue interface {
 	RefreshHeartbeat(token uuid.UUID)
 }
 
+// SimpleLogger provides a structured logging methods for the jobqueue library.
+type SimpleLogger interface {
+	// Info creates an info-level message and arbitrary amount of key-value string pairs which
+	// can be optionally mapped to fields by underlying implementations.
+	Info(msg string, args ...string)
+
+	// Error creates an error-level message and arbitrary amount of key-value string pairs which
+	// can be optionally mapped to fields by underlying implementations. The first error argument
+	// can be set to nil when no context error is available.
+	Error(err error, msg string, args ...string)
+}
+
 var (
 	ErrNotExist       = errors.New("job does not exist")
 	ErrNotPending     = errors.New("job is not pending")


### PR DESCRIPTION
Thanks for extracting jobqueue into pkg/. Now, in order to use it in our project, we have two changes to make:

* We rely on database/sql connection pool instead of pgx.
* We do not use logrus.

This patch aims to solve the latter by creating a very simple facade via interface called `SimpleLogger` (naming things is hard bring your own suggestions). It seems the jobqueue only uses logging messages at info level and then error level, so the interface only supports these to keep things simple. It makes sense, as a user of any library you typically want to either enable or disable logging, verbosity mapping has always been problematic thing to solve.

The patch introduces a logrus implementation and a noop implementation. It will require a change in all callers of the New function, I tried my best to find all uses, but since I do not have a full development setup yet, I could not test this properly.
 
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change (not relevant I guess)

I am going to make a draft first to gather feedback. I would appreciate any help in regard to how to test this change.