### PR TITLE
manifest+playground: improve developer experience

### DIFF
--- a/cmd/osbuild-playground/main.go
+++ b/cmd/osbuild-playground/main.go
@@ -49,11 +49,11 @@ func findDnfJsonBin() string {
 
 func main() {
 	var distroArg string
-	flag.StringVar(&distroArg, "distro", "", "distro to build from")
+	flag.StringVar(&distroArg, "distro", "host", "distro to build from")
 	var archArg string
 	flag.StringVar(&archArg, "arch", common.CurrentArch(), "architecture to build for")
 	var imageTypeArg string
-	flag.StringVar(&imageTypeArg, "type", "my-image", "image type to build")
+	flag.StringVar(&imageTypeArg, "type", "my-container", "image type to build")
 	flag.Parse()
 
 	// Path to options or '-' for stdin
@@ -83,15 +83,15 @@ func main() {
 
 	distros := distroregistry.NewDefault()
 	var d distro.Distro
-	if distroArg != "" {
-		d = distros.GetDistro(distroArg)
-		if d == nil {
-			panic(fmt.Sprintf("distro '%s' not supported\n", distroArg))
-		}
-	} else {
+	if distroArg == "host" {
 		d = distros.FromHost()
 		if d == nil {
 			panic("host distro not supported")
+		}
+	} else {
+		d = distros.GetDistro(distroArg)
+		if d == nil {
+			panic(fmt.Sprintf("distro '%s' not supported\n", distroArg))
 		}
 	}
 

--- a/cmd/osbuild-playground/main.go
+++ b/cmd/osbuild-playground/main.go
@@ -14,13 +14,14 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
 )
 
 var ImageTypes = make(map[string]ImageType)
 
 type ImageType interface {
 	Name() string
-	InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner string) error
+	InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner runner.Runner) error
 	GetExports() []string
 	GetCheckpoints() []string
 }

--- a/cmd/osbuild-playground/my-container.go
+++ b/cmd/osbuild-playground/my-container.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/manifest"
+	"github.com/osbuild/osbuild-composer/internal/platform"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
+)
+
+// MyContainer contains the arguments passed in as a JSON blob.
+// You can replace them with whatever you want to use to
+// configure your image. In the current example they are
+// unused.
+type MyContainer struct {
+	MyOption string `json:"my_option"`
+}
+
+// Name returns the name of the image type, used to select what kind
+// of image to build.
+func (img *MyContainer) Name() string {
+	return "my-container"
+}
+
+// init registeres this image type
+func init() {
+	AddImageType(&MyContainer{})
+}
+
+// Build your manifest by attaching pipelines to it
+//
+// @m is the manifest you are constructing
+// @options are what was passed in on the commandline
+// @repos are the default repositories for the host OS/arch
+// @runner is needed by any build pipelines
+//
+// Return nil when you are done, or an error if something
+// went wrong. Your manifest will be streamed to osbuild
+// for building.
+func (img *MyContainer) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner runner.Runner) error {
+	// Let's create a simple OCI container!
+
+	// configure a build pipeline
+	build := manifest.NewBuild(m, runner, repos)
+
+	// create a minimal non-bootable OS tree
+	os := manifest.NewOS(m, build, &platform.X86{}, repos)
+
+	// create an OCI container containing the OS tree created above
+	manifest.NewOCIContainer(m, build, os)
+
+	return nil
+}
+
+// GetExports returns a list of the pipelines osbuild should export.
+// These are the pipelines containing the artefact you want returned.
+//
+// TODO: Move this to be implemented in terms ofthe Manifest package.
+//       We should not need to know the pipeline names.
+func (img *MyContainer) GetExports() []string {
+	return []string{"container"}
+}
+
+// GetCheckpoints returns a list of the pipelines osbuild should
+// checkpoint. These are the pipelines likely to be reusable in
+// future runs.
+//
+// TODO: Move this to be implemented in terms ofthe Manifest package.
+//       We should not need to know the pipeline names.
+func (img *MyContainer) GetCheckpoints() []string {
+	return []string{"build"}
+}

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
 )
 
 func init() {
@@ -35,7 +36,7 @@ func (img *MyImage) Name() string {
 // Return nil when you are done, or an error if something
 // went wrong. Your manifest will be streamed to osbuild
 // for building.
-func (img *MyImage) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner string) error {
+func (img *MyImage) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner runner.Runner) error {
 	// Let's create a simple OCI container!
 
 	// configure a build pipeline

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -40,10 +40,10 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.Repo
 	// Let's create a simple OCI container!
 
 	// configure a build pipeline
-	build := manifest.NewBuildPipeline(m, runner, repos)
+	build := manifest.NewBuild(m, runner, repos)
 
 	// create a non-bootable OS tree containing the `core` comps group
-	os := manifest.NewOSPipeline(m, build, &platform.X86{}, repos)
+	os := manifest.NewOS(m, build, &platform.X86{}, repos)
 	os.ExtraBasePackages = []string{
 		"@core",
 	}
@@ -53,7 +53,7 @@ func (img *MyImage) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.Repo
 		filename = img.Filename
 	}
 	// create an OCI container containing the OS tree created above
-	manifest.NewOCIContainerPipeline(m, build, &os.BasePipeline, "x86_64", filename)
+	manifest.NewOCIContainer(m, build, &os.Base, "x86_64", filename)
 
 	return nil
 }

--- a/cmd/osbuild-playground/my-image.go
+++ b/cmd/osbuild-playground/my-image.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/manifest"
+	"github.com/osbuild/osbuild-composer/internal/platform"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+func init() {
+	AddImageType(&MyImage{})
+}
+
+// MyImage contains the arguments passed in as a JSON blob.
+// You can replace them with whatever you want to use to
+// configure your image. In the current example they are
+// unused.
+type MyImage struct {
+	MyOption string `json:"my_option"`
+	Filename string `json:"filename"`
+}
+
+// Name returns the name of the image type, used to select what kind
+// of image to build.
+func (img *MyImage) Name() string {
+	return "my-image"
+}
+
+// Build your manifest by attaching pipelines to it
+//
+// @m is the manifest you are constructing
+// @options are what was passed in on the commandline
+// @repos are the default repositories for the host OS/arch
+// @runner is needed by any build pipelines
+//
+// Return nil when you are done, or an error if something
+// went wrong. Your manifest will be streamed to osbuild
+// for building.
+func (img *MyImage) InstantiateManifest(m *manifest.Manifest, repos []rpmmd.RepoConfig, runner string) error {
+	// Let's create a simple OCI container!
+
+	// configure a build pipeline
+	build := manifest.NewBuildPipeline(m, runner, repos)
+
+	// create a non-bootable OS tree containing the `core` comps group
+	os := manifest.NewOSPipeline(m, build, &platform.X86{}, repos)
+	os.ExtraBasePackages = []string{
+		"@core",
+	}
+
+	filename := "my-container.tar"
+	if img.Filename != "" {
+		filename = img.Filename
+	}
+	// create an OCI container containing the OS tree created above
+	manifest.NewOCIContainerPipeline(m, build, &os.BasePipeline, "x86_64", filename)
+
+	return nil
+}
+
+// GetExports returns a list of the pipelines osbuild should export.
+// These are the pipelines containing the artefact you want returned.
+//
+// TODO: Move this to be implemented in terms ofthe Manifest package.
+//       We should not need to know the pipeline names.
+func (img *MyImage) GetExports() []string {
+	return []string{"container"}
+}
+
+// GetCheckpoints returns a list of the pipelines osbuild should
+// checkpoint. These are the pipelines likely to be reusable in
+// future runs.
+//
+// TODO: Move this to be implemented in terms ofthe Manifest package.
+//       We should not need to know the pipeline names.
+func (img *MyImage) GetCheckpoints() []string {
+	return []string{"build"}
+}

--- a/cmd/osbuild-playground/partitiontables.go
+++ b/cmd/osbuild-playground/partitiontables.go
@@ -1,0 +1,56 @@
+package main
+
+import "github.com/osbuild/osbuild-composer/internal/disk"
+
+var basePT = disk.PartitionTable{
+	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+	Type: "gpt",
+	Partitions: []disk.Partition{
+		{
+			Size:     1048576, // 1MB
+			Bootable: true,
+			Type:     disk.BIOSBootPartitionGUID,
+			UUID:     disk.BIOSBootPartitionUUID,
+		},
+		{
+			Size: 209715200, // 200 MB
+			Type: disk.EFISystemPartitionGUID,
+			UUID: disk.EFISystemPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "vfat",
+				UUID:         disk.EFIFilesystemUUID,
+				Mountpoint:   "/boot/efi",
+				Label:        "EFI-SYSTEM",
+				FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+				FSTabFreq:    0,
+				FSTabPassNo:  2,
+			},
+		},
+		{
+			Size: 524288000, // 500 MB
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.FilesystemDataUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Mountpoint:   "/boot",
+				Label:        "boot",
+				FSTabOptions: "defaults",
+				FSTabFreq:    0,
+				FSTabPassNo:  0,
+			},
+		},
+		{
+			Size: 2147483648, // 2GiB
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.RootPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Label:        "root",
+				Mountpoint:   "/",
+				FSTabOptions: "defaults",
+				FSTabFreq:    0,
+				FSTabPassNo:  0,
+			},
+		},
+	},
+}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
 )
 
 func RunPlayground(img ImageType, d distro.Distro, arch distro.Arch, repos map[string][]rpmmd.RepoConfig, state_dir string) {
@@ -22,8 +23,8 @@ func RunPlayground(img ImageType, d distro.Distro, arch distro.Arch, repos map[s
 
 	manifest := manifest.New()
 
-	// TODO: figure out the runner situation
-	err := img.InstantiateManifest(&manifest, repos[arch.Name()], "org.osbuild.fedora36")
+	// TODO: query distro for runner
+	err := img.InstantiateManifest(&manifest, repos[arch.Name()], &runner.Fedora{Version: 36})
 	if err != nil {
 		panic("InstantiateManifest() failed: " + err.Error())
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
@@ -144,7 +145,7 @@ func (impl *OSBuildKojiJobImpl) Run(job worker.Job) error {
 			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, err.Error())
 			return err
 		}
-		result.OSBuildOutput, err = RunOSBuild(args.Manifest, impl.Store, outputDirectory, exports, os.Stderr)
+		result.OSBuildOutput, err = osbuild2.RunOSBuild(args.Manifest, impl.Store, outputDirectory, exports, nil, true, os.Stderr)
 		if err != nil {
 			return err
 		}

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/container"
+	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 	"github.com/osbuild/osbuild-composer/internal/upload/oci"
 
 	"github.com/google/uuid"
@@ -21,7 +22,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/cloud/awscloud"
 	"github.com/osbuild/osbuild-composer/internal/cloud/gcp"
 	"github.com/osbuild/osbuild-composer/internal/common"
-	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/upload/azure"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
@@ -202,7 +202,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	// Initialize variable needed for reporting back to osbuild-composer.
 	var osbuildJobResult *worker.OSBuildJobResult = &worker.OSBuildJobResult{
 		Success: false,
-		OSBuildOutput: &osbuild.Result{
+		OSBuildOutput: &osbuild2.Result{
 			Success: false,
 		},
 		UploadStatus: "failure",
@@ -306,7 +306,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	}
 
 	// Run osbuild and handle two kinds of errors
-	osbuildJobResult.OSBuildOutput, err = RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, os.Stderr)
+	osbuildJobResult.OSBuildOutput, err = osbuild2.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, true, os.Stderr)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed")

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
 	"github.com/osbuild/osbuild-composer/internal/workload"
 )
 
@@ -289,7 +290,7 @@ type distribution struct {
 	vendor             string
 	ostreeRefTmpl      string
 	isolabelTmpl       string
-	runner             string
+	runner             runner.Runner
 	arches             map[string]distro.Arch
 	defaultImageConfig *distro.ImageConfig
 }
@@ -311,7 +312,7 @@ var distroMap = map[string]distribution{
 		vendor:             "fedora",
 		ostreeRefTmpl:      "fedora/34/%s/iot",
 		isolabelTmpl:       "Fedora-34-BaseOS-%s",
-		runner:             "org.osbuild.fedora34",
+		runner:             &runner.Fedora{Version: 34},
 		defaultImageConfig: defaultDistroImageConfig,
 	},
 	fedora35Distribution: {
@@ -323,7 +324,7 @@ var distroMap = map[string]distribution{
 		vendor:             "fedora",
 		ostreeRefTmpl:      "fedora/35/%s/iot",
 		isolabelTmpl:       "Fedora-35-BaseOS-%s",
-		runner:             "org.osbuild.fedora35",
+		runner:             &runner.Fedora{Version: 35},
 		defaultImageConfig: defaultDistroImageConfig,
 	},
 	fedora36Distribution: {
@@ -335,7 +336,7 @@ var distroMap = map[string]distribution{
 		vendor:             "fedora",
 		ostreeRefTmpl:      "fedora/36/%s/iot",
 		isolabelTmpl:       "Fedora-36-BaseOS-%s",
-		runner:             "org.osbuild.fedora36",
+		runner:             &runner.Fedora{Version: 36},
 		defaultImageConfig: defaultDistroImageConfig,
 	},
 }

--- a/internal/distro/fedora/manifests.go
+++ b/internal/distro/fedora/manifests.go
@@ -19,13 +19,13 @@ func qcow2Manifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return err
 	}
-	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	qcow2Pipeline := manifest.NewQCOW2Pipeline(m, buildPipeline, imagePipeline, t.filename)
+	imagePipeline := manifest.NewRawImage(m, buildPipeline, treePipeline, "disk.img")
+	qcow2Pipeline := manifest.NewQCOW2(m, buildPipeline, imagePipeline, t.filename)
 	qcow2Pipeline.Compat = "1.1"
 
 	return nil
@@ -40,13 +40,13 @@ func vhdManifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return err
 	}
-	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	manifest.NewVPCPipeline(m, buildPipeline, imagePipeline, t.filename)
+	imagePipeline := manifest.NewRawImage(m, buildPipeline, treePipeline, "disk.img")
+	manifest.NewVPC(m, buildPipeline, imagePipeline, t.filename)
 
 	return nil
 }
@@ -60,13 +60,13 @@ func vmdkManifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return err
 	}
-	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	manifest.NewVMDKPipeline(m, buildPipeline, imagePipeline, t.filename)
+	imagePipeline := manifest.NewRawImage(m, buildPipeline, treePipeline, "disk.img")
+	manifest.NewVMDK(m, buildPipeline, imagePipeline, t.filename)
 
 	return nil
 }
@@ -80,13 +80,13 @@ func openstackManifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return err
 	}
-	imagePipeline := manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, "disk.img")
-	manifest.NewQCOW2Pipeline(m, buildPipeline, imagePipeline, t.filename)
+	imagePipeline := manifest.NewRawImage(m, buildPipeline, treePipeline, "disk.img")
+	manifest.NewQCOW2(m, buildPipeline, imagePipeline, t.filename)
 
 	return nil
 }
@@ -101,12 +101,12 @@ func ec2CommonManifest(m *manifest.Manifest,
 	rng *rand.Rand,
 	diskfile string) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return nil
 	}
-	manifest.NewLiveImgPipeline(m, buildPipeline, treePipeline, diskfile)
+	manifest.NewRawImage(m, buildPipeline, treePipeline, diskfile)
 
 	return nil
 }
@@ -132,7 +132,7 @@ func iotInstallerManifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 
 	d := t.arch.distro
 	ksUsers := len(customizations.GetUsers())+len(customizations.GetGroups()) > 0
@@ -150,10 +150,10 @@ func iotCorePipelines(m *manifest.Manifest,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
 	repos []rpmmd.RepoConfig,
-	packageSets map[string]rpmmd.PackageSet) (*manifest.BuildPipeline,
-	*manifest.OSTreeCommitPipeline,
+	packageSets map[string]rpmmd.PackageSet) (*manifest.Build,
+	*manifest.OSTreeCommit,
 	error) {
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, nil)
 	if err != nil {
 		return nil, nil, err
@@ -176,7 +176,7 @@ func iotCommitManifest(m *manifest.Manifest,
 	if err != nil {
 		return err
 	}
-	manifest.NewTarPipeline(m, buildPipeline, &commitPipeline.BasePipeline, "commit-archive", t.Filename())
+	manifest.NewTar(m, buildPipeline, &commitPipeline.Base, "commit-archive", t.Filename())
 
 	return nil
 }
@@ -197,7 +197,7 @@ func iotContainerManifest(m *manifest.Manifest,
 	nginxConfigPath := "/etc/nginx.conf"
 	httpPort := "8080"
 	containerTreePipeline := containerTreePipeline(m, buildPipeline, commitPipeline, repos, packageSets[containerPkgsKey], options, customizations, nginxConfigPath, httpPort)
-	containerPipeline(m, buildPipeline, &containerTreePipeline.BasePipeline, t, nginxConfigPath, httpPort)
+	containerPipeline(m, buildPipeline, &containerTreePipeline.Base, t, nginxConfigPath, httpPort)
 
 	return nil
 }
@@ -211,29 +211,29 @@ func containerManifest(m *manifest.Manifest,
 	packageSets map[string]rpmmd.PackageSet,
 	rng *rand.Rand) error {
 
-	buildPipeline := manifest.NewBuildPipeline(m, t.arch.distro.runner, repos)
+	buildPipeline := manifest.NewBuild(m, t.arch.distro.runner, repos)
 	treePipeline, err := osPipeline(m, buildPipeline, workload, t, repos, packageSets[osPkgsKey], customizations, options, rng)
 	if err != nil {
 		return err
 	}
-	manifest.NewOCIContainerPipeline(m, buildPipeline, &treePipeline.BasePipeline, t.Arch().Name(), t.Filename())
+	manifest.NewOCIContainer(m, buildPipeline, &treePipeline.Base, t.Arch().Name(), t.Filename())
 
 	return nil
 }
 
 func osPipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
+	buildPipeline *manifest.Build,
 	workload workload.Workload,
 	t *imageType,
 	repos []rpmmd.RepoConfig,
 	osPackageSet rpmmd.PackageSet,
 	c *blueprint.Customizations,
 	options distro.ImageOptions,
-	rng *rand.Rand) (*manifest.OSPipeline, error) {
+	rng *rand.Rand) (*manifest.OS, error) {
 
 	imageConfig := t.getDefaultImageConfig()
 
-	pl := manifest.NewOSPipeline(m, buildPipeline, t.platform, repos)
+	pl := manifest.NewOS(m, buildPipeline, t.platform, repos)
 	pl.Environment = t.environment
 	pl.Workload = workload
 
@@ -347,25 +347,25 @@ func osPipeline(m *manifest.Manifest,
 }
 
 func ostreeCommitPipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
-	treePipeline *manifest.OSPipeline,
+	buildPipeline *manifest.Build,
+	treePipeline *manifest.OS,
 	options distro.ImageOptions,
-	osVersion string) *manifest.OSTreeCommitPipeline {
-	p := manifest.NewOSTreeCommitPipeline(m, buildPipeline, treePipeline, options.OSTree.Ref)
+	osVersion string) *manifest.OSTreeCommit {
+	p := manifest.NewOSTreeCommit(m, buildPipeline, treePipeline, options.OSTree.Ref)
 	p.OSVersion = osVersion
 	return p
 }
 
 func containerTreePipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
-	commitPipeline *manifest.OSTreeCommitPipeline,
+	buildPipeline *manifest.Build,
+	commitPipeline *manifest.OSTreeCommit,
 	repos []rpmmd.RepoConfig,
 	containerPackageSet rpmmd.PackageSet,
 	options distro.ImageOptions,
 	c *blueprint.Customizations,
 	nginxConfigPath,
-	listenPort string) *manifest.OSTreeCommitServerTreePipeline {
-	p := manifest.NewOSTreeCommitServerTreePipeline(m, buildPipeline, repos, commitPipeline, nginxConfigPath, listenPort)
+	listenPort string) *manifest.OSTreeCommitServer {
+	p := manifest.NewOSTreeCommitServer(m, buildPipeline, repos, commitPipeline, nginxConfigPath, listenPort)
 	p.ExtraPackages = containerPackageSet.Include
 	p.ExtraRepos = containerPackageSet.Repositories
 	language, _ := c.GetPrimaryLocale()
@@ -376,24 +376,24 @@ func containerTreePipeline(m *manifest.Manifest,
 }
 
 func containerPipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
-	treePipeline *manifest.BasePipeline,
+	buildPipeline *manifest.Build,
+	treePipeline *manifest.Base,
 	t *imageType,
 	nginxConfigPath,
-	listenPort string) *manifest.OCIContainerPipeline {
-	p := manifest.NewOCIContainerPipeline(m, buildPipeline, treePipeline, t.Arch().Name(), t.Filename())
+	listenPort string) *manifest.OCIContainer {
+	p := manifest.NewOCIContainer(m, buildPipeline, treePipeline, t.Arch().Name(), t.Filename())
 	p.Cmd = []string{"nginx", "-c", nginxConfigPath}
 	p.ExposedPorts = []string{listenPort}
 	return p
 }
 
 func anacondaTreePipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
+	buildPipeline *manifest.Build,
 	repos []rpmmd.RepoConfig,
 	installerPackageSet rpmmd.PackageSet,
 	arch, product, osVersion, variant string,
-	users bool) *manifest.AnacondaPipeline {
-	p := manifest.NewAnacondaPipeline(m, buildPipeline, repos, "kernel", arch, product, osVersion)
+	users bool) *manifest.Anaconda {
+	p := manifest.NewAnaconda(m, buildPipeline, repos, "kernel", arch, product, osVersion)
 	p.ExtraPackages = installerPackageSet.Include
 	p.ExtraRepos = installerPackageSet.Repositories
 
@@ -404,14 +404,14 @@ func anacondaTreePipeline(m *manifest.Manifest,
 }
 
 func bootISOTreePipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
-	anacondaPipeline *manifest.AnacondaPipeline,
+	buildPipeline *manifest.Build,
+	anacondaPipeline *manifest.Anaconda,
 	options distro.ImageOptions,
 	vendor,
 	isoLabelTempl string,
 	users []blueprint.UserCustomization,
-	groups []blueprint.GroupCustomization) *manifest.ISOTreePipeline {
-	p := manifest.NewISOTreePipeline(m, buildPipeline, anacondaPipeline, options.OSTree.Parent, options.OSTree.URL, options.OSTree.Ref, isoLabelTempl)
+	groups []blueprint.GroupCustomization) *manifest.ISOTree {
+	p := manifest.NewISOTree(m, buildPipeline, anacondaPipeline, options.OSTree.Parent, options.OSTree.URL, options.OSTree.Ref, isoLabelTempl)
 	p.Release = "202010217.n.0"
 	p.OSName = "fedora"
 	p.UEFIVendor = vendor
@@ -422,11 +422,11 @@ func bootISOTreePipeline(m *manifest.Manifest,
 }
 
 func bootISOPipeline(m *manifest.Manifest,
-	buildPipeline *manifest.BuildPipeline,
-	treePipeline *manifest.ISOTreePipeline,
+	buildPipeline *manifest.Build,
+	treePipeline *manifest.ISOTree,
 	filename string,
-	isolinux bool) *manifest.ISOPipeline {
-	p := manifest.NewISOPipeline(m, buildPipeline, treePipeline, filename)
+	isolinux bool) *manifest.ISO {
+	p := manifest.NewISO(m, buildPipeline, treePipeline, filename)
 	p.ISOLinux = isolinux
 	return p
 }

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -52,7 +52,7 @@ func NewAnacondaPipeline(m *Manifest,
 	product,
 	version string) *AnacondaPipeline {
 	p := &AnacondaPipeline{
-		BasePipeline: NewBasePipeline(m, "anaconda-tree", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "anaconda-tree", buildPipeline),
 		repos:        repos,
 		kernelName:   kernelName,
 		arch:         arch,

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -102,6 +102,7 @@ func (p *AnacondaPipeline) anacondaBootPackageSet() []string {
 func (p *AnacondaPipeline) getBuildPackages() []string {
 	packages := p.anacondaBootPackageSet()
 	packages = append(packages,
+		"rpm",
 		"lorax-templates-generic",
 	)
 	return packages

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -39,7 +39,6 @@ func (p *BuildPipeline) addDependent(dep Pipeline) {
 func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 	// TODO: break apart into individual pipelines
 	packages := []string{
-		"dnf",
 		"selinux-policy-targeted",
 		"coreutils",
 		"systemd",

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -40,11 +40,10 @@ func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 	// TODO: break apart into individual pipelines
 	packages := []string{
 		"dnf",
+		"selinux-policy-targeted",
 		"coreutils",
 		"dosfstools",
 		"e2fsprogs",
-		"policycoreutils",
-		"selinux-policy-targeted",
 		"systemd",
 		"tar",
 		"xz",

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -42,8 +42,6 @@ func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 		"dnf",
 		"selinux-policy-targeted",
 		"coreutils",
-		"dosfstools",
-		"e2fsprogs",
 		"systemd",
 		"tar",
 		"xz",

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -43,7 +43,6 @@ func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 		"selinux-policy-targeted",
 		"coreutils",
 		"systemd",
-		"tar",
 		"xz",
 	}
 

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -43,7 +43,6 @@ func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 		"dosfstools",
 		"e2fsprogs",
 		"policycoreutils",
-		"qemu-img",
 		"selinux-policy-targeted",
 		"systemd",
 		"tar",

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -40,6 +40,7 @@ func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
 	// TODO: break apart into individual pipelines
 	packages := []string{
 		"dnf",
+		"coreutils",
 		"dosfstools",
 		"e2fsprogs",
 		"policycoreutils",

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -37,12 +37,15 @@ func (p *BuildPipeline) addDependent(dep Pipeline) {
 }
 
 func (p *BuildPipeline) getPackageSetChain() []rpmmd.PackageSet {
-	// TODO: break apart into individual pipelines
+	// TODO: have a runner abstraction that provides the necessary packages
+	// TODO: make the /usr/bin/cp dependency conditional
+	// TODO: make the /usr/bin/xz dependency conditional
 	packages := []string{
-		"selinux-policy-targeted",
-		"coreutils",
-		"systemd",
-		"xz",
+		"selinux-policy-targeted", // needed to build the build pipeline
+		"coreutils",               // /usr/bin/cp - used all over
+		"glibc",                   // ldconfig - used in the runner
+		"systemd",                 // systemd-tmpfiles and systemd-sysusers - used in the runner
+		"xz",                      // usage unclear
 	}
 
 	for _, pipeline := range p.dependents {
@@ -85,6 +88,7 @@ func (p *BuildPipeline) serialize() osbuild2.Pipeline {
 	pipeline.AddStage(osbuild2.NewSELinuxStage(&osbuild2.SELinuxStageOptions{
 		FileContexts: "etc/selinux/targeted/contexts/files/file_contexts",
 		Labels: map[string]string{
+			// TODO: make conditional
 			"/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
 		},
 	},

--- a/internal/manifest/commit.go
+++ b/internal/manifest/commit.go
@@ -21,7 +21,7 @@ func NewOSTreeCommitPipeline(m *Manifest,
 	treePipeline *OSPipeline,
 	ref string) *OSTreeCommitPipeline {
 	p := &OSTreeCommitPipeline{
-		BasePipeline: NewBasePipeline(m, "ostree-commit", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "ostree-commit", buildPipeline),
 		treePipeline: treePipeline,
 		ref:          ref,
 	}

--- a/internal/manifest/commit.go
+++ b/internal/manifest/commit.go
@@ -4,28 +4,28 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// OSTreeCommitPipeline represents an ostree with one commit.
-type OSTreeCommitPipeline struct {
-	BasePipeline
+// OSTreeCommit represents an ostree with one commit.
+type OSTreeCommit struct {
+	Base
 	OSVersion string
 
-	treePipeline *OSPipeline
+	treePipeline *OS
 	ref          string
 }
 
-// NewOSTreeCommitPipeline creates a new OSTree commit pipeline. The
+// NewOSTreeCommit creates a new OSTree commit pipeline. The
 // treePipeline is the tree representing the content of the commit.
 // ref is the ref to create the commit under.
-func NewOSTreeCommitPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	treePipeline *OSPipeline,
-	ref string) *OSTreeCommitPipeline {
-	p := &OSTreeCommitPipeline{
-		BasePipeline: NewBasePipeline(m, "ostree-commit", buildPipeline),
+func NewOSTreeCommit(m *Manifest,
+	buildPipeline *Build,
+	treePipeline *OS,
+	ref string) *OSTreeCommit {
+	p := &OSTreeCommit{
+		Base:         NewBase(m, "ostree-commit", buildPipeline),
 		treePipeline: treePipeline,
 		ref:          ref,
 	}
-	if treePipeline.BasePipeline.manifest != m {
+	if treePipeline.Base.manifest != m {
 		panic("tree pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -33,15 +33,15 @@ func NewOSTreeCommitPipeline(m *Manifest,
 	return p
 }
 
-func (p *OSTreeCommitPipeline) getBuildPackages() []string {
+func (p *OSTreeCommit) getBuildPackages() []string {
 	packages := []string{
 		"rpm-ostree",
 	}
 	return packages
 }
 
-func (p *OSTreeCommitPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *OSTreeCommit) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	if p.treePipeline.OSTree == nil {
 		panic("tree is not ostree")

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -66,6 +66,7 @@ func (p *OSTreeCommitServerTreePipeline) getPackageSetChain() []rpmmd.PackageSet
 
 func (p *OSTreeCommitServerTreePipeline) getBuildPackages() []string {
 	packages := []string{
+		"rpm",
 		"rpm-ostree",
 	}
 	return packages

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -39,7 +39,7 @@ func NewOSTreeCommitServerTreePipeline(m *Manifest,
 	nginxConfigPath,
 	listenPort string) *OSTreeCommitServerTreePipeline {
 	p := &OSTreeCommitServerTreePipeline{
-		BasePipeline:    NewBasePipeline(m, "container-tree", buildPipeline, nil),
+		BasePipeline:    NewBasePipeline(m, "container-tree", buildPipeline),
 		repos:           repos,
 		commitPipeline:  commitPipeline,
 		nginxConfigPath: nginxConfigPath,

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -8,10 +8,10 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
-// An OSTreeCommitServerTreePipeline contains an nginx server serving
+// An OSTreeCommitServer contains an nginx server serving
 // an embedded ostree commit.
-type OSTreeCommitServerTreePipeline struct {
-	BasePipeline
+type OSTreeCommitServer struct {
+	Base
 	// Packages to install in addition to the ones required by the
 	// pipeline.
 	ExtraPackages []string
@@ -22,31 +22,31 @@ type OSTreeCommitServerTreePipeline struct {
 
 	repos           []rpmmd.RepoConfig
 	packageSpecs    []rpmmd.PackageSpec
-	commitPipeline  *OSTreeCommitPipeline
+	commitPipeline  *OSTreeCommit
 	nginxConfigPath string
 	listenPort      string
 }
 
-// NewOSTreeCommitServerTreePipeline creates a new pipeline. The content
+// NewOSTreeCommitServer creates a new pipeline. The content
 // is built from repos and packages, which must contain nginx. commitPipeline
 // is a pipeline producing an ostree commit to be served. nginxConfigPath
 // is the path to the main nginx config file and listenPort is the port
 // nginx will be listening on.
-func NewOSTreeCommitServerTreePipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
+func NewOSTreeCommitServer(m *Manifest,
+	buildPipeline *Build,
 	repos []rpmmd.RepoConfig,
-	commitPipeline *OSTreeCommitPipeline,
+	commitPipeline *OSTreeCommit,
 	nginxConfigPath,
-	listenPort string) *OSTreeCommitServerTreePipeline {
-	p := &OSTreeCommitServerTreePipeline{
-		BasePipeline:    NewBasePipeline(m, "container-tree", buildPipeline),
+	listenPort string) *OSTreeCommitServer {
+	p := &OSTreeCommitServer{
+		Base:            NewBase(m, "container-tree", buildPipeline),
 		repos:           repos,
 		commitPipeline:  commitPipeline,
 		nginxConfigPath: nginxConfigPath,
 		listenPort:      listenPort,
 		Language:        "en_US",
 	}
-	if commitPipeline.BasePipeline.manifest != m {
+	if commitPipeline.Base.manifest != m {
 		panic("commit pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -54,7 +54,7 @@ func NewOSTreeCommitServerTreePipeline(m *Manifest,
 	return p
 }
 
-func (p *OSTreeCommitServerTreePipeline) getPackageSetChain() []rpmmd.PackageSet {
+func (p *OSTreeCommitServer) getPackageSetChain() []rpmmd.PackageSet {
 	packages := []string{"nginx"}
 	return []rpmmd.PackageSet{
 		{
@@ -64,7 +64,7 @@ func (p *OSTreeCommitServerTreePipeline) getPackageSetChain() []rpmmd.PackageSet
 	}
 }
 
-func (p *OSTreeCommitServerTreePipeline) getBuildPackages() []string {
+func (p *OSTreeCommitServer) getBuildPackages() []string {
 	packages := []string{
 		"rpm",
 		"rpm-ostree",
@@ -72,29 +72,29 @@ func (p *OSTreeCommitServerTreePipeline) getBuildPackages() []string {
 	return packages
 }
 
-func (p *OSTreeCommitServerTreePipeline) getPackageSpecs() []rpmmd.PackageSpec {
+func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServerTreePipeline) serializeStart(packages []rpmmd.PackageSpec) {
+func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
 	p.packageSpecs = packages
 }
 
-func (p *OSTreeCommitServerTreePipeline) serializeEnd() {
+func (p *OSTreeCommitServer) serializeEnd() {
 	if len(p.packageSpecs) == 0 {
 		panic("serializeEnd() call when serialization not in progress")
 	}
 	p.packageSpecs = nil
 }
 
-func (p *OSTreeCommitServerTreePipeline) serialize() osbuild2.Pipeline {
+func (p *OSTreeCommitServer) serialize() osbuild2.Pipeline {
 	if len(p.packageSpecs) == 0 {
 		panic("serialization not started")
 	}
-	pipeline := p.BasePipeline.serialize()
+	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewRPMStage(osbuild2.NewRPMStageOptions(p.repos), osbuild2.NewRpmStageSourceFilesInputs(p.packageSpecs)))
 	pipeline.AddStage(osbuild2.NewLocaleStage(&osbuild2.LocaleStageOptions{Language: p.Language}))

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
@@ -20,6 +21,7 @@ type OSTreeCommitServer struct {
 	// TODO: should this be configurable?
 	Language string
 
+	platform        platform.Platform
 	repos           []rpmmd.RepoConfig
 	packageSpecs    []rpmmd.PackageSpec
 	commitPipeline  *OSTreeCommit
@@ -34,12 +36,14 @@ type OSTreeCommitServer struct {
 // nginx will be listening on.
 func NewOSTreeCommitServer(m *Manifest,
 	buildPipeline *Build,
+	platform platform.Platform,
 	repos []rpmmd.RepoConfig,
 	commitPipeline *OSTreeCommit,
 	nginxConfigPath,
 	listenPort string) *OSTreeCommitServer {
 	p := &OSTreeCommitServer{
 		Base:            NewBase(m, "container-tree", buildPipeline),
+		platform:        platform,
 		repos:           repos,
 		commitPipeline:  commitPipeline,
 		nginxConfigPath: nginxConfigPath,
@@ -138,4 +142,8 @@ func chmodStageOptions(path, mode string, recursive bool) *osbuild2.ChmodStageOp
 			path: {Mode: mode, Recursive: recursive},
 		},
 	}
+}
+
+func (p *OSTreeCommitServer) GetPlatform() platform.Platform {
+	return p.platform
 }

--- a/internal/manifest/iso.go
+++ b/internal/manifest/iso.go
@@ -19,7 +19,7 @@ func NewISOPipeline(m *Manifest,
 	treePipeline *ISOTreePipeline,
 	filename string) *ISOPipeline {
 	p := &ISOPipeline{
-		BasePipeline: NewBasePipeline(m, "bootiso", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "bootiso", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     filename,
 	}

--- a/internal/manifest/iso.go
+++ b/internal/manifest/iso.go
@@ -4,42 +4,42 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// An ISOPipeline represents a bootable ISO file created from an
+// An ISO represents a bootable ISO file created from an
 // an existing ISOTreePipeline.
-type ISOPipeline struct {
-	BasePipeline
+type ISO struct {
+	Base
 	ISOLinux bool
 
-	treePipeline *ISOTreePipeline
+	treePipeline *ISOTree
 	filename     string
 }
 
-func NewISOPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	treePipeline *ISOTreePipeline,
-	filename string) *ISOPipeline {
-	p := &ISOPipeline{
-		BasePipeline: NewBasePipeline(m, "bootiso", buildPipeline),
+func NewISO(m *Manifest,
+	buildPipeline *Build,
+	treePipeline *ISOTree,
+	filename string) *ISO {
+	p := &ISO{
+		Base:         NewBase(m, "bootiso", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     filename,
 	}
 	buildPipeline.addDependent(p)
-	if treePipeline.BasePipeline.manifest != m {
+	if treePipeline.Base.manifest != m {
 		panic("tree pipeline from different manifest")
 	}
 	m.addPipeline(p)
 	return p
 }
 
-func (p *ISOPipeline) getBuildPackages() []string {
+func (p *ISO) getBuildPackages() []string {
 	return []string{
 		"isomd5sum",
 		"xorriso",
 	}
 }
 
-func (p *ISOPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *ISO) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewXorrisofsStage(xorrisofsStageOptions(p.filename, p.treePipeline.isoLabel, p.ISOLinux), osbuild2.NewXorrisofsStagePipelineTreeInputs(p.treePipeline.Name())))
 	pipeline.AddStage(osbuild2.NewImplantisomd5Stage(&osbuild2.Implantisomd5StageOptions{Filename: p.filename}))

--- a/internal/manifest/iso.go
+++ b/internal/manifest/iso.go
@@ -9,19 +9,18 @@ import (
 type ISO struct {
 	Base
 	ISOLinux bool
+	Filename string
 
 	treePipeline *ISOTree
-	filename     string
 }
 
 func NewISO(m *Manifest,
 	buildPipeline *Build,
-	treePipeline *ISOTree,
-	filename string) *ISO {
+	treePipeline *ISOTree) *ISO {
 	p := &ISO{
 		Base:         NewBase(m, "bootiso", buildPipeline),
 		treePipeline: treePipeline,
-		filename:     filename,
+		Filename:     "image.iso",
 	}
 	buildPipeline.addDependent(p)
 	if treePipeline.Base.manifest != m {
@@ -41,8 +40,8 @@ func (p *ISO) getBuildPackages() []string {
 func (p *ISO) serialize() osbuild2.Pipeline {
 	pipeline := p.Base.serialize()
 
-	pipeline.AddStage(osbuild2.NewXorrisofsStage(xorrisofsStageOptions(p.filename, p.treePipeline.isoLabel, p.ISOLinux), osbuild2.NewXorrisofsStagePipelineTreeInputs(p.treePipeline.Name())))
-	pipeline.AddStage(osbuild2.NewImplantisomd5Stage(&osbuild2.Implantisomd5StageOptions{Filename: p.filename}))
+	pipeline.AddStage(osbuild2.NewXorrisofsStage(xorrisofsStageOptions(p.Filename, p.treePipeline.isoLabel, p.ISOLinux), osbuild2.NewXorrisofsStagePipelineTreeInputs(p.treePipeline.Name())))
+	pipeline.AddStage(osbuild2.NewImplantisomd5Stage(&osbuild2.Implantisomd5StageOptions{Filename: p.Filename}))
 
 	return pipeline
 }

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -36,7 +36,7 @@ func NewISOTree(m *Manifest,
 	osTreeRef,
 	isoLabelTmpl string) *ISOTree {
 	// TODO: replace isoLabelTmpl with more high-level properties
-	isoLabel := fmt.Sprintf(isoLabelTmpl, anacondaPipeline.arch)
+	isoLabel := fmt.Sprintf(isoLabelTmpl, anacondaPipeline.platform.GetArch())
 
 	p := &ISOTree{
 		Base:             NewBase(m, "bootiso-tree", buildPipeline),
@@ -77,7 +77,14 @@ func (p *ISOTree) serialize() osbuild2.Pipeline {
 	kspath := "/osbuild.ks"
 	ostreeRepoPath := "/ostree/repo"
 
-	pipeline.AddStage(osbuild2.NewBootISOMonoStage(bootISOMonoStageOptions(p.anacondaPipeline.kernelVer, p.anacondaPipeline.arch, p.UEFIVendor, p.anacondaPipeline.product, p.anacondaPipeline.version, p.isoLabel, kspath), osbuild2.NewBootISOMonoStagePipelineTreeInputs(p.anacondaPipeline.Name())))
+	pipeline.AddStage(osbuild2.NewBootISOMonoStage(bootISOMonoStageOptions(p.anacondaPipeline.kernelVer,
+		p.anacondaPipeline.platform.GetArch().String(),
+		p.UEFIVendor,
+		p.anacondaPipeline.product,
+		p.anacondaPipeline.version,
+		p.isoLabel,
+		kspath),
+		osbuild2.NewBootISOMonoStagePipelineTreeInputs(p.anacondaPipeline.Name())))
 
 	kickstartOptions, err := osbuild2.NewKickstartStageOptions(kspath, "", p.Users, p.Groups, makeISORootPath(ostreeRepoPath), p.osTreeRef, p.OSName)
 	if err != nil {
@@ -86,7 +93,7 @@ func (p *ISOTree) serialize() osbuild2.Pipeline {
 
 	pipeline.AddStage(osbuild2.NewKickstartStage(kickstartOptions))
 	pipeline.AddStage(osbuild2.NewDiscinfoStage(&osbuild2.DiscinfoStageOptions{
-		BaseArch: p.anacondaPipeline.arch,
+		BaseArch: p.anacondaPipeline.platform.GetArch().String(),
 		Release:  p.Release,
 	}))
 

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -39,7 +39,7 @@ func NewISOTreePipeline(m *Manifest,
 	isoLabel := fmt.Sprintf(isoLabelTmpl, anacondaPipeline.arch)
 
 	p := &ISOTreePipeline{
-		BasePipeline:     NewBasePipeline(m, "bootiso-tree", buildPipeline, nil),
+		BasePipeline:     NewBasePipeline(m, "bootiso-tree", buildPipeline),
 		anacondaPipeline: anacondaPipeline,
 		isoLabel:         isoLabel,
 		osTreeCommit:     osTreeCommit,

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -9,11 +9,11 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// An ISOTreePipeline represents a tree containing the anaconda installer,
+// An ISOTree represents a tree containing the anaconda installer,
 // configuration in terms of a kickstart file, as well as an embedded
 // payload to be installed.
-type ISOTreePipeline struct {
-	BasePipeline
+type ISOTree struct {
+	Base
 	// TODO: review optional and mandatory fields and their meaning
 	UEFIVendor string
 	OSName     string
@@ -21,25 +21,25 @@ type ISOTreePipeline struct {
 	Users      []blueprint.UserCustomization
 	Groups     []blueprint.GroupCustomization
 
-	anacondaPipeline *AnacondaPipeline
+	anacondaPipeline *Anaconda
 	isoLabel         string
 	osTreeCommit     string
 	osTreeURL        string
 	osTreeRef        string
 }
 
-func NewISOTreePipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	anacondaPipeline *AnacondaPipeline,
+func NewISOTree(m *Manifest,
+	buildPipeline *Build,
+	anacondaPipeline *Anaconda,
 	osTreeCommit,
 	osTreeURL,
 	osTreeRef,
-	isoLabelTmpl string) *ISOTreePipeline {
+	isoLabelTmpl string) *ISOTree {
 	// TODO: replace isoLabelTmpl with more high-level properties
 	isoLabel := fmt.Sprintf(isoLabelTmpl, anacondaPipeline.arch)
 
-	p := &ISOTreePipeline{
-		BasePipeline:     NewBasePipeline(m, "bootiso-tree", buildPipeline),
+	p := &ISOTree{
+		Base:             NewBase(m, "bootiso-tree", buildPipeline),
 		anacondaPipeline: anacondaPipeline,
 		isoLabel:         isoLabel,
 		osTreeCommit:     osTreeCommit,
@@ -47,14 +47,14 @@ func NewISOTreePipeline(m *Manifest,
 		osTreeRef:        osTreeRef,
 	}
 	buildPipeline.addDependent(p)
-	if anacondaPipeline.BasePipeline.manifest != m {
+	if anacondaPipeline.Base.manifest != m {
 		panic("anaconda pipeline from different manifest")
 	}
 	m.addPipeline(p)
 	return p
 }
 
-func (p *ISOTreePipeline) getOSTreeCommits() []osTreeCommit {
+func (p *ISOTree) getOSTreeCommits() []osTreeCommit {
 	return []osTreeCommit{
 		{
 			checksum: p.osTreeCommit,
@@ -63,7 +63,7 @@ func (p *ISOTreePipeline) getOSTreeCommits() []osTreeCommit {
 	}
 }
 
-func (p *ISOTreePipeline) getBuildPackages() []string {
+func (p *ISOTree) getBuildPackages() []string {
 	packages := []string{
 		"rpm-ostree",
 		"squashfs-tools",
@@ -71,8 +71,8 @@ func (p *ISOTreePipeline) getBuildPackages() []string {
 	return packages
 }
 
-func (p *ISOTreePipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *ISOTree) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	kspath := "/osbuild.ks"
 	ostreeRepoPath := "/ostree/repo"

--- a/internal/manifest/live.go
+++ b/internal/manifest/live.go
@@ -31,6 +31,10 @@ func NewLiveImgPipeline(m *Manifest,
 	return p
 }
 
+func (p *LiveImgPipeline) getBuildPackages() []string {
+	return p.treePipeline.PartitionTable.GetBuildPackages()
+}
+
 func (p *LiveImgPipeline) serialize() osbuild2.Pipeline {
 	pipeline := p.BasePipeline.serialize()
 

--- a/internal/manifest/live.go
+++ b/internal/manifest/live.go
@@ -19,7 +19,7 @@ func NewLiveImgPipeline(m *Manifest,
 	treePipeline *OSPipeline,
 	filename string) *LiveImgPipeline {
 	p := &LiveImgPipeline{
-		BasePipeline: NewBasePipeline(m, "image", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     filename,
 	}

--- a/internal/manifest/oci_container.go
+++ b/internal/manifest/oci_container.go
@@ -8,26 +8,22 @@ import (
 // tree created by another Pipeline.
 type OCIContainer struct {
 	Base
+	Filename     string
 	Cmd          []string
 	ExposedPorts []string
 
-	treePipeline *Base
-	architecture string
-	filename     string
+	treePipeline Tree
 }
 
 func NewOCIContainer(m *Manifest,
 	buildPipeline *Build,
-	treePipeline *Base,
-	architecture,
-	filename string) *OCIContainer {
+	treePipeline Tree) *OCIContainer {
 	p := &OCIContainer{
 		Base:         NewBase(m, "container", buildPipeline),
 		treePipeline: treePipeline,
-		architecture: architecture,
-		filename:     filename,
+		Filename:     "oci-archive.tar",
 	}
-	if treePipeline.build.Base.manifest != m {
+	if treePipeline.GetManifest() != m {
 		panic("tree pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -39,8 +35,8 @@ func (p *OCIContainer) serialize() osbuild2.Pipeline {
 	pipeline := p.Base.serialize()
 
 	options := &osbuild2.OCIArchiveStageOptions{
-		Architecture: p.architecture,
-		Filename:     p.filename,
+		Architecture: p.treePipeline.GetPlatform().GetArch().String(),
+		Filename:     p.Filename,
 		Config: &osbuild2.OCIArchiveConfig{
 			Cmd:          p.Cmd,
 			ExposedPorts: p.ExposedPorts,

--- a/internal/manifest/oci_container.go
+++ b/internal/manifest/oci_container.go
@@ -4,30 +4,30 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// An OCIContainerPipeline represents an OCI container, containing a filesystem
+// An OCIContainer represents an OCI container, containing a filesystem
 // tree created by another Pipeline.
-type OCIContainerPipeline struct {
-	BasePipeline
+type OCIContainer struct {
+	Base
 	Cmd          []string
 	ExposedPorts []string
 
-	treePipeline *BasePipeline
+	treePipeline *Base
 	architecture string
 	filename     string
 }
 
-func NewOCIContainerPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	treePipeline *BasePipeline,
+func NewOCIContainer(m *Manifest,
+	buildPipeline *Build,
+	treePipeline *Base,
 	architecture,
-	filename string) *OCIContainerPipeline {
-	p := &OCIContainerPipeline{
-		BasePipeline: NewBasePipeline(m, "container", buildPipeline),
+	filename string) *OCIContainer {
+	p := &OCIContainer{
+		Base:         NewBase(m, "container", buildPipeline),
 		treePipeline: treePipeline,
 		architecture: architecture,
 		filename:     filename,
 	}
-	if treePipeline.build.BasePipeline.manifest != m {
+	if treePipeline.build.Base.manifest != m {
 		panic("tree pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -35,8 +35,8 @@ func NewOCIContainerPipeline(m *Manifest,
 	return p
 }
 
-func (p *OCIContainerPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *OCIContainer) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	options := &osbuild2.OCIArchiveStageOptions{
 		Architecture: p.architecture,
@@ -56,6 +56,6 @@ func (p *OCIContainerPipeline) serialize() osbuild2.Pipeline {
 	return pipeline
 }
 
-func (p *OCIContainerPipeline) getBuildPackages() []string {
+func (p *OCIContainer) getBuildPackages() []string {
 	return []string{"tar"}
 }

--- a/internal/manifest/oci_container.go
+++ b/internal/manifest/oci_container.go
@@ -22,7 +22,7 @@ func NewOCIContainerPipeline(m *Manifest,
 	architecture,
 	filename string) *OCIContainerPipeline {
 	p := &OCIContainerPipeline{
-		BasePipeline: NewBasePipeline(m, "container", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "container", buildPipeline),
 		treePipeline: treePipeline,
 		architecture: architecture,
 		filename:     filename,

--- a/internal/manifest/oci_container.go
+++ b/internal/manifest/oci_container.go
@@ -55,3 +55,7 @@ func (p *OCIContainerPipeline) serialize() osbuild2.Pipeline {
 
 	return pipeline
 }
+
+func (p *OCIContainerPipeline) getBuildPackages() []string {
+	return []string{"tar"}
+}

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -110,7 +110,7 @@ func NewOSPipeline(m *Manifest,
 	platform platform.Platform,
 	repos []rpmmd.RepoConfig) *OSPipeline {
 	p := &OSPipeline{
-		BasePipeline: NewBasePipeline(m, "os", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "os", buildPipeline),
 		repos:        repos,
 		platform:     platform,
 		Language:     "C.UTF-8",

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -213,6 +213,10 @@ func (p *OSPipeline) getBuildPackages() []string {
 	if p.OSTree != nil {
 		packages = append(packages, "rpm-ostree")
 	}
+	if p.SElinux != "" {
+		packages = append(packages, "policycoreutils")
+		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
+	}
 	return packages
 }
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -15,11 +15,11 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/workload"
 )
 
-type OSPipelineOSTree struct {
-	Parent *OSPipelineOSTreeParent
+type OSTree struct {
+	Parent *OSTreeParent
 }
 
-type OSPipelineOSTreeParent struct {
+type OSTreeParent struct {
 	Checksum string
 	URL      string
 }
@@ -43,7 +43,7 @@ type OS struct {
 	// Workload to install on top of the base system
 	Workload workload.Workload
 	// OSTree configuration, if nil the tree cannot be in an OSTree commit
-	OSTree *OSPipelineOSTree
+	OSTree *OSTree
 	// Partition table, if nil the tree cannot be put on a partioned disk
 	PartitionTable *disk.PartitionTable
 	// KernelName indicates that a kernel is installed, and names the kernel
@@ -470,4 +470,8 @@ func usersFirstBootOptions(usersStageOptions *osbuild2.UsersStageOptions) *osbui
 	}
 
 	return options
+}
+
+func (p *OS) GetPlatform() platform.Platform {
+	return p.platform
 }

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -132,50 +132,7 @@ func (p *OSPipeline) getPackageSetChain() []rpmmd.PackageSet {
 
 	// If we have a logical volume we need to include the lvm2 package
 	if p.PartitionTable != nil && p.OSTree == nil {
-		hasLVM := false
-		hasBtrfs := false
-		hasXFS := false
-		hasFAT := false
-		hasEXT4 := false
-
-		introspectPT := func(e disk.Entity, path []disk.Entity) error {
-			switch ent := e.(type) {
-			case *disk.LVMLogicalVolume:
-				hasLVM = true
-			case *disk.Btrfs:
-				hasBtrfs = true
-			case *disk.Filesystem:
-				switch ent.GetFSType() {
-				case "vfat":
-					hasFAT = true
-				case "btrfs":
-					hasBtrfs = true
-				case "xfs":
-					hasXFS = true
-				case "ext4":
-					hasEXT4 = true
-				}
-			}
-			return nil
-		}
-		_ = p.PartitionTable.ForEachEntity(introspectPT)
-
-		// TODO: LUKS
-		if hasLVM {
-			packages = append(packages, "lvm2")
-		}
-		if hasBtrfs {
-			packages = append(packages, "btrfs-progs")
-		}
-		if hasXFS {
-			packages = append(packages, "xfsprogs")
-		}
-		if hasFAT {
-			packages = append(packages, "dosfstools")
-		}
-		if hasEXT4 {
-			packages = append(packages, "e2fsprogs")
-		}
+		packages = append(packages, p.PartitionTable.GetBuildPackages()...)
 	}
 
 	if p.Environment != nil {

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -167,6 +167,7 @@ func (p *OSPipeline) getPackageSetChain() []rpmmd.PackageSet {
 
 func (p *OSPipeline) getBuildPackages() []string {
 	packages := p.platform.GetBuildPackages()
+	packages = append(packages, "rpm")
 	if p.OSTree != nil {
 		packages = append(packages, "rpm-ostree")
 	}

--- a/internal/manifest/pipeline.go
+++ b/internal/manifest/pipeline.go
@@ -23,42 +23,42 @@ type Pipeline interface {
 	getInline() []string
 }
 
-// A BasePipeline represents the core functionality shared between each of the pipeline
-// implementations, and the BasePipeline struct must be embedded in each of them.
-type BasePipeline struct {
+// A Base represents the core functionality shared between each of the pipeline
+// implementations, and the Base struct must be embedded in each of them.
+type Base struct {
 	manifest *Manifest
 	name     string
-	build    *BuildPipeline
+	build    *Build
 }
 
 // Name returns the name of the pipeline. The name must be unique for a given manifest.
 // Pipeline names are used to refer to pipelines either as dependencies between pipelines
 // or for exporting them.
-func (p BasePipeline) Name() string {
+func (p Base) Name() string {
 	return p.name
 }
 
-func (p BasePipeline) getBuildPackages() []string {
+func (p Base) getBuildPackages() []string {
 	return []string{}
 }
 
-func (p BasePipeline) getPackageSetChain() []rpmmd.PackageSet {
+func (p Base) getPackageSetChain() []rpmmd.PackageSet {
 	return nil
 }
 
-func (p BasePipeline) getPackageSpecs() []rpmmd.PackageSpec {
+func (p Base) getPackageSpecs() []rpmmd.PackageSpec {
 	return []rpmmd.PackageSpec{}
 }
 
-func (p BasePipeline) getOSTreeCommits() []osTreeCommit {
+func (p Base) getOSTreeCommits() []osTreeCommit {
 	return []osTreeCommit{}
 }
 
-func (p BasePipeline) getInline() []string {
+func (p Base) getInline() []string {
 	return []string{}
 }
 
-// NewBasePipeline returns a generic Pipeline object. The name is mandatory, immutable and must
+// NewBase returns a generic Pipeline object. The name is mandatory, immutable and must
 // be unique among all the pipelines used in a manifest, which is currently not enforced.
 // The build argument is a pipeline representing a build root in which the rest of the
 // pipeline is built. In order to ensure reproducibility a build pipeline must always be
@@ -66,14 +66,14 @@ func (p BasePipeline) getInline() []string {
 // the build host's filesystem is used as the build root. The runner specifies how to use this
 // pipeline as a build pipeline, by naming the distro it contains. When the host system is used
 // as a build root, then the necessary runner is autodetected.
-func NewBasePipeline(m *Manifest, name string, build *BuildPipeline) BasePipeline {
-	p := BasePipeline{
+func NewBase(m *Manifest, name string, build *Build) Base {
+	p := Base{
 		manifest: m,
 		name:     name,
 		build:    build,
 	}
 	if build != nil {
-		if build.BasePipeline.manifest != m {
+		if build.Base.manifest != m {
 			panic("build pipeline from a different manifest")
 		}
 	}
@@ -82,18 +82,18 @@ func NewBasePipeline(m *Manifest, name string, build *BuildPipeline) BasePipelin
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p BasePipeline) serializeStart([]rpmmd.PackageSpec) {
+func (p Base) serializeStart([]rpmmd.PackageSpec) {
 }
 
 // serializeEnd must be called exactly once after each call to
 // serialize().
-func (p BasePipeline) serializeEnd() {
+func (p Base) serializeEnd() {
 }
 
 // Serialize turns a given pipeline into an osbuild2.Pipeline object. This object is
 // meant to be treated as opaque and not to be modified further outside of the pipeline
 // package.
-func (p BasePipeline) serialize() osbuild2.Pipeline {
+func (p Base) serialize() osbuild2.Pipeline {
 	pipeline := osbuild2.Pipeline{
 		Name: p.name,
 	}

--- a/internal/manifest/pipeline.go
+++ b/internal/manifest/pipeline.go
@@ -8,6 +8,7 @@ package manifest
 
 import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
+	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
@@ -36,6 +37,10 @@ type Base struct {
 // or for exporting them.
 func (p Base) Name() string {
 	return p.name
+}
+
+func (p Base) GetManifest() *Manifest {
+	return p.manifest
 }
 
 func (p Base) getBuildPackages() []string {
@@ -101,4 +106,10 @@ func (p Base) serialize() osbuild2.Pipeline {
 		pipeline.Build = "name:" + p.build.Name()
 	}
 	return pipeline
+}
+
+type Tree interface {
+	Name() string
+	GetManifest() *Manifest
+	GetPlatform() platform.Platform
 }

--- a/internal/manifest/pipeline.go
+++ b/internal/manifest/pipeline.go
@@ -28,7 +28,6 @@ type Pipeline interface {
 type BasePipeline struct {
 	manifest *Manifest
 	name     string
-	runner   string
 	build    *BuildPipeline
 }
 
@@ -67,7 +66,7 @@ func (p BasePipeline) getInline() []string {
 // the build host's filesystem is used as the build root. The runner specifies how to use this
 // pipeline as a build pipeline, by naming the distro it contains. When the host system is used
 // as a build root, then the necessary runner is autodetected.
-func NewBasePipeline(m *Manifest, name string, build *BuildPipeline, runner *string) BasePipeline {
+func NewBasePipeline(m *Manifest, name string, build *BuildPipeline) BasePipeline {
 	p := BasePipeline{
 		manifest: m,
 		name:     name,
@@ -77,12 +76,6 @@ func NewBasePipeline(m *Manifest, name string, build *BuildPipeline, runner *str
 		if build.BasePipeline.manifest != m {
 			panic("build pipeline from a different manifest")
 		}
-		if build.BasePipeline.runner == "" {
-			panic("build pipeline does not have runner")
-		}
-	}
-	if runner != nil {
-		p.runner = *runner
 	}
 	return p
 }
@@ -101,13 +94,11 @@ func (p BasePipeline) serializeEnd() {
 // meant to be treated as opaque and not to be modified further outside of the pipeline
 // package.
 func (p BasePipeline) serialize() osbuild2.Pipeline {
-	var buildName string
+	pipeline := osbuild2.Pipeline{
+		Name: p.name,
+	}
 	if p.build != nil {
-		buildName = "name:" + p.build.Name()
+		pipeline.Build = "name:" + p.build.Name()
 	}
-	return osbuild2.Pipeline{
-		Name:   p.name,
-		Runner: p.runner,
-		Build:  buildName,
-	}
+	return pipeline
 }

--- a/internal/manifest/qcow2.go
+++ b/internal/manifest/qcow2.go
@@ -4,28 +4,28 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// A QCOW2Pipeline turns a raw image file into qcow2 image.
-type QCOW2Pipeline struct {
-	BasePipeline
+// A QCOW2 turns a raw image file into qcow2 image.
+type QCOW2 struct {
+	Base
 	Compat string
 
-	imgPipeline *LiveImgPipeline
+	imgPipeline *RawImage
 	filename    string
 }
 
-// NewQCOW2Pipeline createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
+// NewQCOW2 createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced qcow2 image.
-func NewQCOW2Pipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	imgPipeline *LiveImgPipeline,
-	filename string) *QCOW2Pipeline {
-	p := &QCOW2Pipeline{
-		BasePipeline: NewBasePipeline(m, "qcow2", buildPipeline),
-		imgPipeline:  imgPipeline,
-		filename:     filename,
+func NewQCOW2(m *Manifest,
+	buildPipeline *Build,
+	imgPipeline *RawImage,
+	filename string) *QCOW2 {
+	p := &QCOW2{
+		Base:        NewBase(m, "qcow2", buildPipeline),
+		imgPipeline: imgPipeline,
+		filename:    filename,
 	}
-	if imgPipeline.BasePipeline.manifest != m {
+	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -33,8 +33,8 @@ func NewQCOW2Pipeline(m *Manifest,
 	return p
 }
 
-func (p *QCOW2Pipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *QCOW2) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
 		osbuild2.NewQEMUStageOptions(p.filename,
@@ -48,6 +48,6 @@ func (p *QCOW2Pipeline) serialize() osbuild2.Pipeline {
 	return pipeline
 }
 
-func (p *QCOW2Pipeline) getBuildPackages() []string {
+func (p *QCOW2) getBuildPackages() []string {
 	return []string{"qemu-img"}
 }

--- a/internal/manifest/qcow2.go
+++ b/internal/manifest/qcow2.go
@@ -21,7 +21,7 @@ func NewQCOW2Pipeline(m *Manifest,
 	imgPipeline *LiveImgPipeline,
 	filename string) *QCOW2Pipeline {
 	p := &QCOW2Pipeline{
-		BasePipeline: NewBasePipeline(m, "qcow2", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "qcow2", buildPipeline),
 		imgPipeline:  imgPipeline,
 		filename:     filename,
 	}

--- a/internal/manifest/qcow2.go
+++ b/internal/manifest/qcow2.go
@@ -7,10 +7,10 @@ import (
 // A QCOW2 turns a raw image file into qcow2 image.
 type QCOW2 struct {
 	Base
-	Compat string
+	Filename string
+	Compat   string
 
 	imgPipeline *RawImage
-	filename    string
 }
 
 // NewQCOW2 createsa new QCOW2 pipeline. imgPipeline is the pipeline producing the
@@ -18,12 +18,11 @@ type QCOW2 struct {
 // of the produced qcow2 image.
 func NewQCOW2(m *Manifest,
 	buildPipeline *Build,
-	imgPipeline *RawImage,
-	filename string) *QCOW2 {
+	imgPipeline *RawImage) *QCOW2 {
 	p := &QCOW2{
 		Base:        NewBase(m, "qcow2", buildPipeline),
 		imgPipeline: imgPipeline,
-		filename:    filename,
+		Filename:    "image.qcow2",
 	}
 	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
@@ -37,12 +36,12 @@ func (p *QCOW2) serialize() osbuild2.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
-		osbuild2.NewQEMUStageOptions(p.filename,
+		osbuild2.NewQEMUStageOptions(p.Filename,
 			osbuild2.QEMUFormatQCOW2,
 			osbuild2.QCOW2Options{
 				Compat: p.Compat,
 			}),
-		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.filename),
+		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename),
 	))
 
 	return pipeline

--- a/internal/manifest/qcow2.go
+++ b/internal/manifest/qcow2.go
@@ -47,3 +47,7 @@ func (p *QCOW2Pipeline) serialize() osbuild2.Pipeline {
 
 	return pipeline
 }
+
+func (p *QCOW2Pipeline) getBuildPackages() []string {
+	return []string{"qemu-img"}
+}

--- a/internal/manifest/raw.go
+++ b/internal/manifest/raw.go
@@ -5,38 +5,38 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/platform"
 )
 
-// A LiveImgPipeline represents a raw image file which can be booted in a
+// A RawImage represents a raw image file which can be booted in a
 // hypervisor. It is created from an existing OSPipeline.
-type LiveImgPipeline struct {
-	BasePipeline
-	treePipeline *OSPipeline
+type RawImage struct {
+	Base
+	treePipeline *OS
 
 	filename string
 }
 
-func NewLiveImgPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	treePipeline *OSPipeline,
-	filename string) *LiveImgPipeline {
-	p := &LiveImgPipeline{
-		BasePipeline: NewBasePipeline(m, "image", buildPipeline),
+func NewRawImage(m *Manifest,
+	buildPipeline *Build,
+	treePipeline *OS,
+	filename string) *RawImage {
+	p := &RawImage{
+		Base:         NewBase(m, "image", buildPipeline),
 		treePipeline: treePipeline,
 		filename:     filename,
 	}
 	buildPipeline.addDependent(p)
-	if treePipeline.BasePipeline.manifest != m {
+	if treePipeline.Base.manifest != m {
 		panic("tree pipeline from different manifest")
 	}
 	m.addPipeline(p)
 	return p
 }
 
-func (p *LiveImgPipeline) getBuildPackages() []string {
+func (p *RawImage) getBuildPackages() []string {
 	return p.treePipeline.PartitionTable.GetBuildPackages()
 }
 
-func (p *LiveImgPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *RawImage) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	pt := p.treePipeline.PartitionTable
 	if pt == nil {

--- a/internal/manifest/raw.go
+++ b/internal/manifest/raw.go
@@ -10,18 +10,16 @@ import (
 type RawImage struct {
 	Base
 	treePipeline *OS
-
-	filename string
+	Filename     string
 }
 
 func NewRawImage(m *Manifest,
 	buildPipeline *Build,
-	treePipeline *OS,
-	filename string) *RawImage {
+	treePipeline *OS) *RawImage {
 	p := &RawImage{
 		Base:         NewBase(m, "image", buildPipeline),
 		treePipeline: treePipeline,
-		filename:     filename,
+		Filename:     "disk.img",
 	}
 	buildPipeline.addDependent(p)
 	if treePipeline.Base.manifest != m {
@@ -43,26 +41,26 @@ func (p *RawImage) serialize() osbuild2.Pipeline {
 		panic("no partition table in live image")
 	}
 
-	for _, stage := range osbuild2.GenImagePrepareStages(pt, p.filename, osbuild2.PTSfdisk) {
+	for _, stage := range osbuild2.GenImagePrepareStages(pt, p.Filename, osbuild2.PTSfdisk) {
 		pipeline.AddStage(stage)
 	}
 
 	inputName := "root-tree"
-	copyOptions, copyDevices, copyMounts := osbuild2.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.filename, pt)
+	copyOptions, copyDevices, copyMounts := osbuild2.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
 	copyInputs := osbuild2.NewCopyStagePipelineTreeInputs(inputName, p.treePipeline.Name())
 	pipeline.AddStage(osbuild2.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
-	for _, stage := range osbuild2.GenImageFinishStages(pt, p.filename) {
+	for _, stage := range osbuild2.GenImageFinishStages(pt, p.Filename) {
 		pipeline.AddStage(stage)
 	}
 
 	switch p.treePipeline.platform.GetArch() {
 	case platform.ARCH_S390X:
-		loopback := osbuild2.NewLoopbackDevice(&osbuild2.LoopbackDeviceOptions{Filename: p.filename})
+		loopback := osbuild2.NewLoopbackDevice(&osbuild2.LoopbackDeviceOptions{Filename: p.Filename})
 		pipeline.AddStage(osbuild2.NewZiplInstStage(osbuild2.NewZiplInstStageOptions(p.treePipeline.kernelVer, pt), loopback, copyDevices, copyMounts))
 	default:
 		if grubLegacy := p.treePipeline.platform.GetBIOSPlatform(); grubLegacy != "" {
-			pipeline.AddStage(osbuild2.NewGrub2InstStage(osbuild2.NewGrub2InstStageOption(p.filename, pt, grubLegacy)))
+			pipeline.AddStage(osbuild2.NewGrub2InstStage(osbuild2.NewGrub2InstStageOption(p.Filename, pt, grubLegacy)))
 		}
 	}
 

--- a/internal/manifest/tar.go
+++ b/internal/manifest/tar.go
@@ -45,3 +45,7 @@ func (p *TarPipeline) serialize() osbuild2.Pipeline {
 
 	return pipeline
 }
+
+func (p *TarPipeline) getBuildPackages() []string {
+	return []string{"tar"}
+}

--- a/internal/manifest/tar.go
+++ b/internal/manifest/tar.go
@@ -20,7 +20,7 @@ func NewTarPipeline(m *Manifest,
 	pipelinename,
 	filename string) *TarPipeline {
 	p := &TarPipeline{
-		BasePipeline:  NewBasePipeline(m, pipelinename, buildPipeline, nil),
+		BasePipeline:  NewBasePipeline(m, pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
 		filename:      filename,
 	}

--- a/internal/manifest/tar.go
+++ b/internal/manifest/tar.go
@@ -7,8 +7,9 @@ import (
 // A Tar represents the contents of another pipeline in a tar file
 type Tar struct {
 	Base
+	Filename string
+
 	inputPipeline *Base
-	filename      string
 }
 
 // NewTar creates a new TarPipeline. The inputPipeline represents the
@@ -17,12 +18,11 @@ type Tar struct {
 func NewTar(m *Manifest,
 	buildPipeline *Build,
 	inputPipeline *Base,
-	pipelinename,
-	filename string) *Tar {
+	pipelinename string) *Tar {
 	p := &Tar{
 		Base:          NewBase(m, pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
-		filename:      filename,
+		Filename:      "image.tar",
 	}
 	if inputPipeline.manifest != m {
 		panic("tree pipeline from different manifest")
@@ -39,7 +39,7 @@ func (p *Tar) serialize() osbuild2.Pipeline {
 	tree.Type = "org.osbuild.tree"
 	tree.Origin = "org.osbuild.pipeline"
 	tree.References = []string{"name:" + p.inputPipeline.Name()}
-	tarStage := osbuild2.NewTarStage(&osbuild2.TarStageOptions{Filename: p.filename}, &osbuild2.TarStageInputs{Tree: tree})
+	tarStage := osbuild2.NewTarStage(&osbuild2.TarStageOptions{Filename: p.Filename}, &osbuild2.TarStageInputs{Tree: tree})
 
 	pipeline.AddStage(tarStage)
 

--- a/internal/manifest/tar.go
+++ b/internal/manifest/tar.go
@@ -4,23 +4,23 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// A TarPipeline represents the contents of another pipeline in a tar file
-type TarPipeline struct {
-	BasePipeline
-	inputPipeline *BasePipeline
+// A Tar represents the contents of another pipeline in a tar file
+type Tar struct {
+	Base
+	inputPipeline *Base
 	filename      string
 }
 
-// NewTarPipeline creates a new TarPipeline. The inputPipeline represents the
+// NewTar creates a new TarPipeline. The inputPipeline represents the
 // filesystem tree which will be the contents of the tar file. The pipelinename
 // is the name of the pipeline. The filename is the name of the output tar file.
-func NewTarPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	inputPipeline *BasePipeline,
+func NewTar(m *Manifest,
+	buildPipeline *Build,
+	inputPipeline *Base,
 	pipelinename,
-	filename string) *TarPipeline {
-	p := &TarPipeline{
-		BasePipeline:  NewBasePipeline(m, pipelinename, buildPipeline),
+	filename string) *Tar {
+	p := &Tar{
+		Base:          NewBase(m, pipelinename, buildPipeline),
 		inputPipeline: inputPipeline,
 		filename:      filename,
 	}
@@ -32,8 +32,8 @@ func NewTarPipeline(m *Manifest,
 	return p
 }
 
-func (p *TarPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *Tar) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	tree := new(osbuild2.TarStageInput)
 	tree.Type = "org.osbuild.tree"
@@ -46,6 +46,6 @@ func (p *TarPipeline) serialize() osbuild2.Pipeline {
 	return pipeline
 }
 
-func (p *TarPipeline) getBuildPackages() []string {
+func (p *Tar) getBuildPackages() []string {
 	return []string{"tar"}
 }

--- a/internal/manifest/vmdk.go
+++ b/internal/manifest/vmdk.go
@@ -4,26 +4,26 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// A VMDKPipeline turns a raw image file into vmdk image.
-type VMDKPipeline struct {
-	BasePipeline
+// A VMDK turns a raw image file into vmdk image.
+type VMDK struct {
+	Base
 
-	imgPipeline *LiveImgPipeline
+	imgPipeline *RawImage
 	filename    string
 }
 
-// NewVMDKPipeline creates a new VMDK pipeline. imgPipeline is the pipeline producing the
+// NewVMDK creates a new VMDK pipeline. imgPipeline is the pipeline producing the
 // raw image. Filename is the name of the produced image.
-func NewVMDKPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	imgPipeline *LiveImgPipeline,
-	filename string) *VMDKPipeline {
-	p := &VMDKPipeline{
-		BasePipeline: NewBasePipeline(m, "vmdk", buildPipeline),
-		imgPipeline:  imgPipeline,
-		filename:     filename,
+func NewVMDK(m *Manifest,
+	buildPipeline *Build,
+	imgPipeline *RawImage,
+	filename string) *VMDK {
+	p := &VMDK{
+		Base:        NewBase(m, "vmdk", buildPipeline),
+		imgPipeline: imgPipeline,
+		filename:    filename,
 	}
-	if imgPipeline.BasePipeline.manifest != m {
+	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -31,8 +31,8 @@ func NewVMDKPipeline(m *Manifest,
 	return p
 }
 
-func (p *VMDKPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *VMDK) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
 		osbuild2.NewQEMUStageOptions(p.filename, osbuild2.QEMUFormatVMDK, osbuild2.VMDKOptions{
@@ -44,6 +44,6 @@ func (p *VMDKPipeline) serialize() osbuild2.Pipeline {
 	return pipeline
 }
 
-func (p *VMDKPipeline) getBuildPackages() []string {
+func (p *VMDK) getBuildPackages() []string {
 	return []string{"qemu-img"}
 }

--- a/internal/manifest/vmdk.go
+++ b/internal/manifest/vmdk.go
@@ -43,3 +43,7 @@ func (p *VMDKPipeline) serialize() osbuild2.Pipeline {
 
 	return pipeline
 }
+
+func (p *VMDKPipeline) getBuildPackages() []string {
+	return []string{"qemu-img"}
+}

--- a/internal/manifest/vmdk.go
+++ b/internal/manifest/vmdk.go
@@ -19,7 +19,7 @@ func NewVMDKPipeline(m *Manifest,
 	imgPipeline *LiveImgPipeline,
 	filename string) *VMDKPipeline {
 	p := &VMDKPipeline{
-		BasePipeline: NewBasePipeline(m, "vmdk", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "vmdk", buildPipeline),
 		imgPipeline:  imgPipeline,
 		filename:     filename,
 	}

--- a/internal/manifest/vmdk.go
+++ b/internal/manifest/vmdk.go
@@ -7,21 +7,20 @@ import (
 // A VMDK turns a raw image file into vmdk image.
 type VMDK struct {
 	Base
+	Filename string
 
 	imgPipeline *RawImage
-	filename    string
 }
 
 // NewVMDK creates a new VMDK pipeline. imgPipeline is the pipeline producing the
 // raw image. Filename is the name of the produced image.
 func NewVMDK(m *Manifest,
 	buildPipeline *Build,
-	imgPipeline *RawImage,
-	filename string) *VMDK {
+	imgPipeline *RawImage) *VMDK {
 	p := &VMDK{
 		Base:        NewBase(m, "vmdk", buildPipeline),
 		imgPipeline: imgPipeline,
-		filename:    filename,
+		Filename:    "image.vmdk",
 	}
 	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
@@ -35,10 +34,10 @@ func (p *VMDK) serialize() osbuild2.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
-		osbuild2.NewQEMUStageOptions(p.filename, osbuild2.QEMUFormatVMDK, osbuild2.VMDKOptions{
+		osbuild2.NewQEMUStageOptions(p.Filename, osbuild2.QEMUFormatVMDK, osbuild2.VMDKOptions{
 			Subformat: osbuild2.VMDKSubformatStreamOptimized,
 		}),
-		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.filename),
+		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename),
 	))
 
 	return pipeline

--- a/internal/manifest/vpc.go
+++ b/internal/manifest/vpc.go
@@ -42,3 +42,7 @@ func (p *VPCPipeline) serialize() osbuild2.Pipeline {
 
 	return pipeline
 }
+
+func (p *VPCPipeline) getBuildPackages() []string {
+	return []string{"qemu-img"}
+}

--- a/internal/manifest/vpc.go
+++ b/internal/manifest/vpc.go
@@ -20,7 +20,7 @@ func NewVPCPipeline(m *Manifest,
 	imgPipeline *LiveImgPipeline,
 	filename string) *VPCPipeline {
 	p := &VPCPipeline{
-		BasePipeline: NewBasePipeline(m, "vpc", buildPipeline, nil),
+		BasePipeline: NewBasePipeline(m, "vpc", buildPipeline),
 		imgPipeline:  imgPipeline,
 		filename:     filename,
 	}

--- a/internal/manifest/vpc.go
+++ b/internal/manifest/vpc.go
@@ -7,9 +7,9 @@ import (
 // A VPC turns a raw image file into qemu-based image format, such as qcow2.
 type VPC struct {
 	Base
+	Filename string
 
 	imgPipeline *RawImage
-	filename    string
 }
 
 // NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
@@ -17,12 +17,11 @@ type VPC struct {
 // of the produced image.
 func NewVPC(m *Manifest,
 	buildPipeline *Build,
-	imgPipeline *RawImage,
-	filename string) *VPC {
+	imgPipeline *RawImage) *VPC {
 	p := &VPC{
 		Base:        NewBase(m, "vpc", buildPipeline),
 		imgPipeline: imgPipeline,
-		filename:    filename,
+		Filename:    "image.vpc",
 	}
 	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
@@ -36,8 +35,8 @@ func (p *VPC) serialize() osbuild2.Pipeline {
 	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
-		osbuild2.NewQEMUStageOptions(p.filename, osbuild2.QEMUFormatVPC, nil),
-		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.filename),
+		osbuild2.NewQEMUStageOptions(p.Filename, osbuild2.QEMUFormatVPC, nil),
+		osbuild2.NewQemuStagePipelineFilesInputs(p.imgPipeline.Name(), p.imgPipeline.Filename),
 	))
 
 	return pipeline

--- a/internal/manifest/vpc.go
+++ b/internal/manifest/vpc.go
@@ -4,27 +4,27 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild2"
 )
 
-// A VPCPipeline turns a raw image file into qemu-based image format, such as qcow2.
-type VPCPipeline struct {
-	BasePipeline
+// A VPC turns a raw image file into qemu-based image format, such as qcow2.
+type VPC struct {
+	Base
 
-	imgPipeline *LiveImgPipeline
+	imgPipeline *RawImage
 	filename    string
 }
 
-// NewVPCPipeline createsa new Qemu pipeline. imgPipeline is the pipeline producing the
+// NewVPC createsa new Qemu pipeline. imgPipeline is the pipeline producing the
 // raw image. The pipeline name is the name of the new pipeline. Filename is the name
 // of the produced image.
-func NewVPCPipeline(m *Manifest,
-	buildPipeline *BuildPipeline,
-	imgPipeline *LiveImgPipeline,
-	filename string) *VPCPipeline {
-	p := &VPCPipeline{
-		BasePipeline: NewBasePipeline(m, "vpc", buildPipeline),
-		imgPipeline:  imgPipeline,
-		filename:     filename,
+func NewVPC(m *Manifest,
+	buildPipeline *Build,
+	imgPipeline *RawImage,
+	filename string) *VPC {
+	p := &VPC{
+		Base:        NewBase(m, "vpc", buildPipeline),
+		imgPipeline: imgPipeline,
+		filename:    filename,
 	}
-	if imgPipeline.BasePipeline.manifest != m {
+	if imgPipeline.Base.manifest != m {
 		panic("live image pipeline from different manifest")
 	}
 	buildPipeline.addDependent(p)
@@ -32,8 +32,8 @@ func NewVPCPipeline(m *Manifest,
 	return p
 }
 
-func (p *VPCPipeline) serialize() osbuild2.Pipeline {
-	pipeline := p.BasePipeline.serialize()
+func (p *VPC) serialize() osbuild2.Pipeline {
+	pipeline := p.Base.serialize()
 
 	pipeline.AddStage(osbuild2.NewQEMUStage(
 		osbuild2.NewQEMUStageOptions(p.filename, osbuild2.QEMUFormatVPC, nil),
@@ -43,6 +43,6 @@ func (p *VPCPipeline) serialize() osbuild2.Pipeline {
 	return pipeline
 }
 
-func (p *VPCPipeline) getBuildPackages() []string {
+func (p *VPC) getBuildPackages() []string {
 	return []string{"qemu-img"}
 }

--- a/internal/runner/fedora.go
+++ b/internal/runner/fedora.go
@@ -1,0 +1,18 @@
+package runner
+
+import "fmt"
+
+type Fedora struct {
+	Version uint64
+}
+
+func (r *Fedora) String() string {
+	return fmt.Sprintf("org.osbuild.fedora%d", r.Version)
+}
+
+func (p *Fedora) GetBuildPackages() []string {
+	return []string{
+		"glibc",   // ldconfig
+		"systemd", // systemd-tmpfiles and systemd-sysusers
+	}
+}

--- a/internal/runner/linux.go
+++ b/internal/runner/linux.go
@@ -1,0 +1,15 @@
+package runner
+
+type Linux struct {
+}
+
+func (r *Linux) String() string {
+	return "org.osbuild.linux"
+}
+
+func (p *Linux) GetBuildPackages() []string {
+	return []string{
+		"glibc",   // ldconfig
+		"systemd", // systemd-tmpfiles and systemd-sysusers
+	}
+}

--- a/internal/runner/rhel.go
+++ b/internal/runner/rhel.go
@@ -1,0 +1,24 @@
+package runner
+
+import "fmt"
+
+type RHEL struct {
+	Major uint64
+	Minor uint64
+}
+
+func (r *RHEL) String() string {
+	return fmt.Sprintf("org.osbuild.fedora%d%d", r.Major, r.Minor)
+}
+
+func (p *RHEL) GetBuildPackages() []string {
+	packages := []string{
+		"glibc", // ldconfig
+	}
+	if p.Major >= 8 {
+		packages = append(packages,
+			"systemd", // systemd-tmpfiles and systemd-sysusers
+		)
+	}
+	return packages
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,0 +1,6 @@
+package runner
+
+type Runner interface {
+	String() string
+	GetBuildPackages() []string
+}

--- a/test/data/manifests/fedora_34-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-ami-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -273,30 +257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -314,14 +274,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -377,23 +329,7 @@
                     }
                   },
                   {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -449,14 +385,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -490,14 +418,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +465,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -593,14 +505,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
                     "options": {
                       "metadata": {
@@ -633,22 +537,6 @@
                     }
                   },
                   {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -666,14 +554,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +594,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +681,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -874,22 +714,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -913,23 +737,7 @@
                     }
                   },
                   {
-                    "id": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +857,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
                     "options": {
                       "metadata": {
@@ -1162,14 +954,6 @@
                   },
                   {
                     "id": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1281,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1298,14 +1074,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1361,14 +1129,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1378,22 +1138,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1537,14 +1281,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1585,38 +1321,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1634,22 +1338,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1737,23 +1425,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1778,14 +1450,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5044,9 +4708,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
           },
@@ -5073,9 +4734,6 @@
           },
           "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
@@ -5160,9 +4818,6 @@
           },
           "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
-          },
-          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
           },
           "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
@@ -5565,9 +5220,6 @@
           },
           "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
-          },
-          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
           },
           "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
@@ -6148,26 +5800,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6318,36 +5950,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6375,16 +5977,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -6448,16 +6040,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -6465,16 +6047,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
         "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
         "check_gpg": true
       },
       {
@@ -6538,16 +6110,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6595,16 +6157,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -6658,16 +6210,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6718,16 +6260,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
-        "check_gpg": true
-      },
-      {
         "name": "libss",
         "epoch": 0,
         "version": "1.45.6",
@@ -6768,26 +6300,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
-        "check_gpg": true
-      },
-      {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6815,16 +6327,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -6875,16 +6377,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -6988,16 +6480,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7005,26 +6487,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -7048,16 +6510,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7075,26 +6527,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -7118,16 +6550,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
-        "check_gpg": true
-      },
-      {
         "name": "sqlite-libs",
         "epoch": 0,
         "version": "3.34.1",
@@ -7135,16 +6557,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
         "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
         "check_gpg": true
       },
       {
@@ -7288,26 +6700,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "055",
@@ -7435,16 +6827,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
         "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
-        "check_gpg": true
-      },
-      {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.68.4",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
-        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
         "check_gpg": true
       },
       {
@@ -7578,16 +6960,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7605,16 +6977,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -7678,16 +7040,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7705,26 +7057,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7898,16 +7230,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -7958,46 +7280,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8025,26 +7307,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {
@@ -8148,16 +7410,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8165,16 +7417,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -8205,16 +7447,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-aarch64-container-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-container-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -170,30 +154,6 @@
                   },
                   {
                     "id": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -273,30 +233,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -314,14 +250,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -377,23 +305,7 @@
                     }
                   },
                   {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -449,14 +361,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -490,14 +394,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -593,22 +481,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
                     "options": {
                       "metadata": {
@@ -633,22 +505,6 @@
                     }
                   },
                   {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -666,14 +522,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +562,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +649,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +673,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -881,22 +689,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
                     "options": {
                       "metadata": {
@@ -906,14 +698,6 @@
                   },
                   {
                     "id": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +833,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
                     "options": {
                       "metadata": {
@@ -1162,14 +930,6 @@
                   },
                   {
                     "id": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1281,14 +1041,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1298,14 +1050,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1361,14 +1105,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1378,22 +1114,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1537,14 +1257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1585,38 +1297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1634,22 +1314,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1737,23 +1401,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1778,14 +1426,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3100,17 +2740,11 @@
           "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm"
           },
-          "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm"
-          },
           "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
           },
           "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
-          },
-          "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
           },
           "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
@@ -3139,9 +2773,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
           },
@@ -3156,9 +2787,6 @@
           },
           "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
@@ -3202,9 +2830,6 @@
           "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
           },
-          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
-          },
           "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
           },
@@ -3223,14 +2848,8 @@
           "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
           },
-          "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm"
-          },
           "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
-          },
-          "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm"
           },
           "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm"
@@ -3316,9 +2935,6 @@
           "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
           },
-          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
-          },
           "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
           },
@@ -3385,9 +3001,6 @@
           "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm"
           },
-          "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm"
-          },
           "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm"
           },
@@ -3436,9 +3049,6 @@
           "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm"
-          },
           "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm"
           },
@@ -3459,9 +3069,6 @@
           },
           "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm"
-          },
-          "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm"
           },
           "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm"
@@ -3622,17 +3229,8 @@
           "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm"
           },
-          "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm"
-          },
           "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm"
-          },
-          "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm"
-          },
-          "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm"
           },
           "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm"
@@ -3679,9 +3277,6 @@
           "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm"
           },
-          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
-          },
           "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm"
           },
@@ -3699,9 +3294,6 @@
           },
           "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm"
-          },
-          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
           },
           "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
@@ -3871,26 +3463,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -3918,36 +3490,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
         "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
         "check_gpg": true
       },
       {
@@ -4041,36 +3583,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -4098,16 +3610,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -4171,16 +3673,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -4188,16 +3680,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
         "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
         "check_gpg": true
       },
       {
@@ -4261,16 +3743,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -4318,16 +3790,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -4381,16 +3843,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -4441,26 +3893,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4491,26 +3923,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
-        "check_gpg": true
-      },
-      {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -4538,16 +3950,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -4598,16 +4000,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -4711,16 +4103,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -4728,26 +4110,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -4771,16 +4133,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -4801,26 +4153,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
-        "check_gpg": true
-      },
-      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4838,16 +4170,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
         "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
-        "check_gpg": true
-      },
-      {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
         "check_gpg": true
       },
       {
@@ -5011,26 +4333,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "055",
@@ -5158,16 +4460,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
         "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
-        "check_gpg": true
-      },
-      {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.68.4",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
-        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
         "check_gpg": true
       },
       {
@@ -5301,16 +4593,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -5328,16 +4610,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -5401,16 +4673,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -5428,26 +4690,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -5621,16 +4863,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -5681,46 +4913,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -5748,26 +4940,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {
@@ -5871,16 +5043,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -5888,16 +5050,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -5928,16 +5080,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_commit-boot.json
@@ -145,22 +145,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -178,30 +162,6 @@
                   },
                   {
                     "id": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -337,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
                     "options": {
                       "metadata": {
@@ -386,14 +338,6 @@
                   },
                   {
                     "id": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -458,14 +402,6 @@
                   },
                   {
                     "id": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
                     "options": {
                       "metadata": {
@@ -642,14 +570,6 @@
                   },
                   {
                     "id": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,31 +745,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -873,14 +769,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -890,22 +778,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1058,22 +930,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1313,14 +1169,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1330,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1418,14 +1258,6 @@
                   },
                   {
                     "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1641,38 +1473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1690,22 +1490,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1809,23 +1593,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5481,9 +5249,6 @@
           "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
           },
-          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:076a1e90dd9897a6a3295eb7a6f48be3a59ccf05238ce9455cce232193fab24b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/greenboot-status-0.11-3.fc34.aarch64.rpm"
           },
@@ -5498,9 +5263,6 @@
           },
           "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
-          },
-          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
           },
           "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
@@ -5556,9 +5318,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:126acd75f133605802b13f28e90c989286bd51081efd92aad9e91537fbe5fe66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zezere-ignition-0.5-7.fc34.noarch.rpm"
           },
@@ -5567,9 +5326,6 @@
           },
           "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
-          },
-          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
@@ -5597,9 +5353,6 @@
           },
           "sha256:1745a73b1db55448684565af05be3918002610053183ba335e2b8aefd7ff07d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/conmon-2.0.30-2.fc34.aarch64.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:184f5ac8f7d492fe17955732418eccaa401846b0198d9df546d8cbdeb740ae2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pkgconf-pkg-config-1.7.3-6.fc34.aarch64.rpm"
@@ -5759,9 +5512,6 @@
           },
           "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
-          },
-          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
@@ -5955,9 +5705,6 @@
           "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
           },
-          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
-          },
           "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
           },
@@ -5982,9 +5729,6 @@
           "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
           },
-          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
-          },
           "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
           },
@@ -6005,9 +5749,6 @@
           },
           "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
-          },
-          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
           },
           "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
@@ -6104,9 +5845,6 @@
           },
           "sha256:7891cf2712faefb401b604e965ac989adcb81bc7c8e8c6ff0032e0dcd1ba7de8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/skopeo-1.5.2-1.fc34.aarch64.rpm"
-          },
-          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
           },
           "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
@@ -6309,9 +6047,6 @@
           "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
           },
-          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
-          },
           "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
           },
@@ -6338,9 +6073,6 @@
           },
           "sha256:ace8c33f9e2be15f2bd5abed77521bf1e15344bb4defea30729f0c2c23c3dd8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parsec-0.7.0-2.fc34.aarch64.rpm"
-          },
-          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
           },
           "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
@@ -6498,14 +6230,8 @@
           "sha256:c2b835120a27dcfa789719bba9a6ddeb7cac51c740ef4189c93bc922eefb49ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmbim-1.26.0-1.fc34.aarch64.rpm"
           },
-          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
-          },
           "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
-          },
-          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:c563eaa86cef1046453fa5ff80a8514aa4dd741c08681dc842a646178cd481e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/usbguard-selinux-1.0.0-4.fc34.noarch.rpm"
@@ -6594,9 +6320,6 @@
           "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
           },
-          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
-          },
           "sha256:d578f84d5a1cc3c68ae69b0448e76647be63e960bfa53e33cc1d12e2120aab0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/podman-plugins-3.4.2-1.fc34.aarch64.rpm"
           },
@@ -6641,9 +6364,6 @@
           },
           "sha256:dca779ac7dc21748214dc171c1eaba876f24e16f303081b560e2a4318d71acdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/volume_key-libs-0.3.12-14.fc34.aarch64.rpm"
-          },
-          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
           },
           "sha256:dd4481d36ae25287f8b28e4f8d8d7b8a41143bc1278a6710194f4d21a9b41734": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/r/rpm-ostree-2021.13-2.fc34.aarch64.rpm"
@@ -6696,9 +6416,6 @@
           "sha256:e8d951e93f42a335d46413e410647f366442040c671db09129f692ad7536c5ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/compat-readline5-5.2-39.fc34.aarch64.rpm"
           },
-          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
-          },
           "sha256:eab3cd380a5ad89e7222672b67a89dae56c3848840931e4177cab215233eb826": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pkgconf-m4-1.7.3-6.fc34.noarch.rpm"
           },
@@ -6716,9 +6433,6 @@
           },
           "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
-          },
-          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
           },
           "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
@@ -6931,26 +6645,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6978,36 +6672,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
         "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
         "check_gpg": true
       },
       {
@@ -7171,16 +6835,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
-        "check_gpg": true
-      },
-      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.14",
@@ -7238,16 +6892,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
         "check_gpg": true
       },
       {
@@ -7328,16 +6972,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
         "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
         "check_gpg": true
       },
       {
@@ -7521,16 +7155,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7558,16 +7182,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
         "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
         "check_gpg": true
       },
       {
@@ -7781,16 +7395,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7798,26 +7402,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -7841,16 +7425,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7868,26 +7442,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -8078,26 +7632,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -8391,16 +7925,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -8418,16 +7942,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -8528,16 +8042,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8801,46 +8305,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8868,26 +8332,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {
@@ -9011,16 +8455,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -9028,16 +8462,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_container-boot.json
@@ -145,22 +145,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -178,30 +162,6 @@
                   },
                   {
                     "id": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -337,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
                     "options": {
                       "metadata": {
@@ -386,14 +338,6 @@
                   },
                   {
                     "id": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -458,14 +402,6 @@
                   },
                   {
                     "id": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
                     "options": {
                       "metadata": {
@@ -642,14 +570,6 @@
                   },
                   {
                     "id": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,31 +745,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -873,14 +769,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -890,22 +778,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1058,22 +930,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1313,14 +1169,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1330,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1418,14 +1258,6 @@
                   },
                   {
                     "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1641,38 +1473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1690,22 +1490,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1809,23 +1593,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7004,9 +6772,6 @@
           "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
           },
-          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:076a1e90dd9897a6a3295eb7a6f48be3a59ccf05238ce9455cce232193fab24b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/greenboot-status-0.11-3.fc34.aarch64.rpm"
           },
@@ -7021,9 +6786,6 @@
           },
           "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
-          },
-          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
           },
           "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
@@ -7082,9 +6844,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:126acd75f133605802b13f28e90c989286bd51081efd92aad9e91537fbe5fe66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zezere-ignition-0.5-7.fc34.noarch.rpm"
           },
@@ -7093,9 +6852,6 @@
           },
           "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
-          },
-          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
@@ -7123,9 +6879,6 @@
           },
           "sha256:1745a73b1db55448684565af05be3918002610053183ba335e2b8aefd7ff07d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/conmon-2.0.30-2.fc34.aarch64.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:184f5ac8f7d492fe17955732418eccaa401846b0198d9df546d8cbdeb740ae2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pkgconf-pkg-config-1.7.3-6.fc34.aarch64.rpm"
@@ -7291,9 +7044,6 @@
           },
           "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
-          },
-          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
@@ -7490,9 +7240,6 @@
           "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
           },
-          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
-          },
           "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
           },
@@ -7517,9 +7264,6 @@
           "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
           },
-          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
-          },
           "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
           },
@@ -7540,9 +7284,6 @@
           },
           "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
-          },
-          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
           },
           "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
@@ -7648,9 +7389,6 @@
           },
           "sha256:7891cf2712faefb401b604e965ac989adcb81bc7c8e8c6ff0032e0dcd1ba7de8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/skopeo-1.5.2-1.fc34.aarch64.rpm"
-          },
-          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
           },
           "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
@@ -7856,9 +7594,6 @@
           "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
           },
-          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
-          },
           "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
           },
@@ -7885,9 +7620,6 @@
           },
           "sha256:ace8c33f9e2be15f2bd5abed77521bf1e15344bb4defea30729f0c2c23c3dd8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parsec-0.7.0-2.fc34.aarch64.rpm"
-          },
-          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
           },
           "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
@@ -8048,14 +7780,8 @@
           "sha256:c2b835120a27dcfa789719bba9a6ddeb7cac51c740ef4189c93bc922eefb49ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmbim-1.26.0-1.fc34.aarch64.rpm"
           },
-          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
-          },
           "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
-          },
-          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
           },
           "sha256:c563eaa86cef1046453fa5ff80a8514aa4dd741c08681dc842a646178cd481e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/usbguard-selinux-1.0.0-4.fc34.noarch.rpm"
@@ -8144,9 +7870,6 @@
           "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
           },
-          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
-          },
           "sha256:d578f84d5a1cc3c68ae69b0448e76647be63e960bfa53e33cc1d12e2120aab0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/podman-plugins-3.4.2-1.fc34.aarch64.rpm"
           },
@@ -8191,9 +7914,6 @@
           },
           "sha256:dca779ac7dc21748214dc171c1eaba876f24e16f303081b560e2a4318d71acdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/volume_key-libs-0.3.12-14.fc34.aarch64.rpm"
-          },
-          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
           },
           "sha256:dd4481d36ae25287f8b28e4f8d8d7b8a41143bc1278a6710194f4d21a9b41734": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/r/rpm-ostree-2021.13-2.fc34.aarch64.rpm"
@@ -8246,9 +7966,6 @@
           "sha256:e8d951e93f42a335d46413e410647f366442040c671db09129f692ad7536c5ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/compat-readline5-5.2-39.fc34.aarch64.rpm"
           },
-          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
-          },
           "sha256:eab3cd380a5ad89e7222672b67a89dae56c3848840931e4177cab215233eb826": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pkgconf-m4-1.7.3-6.fc34.noarch.rpm"
           },
@@ -8266,9 +7983,6 @@
           },
           "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
-          },
-          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
           },
           "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
@@ -8487,26 +8201,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -8534,36 +8228,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
         "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
         "check_gpg": true
       },
       {
@@ -8727,16 +8391,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
-        "check_gpg": true
-      },
-      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.14",
@@ -8794,16 +8448,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
         "check_gpg": true
       },
       {
@@ -8884,16 +8528,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
         "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
         "check_gpg": true
       },
       {
@@ -9077,16 +8711,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
-        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -9114,16 +8738,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
         "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
         "check_gpg": true
       },
       {
@@ -9337,16 +8951,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -9354,26 +8958,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -9397,16 +8981,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -9424,26 +8998,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -9634,26 +9188,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -9947,16 +9481,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -9974,16 +9498,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -10084,16 +9598,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -10357,46 +9861,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -10424,26 +9888,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {
@@ -10567,16 +10011,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -10584,16 +10018,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_installer-boot.json
@@ -455,14 +455,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
                     "options": {
                       "metadata": {
@@ -744,14 +736,6 @@
                   },
                   {
                     "id": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1239,14 +1223,6 @@
                     }
                   },
                   {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
                     "options": {
                       "metadata": {
@@ -1360,14 +1336,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2096,14 +2064,6 @@
                   },
                   {
                     "id": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -9921,9 +9881,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:1250ec04fc90ca039585aad4a1e42833f471df3e6abd92a01c90ccdc23bca015": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fxload-2008_10_13-19.fc34.aarch64.rpm"
           },
@@ -9980,9 +9937,6 @@
           },
           "sha256:17cc5cb54568bbed5823c97054f7ef95a57f07386e626d661e129567ef0de02b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/usbutils-014-1.fc34.aarch64.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:180abbc01174d20536db8e7e5f0d8d39aee7429b90ecc00fbbc2217d011ed559": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libisoburn-1.5.4-2.fc34.aarch64.rpm"
@@ -21960,16 +21914,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -22327,16 +22271,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
         "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
         "check_gpg": true
       },
       {
@@ -22940,16 +22874,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -23097,16 +23021,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
         "check_gpg": true
       },
       {
@@ -24017,16 +23931,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
         "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-aarch64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-fedora_iot_installer_with_users-boot.json
@@ -484,14 +484,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
                     "options": {
                       "metadata": {
@@ -773,14 +765,6 @@
                   },
                   {
                     "id": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1268,14 +1252,6 @@
                     }
                   },
                   {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
                     "options": {
                       "metadata": {
@@ -1389,14 +1365,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2125,14 +2093,6 @@
                   },
                   {
                     "id": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -9973,9 +9933,6 @@
           "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
           },
-          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
-          },
           "sha256:1250ec04fc90ca039585aad4a1e42833f471df3e6abd92a01c90ccdc23bca015": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fxload-2008_10_13-19.fc34.aarch64.rpm"
           },
@@ -10032,9 +9989,6 @@
           },
           "sha256:17cc5cb54568bbed5823c97054f7ef95a57f07386e626d661e129567ef0de02b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/usbutils-014-1.fc34.aarch64.rpm"
-          },
-          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
           },
           "sha256:180abbc01174d20536db8e7e5f0d8d39aee7429b90ecc00fbbc2217d011ed559": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libisoburn-1.5.4-2.fc34.aarch64.rpm"
@@ -22012,16 +21966,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
-        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -22379,16 +22323,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
         "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
-        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
         "check_gpg": true
       },
       {
@@ -22992,16 +22926,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -23149,16 +23073,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
         "check_gpg": true
       },
       {
@@ -24069,16 +23983,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
         "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
-        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-oci-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -273,30 +257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -314,14 +274,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -393,14 +345,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
                     "options": {
                       "metadata": {
@@ -449,14 +393,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -490,14 +426,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -586,14 +506,6 @@
                   },
                   {
                     "id": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -641,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -666,14 +570,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +610,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +697,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -874,22 +730,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -922,14 +762,6 @@
                   },
                   {
                     "id": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1042,22 +874,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1281,14 +1097,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1298,14 +1106,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1361,14 +1161,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1378,22 +1170,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1537,14 +1313,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1585,38 +1353,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1634,14 +1370,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1737,23 +1465,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1778,14 +1490,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6060,26 +5764,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6230,36 +5914,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6287,16 +5941,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -6380,16 +6024,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6450,16 +6084,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6507,16 +6131,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -6570,16 +6184,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6627,16 +6231,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
         "check_gpg": true
       },
       {
@@ -6690,16 +6284,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6727,16 +6311,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -6787,16 +6361,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -6900,16 +6464,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -6917,26 +6471,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -6960,16 +6494,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -6987,26 +6511,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -7047,16 +6551,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
         "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
         "check_gpg": true
       },
       {
@@ -7197,26 +6691,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7490,16 +6964,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7517,16 +6981,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -7590,16 +7044,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7617,26 +7061,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7810,16 +7234,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -7870,46 +7284,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -7937,16 +7311,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
         "check_gpg": true
       },
       {
@@ -8060,16 +7424,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8077,16 +7431,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -8117,16 +7461,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-openstack-boot.json
@@ -154,22 +154,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -290,30 +274,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -331,14 +291,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -410,14 +362,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
                     "options": {
                       "metadata": {
@@ -466,14 +410,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -507,14 +443,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -562,14 +490,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -603,14 +523,6 @@
                   },
                   {
                     "id": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -658,14 +570,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -683,14 +587,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -731,14 +627,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -826,31 +714,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -874,14 +738,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -891,22 +747,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -939,14 +779,6 @@
                   },
                   {
                     "id": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1059,22 +891,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1298,14 +1114,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1315,14 +1123,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1378,14 +1178,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1395,22 +1187,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1554,14 +1330,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1602,38 +1370,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1651,14 +1387,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1754,23 +1482,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1795,14 +1507,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5798,9 +5502,6 @@
           "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
           },
-          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
-          },
           "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
           },
@@ -6410,26 +6111,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6580,36 +6261,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6637,16 +6288,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -6730,16 +6371,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6800,16 +6431,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6857,16 +6478,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -6920,16 +6531,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6977,16 +6578,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
         "check_gpg": true
       },
       {
@@ -7040,16 +6631,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7077,16 +6658,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -7137,16 +6708,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -7250,16 +6811,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7267,26 +6818,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -7310,16 +6841,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7337,26 +6858,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -7397,16 +6898,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
         "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
         "check_gpg": true
       },
       {
@@ -7547,26 +7038,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7840,16 +7311,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7867,16 +7328,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -7940,16 +7391,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7967,26 +7408,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8160,16 +7581,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8220,46 +7631,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8287,16 +7658,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
         "check_gpg": true
       },
       {
@@ -8410,16 +7771,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8427,16 +7778,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -8467,16 +7808,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
@@ -151,22 +151,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -287,30 +271,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -328,14 +288,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -407,14 +359,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
                     "options": {
                       "metadata": {
@@ -463,14 +407,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -504,14 +440,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -559,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -600,14 +520,6 @@
                   },
                   {
                     "id": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -655,14 +567,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -680,14 +584,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -728,14 +624,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -823,31 +711,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -871,14 +735,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -888,22 +744,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -936,14 +776,6 @@
                   },
                   {
                     "id": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1056,22 +888,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1295,14 +1111,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1312,14 +1120,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1375,14 +1175,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1392,22 +1184,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1551,14 +1327,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1599,38 +1367,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1648,14 +1384,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1751,23 +1479,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1792,14 +1504,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6084,26 +5788,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6254,36 +5938,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6311,16 +5965,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -6404,16 +6048,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6474,16 +6108,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6531,16 +6155,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -6594,16 +6208,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6651,16 +6255,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
         "check_gpg": true
       },
       {
@@ -6714,16 +6308,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6751,16 +6335,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -6811,16 +6385,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -6924,16 +6488,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -6941,26 +6495,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -6984,16 +6518,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7011,26 +6535,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -7071,16 +6575,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
         "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
         "check_gpg": true
       },
       {
@@ -7221,26 +6715,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7514,16 +6988,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7541,16 +7005,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -7614,16 +7068,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7641,26 +7085,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7834,16 +7258,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -7894,46 +7308,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -7961,16 +7335,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
         "check_gpg": true
       },
       {
@@ -8084,16 +7448,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8101,16 +7455,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -8141,16 +7485,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
                     "options": {
                       "metadata": {
@@ -345,30 +329,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
                     "options": {
                       "metadata": {
@@ -386,14 +346,6 @@
                   },
                   {
                     "id": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -465,14 +417,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
                     "options": {
                       "metadata": {
@@ -521,14 +465,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
                     "options": {
                       "metadata": {
@@ -562,14 +498,6 @@
                   },
                   {
                     "id": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
                     "options": {
                       "metadata": {
@@ -658,14 +578,6 @@
                   },
                   {
                     "id": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -713,14 +625,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
                     "options": {
                       "metadata": {
@@ -738,14 +642,6 @@
                   },
                   {
                     "id": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -786,14 +682,6 @@
                   },
                   {
                     "id": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -881,31 +769,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -929,14 +793,6 @@
                     }
                   },
                   {
-                    "id": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
                     "options": {
                       "metadata": {
@@ -946,22 +802,6 @@
                   },
                   {
                     "id": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -994,14 +834,6 @@
                   },
                   {
                     "id": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1114,22 +946,6 @@
                   },
                   {
                     "id": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1353,14 +1169,6 @@
                     }
                   },
                   {
-                    "id": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
                     "options": {
                       "metadata": {
@@ -1370,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1433,14 +1233,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
                     "options": {
                       "metadata": {
@@ -1450,22 +1242,6 @@
                   },
                   {
                     "id": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1609,14 +1385,6 @@
                     }
                   },
                   {
-                    "id": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
                     "options": {
                       "metadata": {
@@ -1657,38 +1425,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
                     "options": {
                       "metadata": {
@@ -1706,14 +1442,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1809,23 +1537,7 @@
                     }
                   },
                   {
-                    "id": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1850,14 +1562,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6405,26 +6109,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
-        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
-        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6575,36 +6259,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
-        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6632,16 +6286,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
         "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
-        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
         "check_gpg": true
       },
       {
@@ -6725,16 +6369,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6795,16 +6429,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
-        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6852,16 +6476,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
         "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
         "check_gpg": true
       },
       {
@@ -6915,16 +6529,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
-        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6972,16 +6576,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
-        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
         "check_gpg": true
       },
       {
@@ -7035,16 +6629,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
-        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7072,16 +6656,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
         "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
-        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
         "check_gpg": true
       },
       {
@@ -7132,16 +6706,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
         "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
-        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
         "check_gpg": true
       },
       {
@@ -7245,16 +6809,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
-        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7262,26 +6816,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
-        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
         "check_gpg": true
       },
       {
@@ -7305,16 +6839,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7332,26 +6856,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
         "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
-        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
         "check_gpg": true
       },
       {
@@ -7392,16 +6896,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
         "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
-        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
         "check_gpg": true
       },
       {
@@ -7542,26 +7036,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
         "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7835,16 +7309,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7862,16 +7326,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
         "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
         "check_gpg": true
       },
       {
@@ -7935,16 +7389,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
-        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7962,26 +7406,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
         "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8155,16 +7579,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8215,46 +7629,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
-        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8282,16 +7656,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
         "check_gpg": true
       },
       {
@@ -8405,16 +7769,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
-        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8422,16 +7776,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
-        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
         "check_gpg": true
       },
       {
@@ -8462,16 +7806,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
-        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-ami-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -273,30 +257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -314,14 +274,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -377,23 +329,7 @@
                     }
                   },
                   {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -449,14 +385,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -490,14 +418,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +465,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -593,14 +505,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
                     "options": {
                       "metadata": {
@@ -633,22 +537,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -666,14 +554,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +594,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +681,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -874,22 +714,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -913,23 +737,7 @@
                     }
                   },
                   {
-                    "id": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +857,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
                     "options": {
                       "metadata": {
@@ -1162,14 +954,6 @@
                   },
                   {
                     "id": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1297,14 +1081,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1314,14 +1090,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1377,14 +1145,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1394,22 +1154,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1561,14 +1305,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1609,38 +1345,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1658,22 +1362,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1761,23 +1449,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1802,14 +1474,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5119,17 +4783,11 @@
           "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
           },
-          "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm"
-          },
           "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.x86_64.rpm"
           },
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
-          },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
           },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
@@ -5433,9 +5091,6 @@
           },
           "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm"
-          },
-          "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm"
           },
           "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm"
@@ -5800,9 +5455,6 @@
           "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
           },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
-          },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
           },
@@ -6151,26 +5803,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6321,36 +5953,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6378,16 +5980,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6451,16 +6043,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -6468,16 +6050,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.x86_64.rpm",
         "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
         "check_gpg": true
       },
       {
@@ -6541,16 +6113,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6598,16 +6160,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6661,16 +6213,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6721,16 +6263,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
-        "check_gpg": true
-      },
-      {
         "name": "libss",
         "epoch": 0,
         "version": "1.45.6",
@@ -6771,26 +6303,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
-        "check_gpg": true
-      },
-      {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6818,16 +6330,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -6878,16 +6380,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -6991,16 +6483,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7008,26 +6490,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7051,16 +6513,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7078,26 +6530,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7121,16 +6553,6 @@
         "check_gpg": true
       },
       {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
-        "check_gpg": true
-      },
-      {
         "name": "sqlite-libs",
         "epoch": 0,
         "version": "3.34.1",
@@ -7138,16 +6560,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7291,26 +6703,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "055",
@@ -7438,16 +6830,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.x86_64.rpm",
         "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
-        "check_gpg": true
-      },
-      {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.68.4",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.x86_64.rpm",
-        "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
         "check_gpg": true
       },
       {
@@ -7601,16 +6983,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7628,16 +7000,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -7701,16 +7063,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7728,26 +7080,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7931,16 +7263,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -7991,46 +7313,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8058,26 +7340,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {
@@ -8181,16 +7443,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8198,16 +7450,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8238,16 +7480,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-container-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -170,30 +154,6 @@
                   },
                   {
                     "id": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -273,30 +233,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -314,14 +250,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -377,23 +305,7 @@
                     }
                   },
                   {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -449,14 +361,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -490,14 +394,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -593,22 +481,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
                     "options": {
                       "metadata": {
@@ -633,22 +505,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -666,14 +522,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +562,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +649,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +673,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -881,22 +689,6 @@
                     }
                   },
                   {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d",
                     "options": {
                       "metadata": {
@@ -906,14 +698,6 @@
                   },
                   {
                     "id": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +833,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
                     "options": {
                       "metadata": {
@@ -1162,14 +930,6 @@
                   },
                   {
                     "id": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1281,14 +1041,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1298,14 +1050,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1361,14 +1105,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1378,22 +1114,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1545,14 +1265,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1593,38 +1305,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1642,22 +1322,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1745,23 +1409,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1786,14 +1434,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3168,17 +2808,11 @@
           "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
           },
-          "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm"
-          },
           "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.x86_64.rpm"
           },
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
-          },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
           },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
@@ -3209,12 +2843,6 @@
           },
           "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.x86_64.rpm"
-          },
-          "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm"
-          },
-          "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm"
           },
           "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
@@ -3270,9 +2898,6 @@
           "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
           },
-          "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm"
-          },
           "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.x86_64.rpm"
           },
@@ -3311,9 +2936,6 @@
           },
           "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.x86_64.rpm"
-          },
-          "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm"
           },
           "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
@@ -3408,9 +3030,6 @@
           "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.x86_64.rpm"
           },
-          "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm"
-          },
           "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm"
           },
@@ -3431,9 +3050,6 @@
           },
           "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.x86_64.rpm"
-          },
-          "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm"
           },
           "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.x86_64.rpm"
@@ -3461,9 +3077,6 @@
           },
           "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.x86_64.rpm"
-          },
-          "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm"
           },
           "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
@@ -3561,9 +3174,6 @@
           "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.x86_64.rpm"
           },
-          "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm"
-          },
           "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm"
           },
@@ -3603,9 +3213,6 @@
           "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.x86_64.rpm"
           },
-          "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm"
-          },
           "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.x86_64.rpm"
           },
@@ -3630,9 +3237,6 @@
           "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
           },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
-          },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
           },
@@ -3647,9 +3251,6 @@
           },
           "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm"
-          },
-          "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm"
           },
           "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm"
@@ -3702,9 +3303,6 @@
           "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.x86_64.rpm"
           },
-          "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm"
-          },
           "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm"
           },
@@ -3716,9 +3314,6 @@
           },
           "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
-          },
-          "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm"
           },
           "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.x86_64.rpm"
@@ -3755,9 +3350,6 @@
           },
           "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
-          },
-          "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm"
           },
           "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.x86_64.rpm"
@@ -3882,26 +3474,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -3929,36 +3501,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
         "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
         "check_gpg": true
       },
       {
@@ -4052,36 +3594,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -4109,16 +3621,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -4182,16 +3684,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -4199,16 +3691,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.x86_64.rpm",
         "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
         "check_gpg": true
       },
       {
@@ -4272,16 +3754,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -4329,16 +3801,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -4392,16 +3854,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -4452,26 +3904,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4502,26 +3934,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
-        "check_gpg": true
-      },
-      {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -4549,16 +3961,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -4609,16 +4011,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -4722,16 +4114,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -4739,26 +4121,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -4782,16 +4144,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -4812,26 +4164,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
-        "check_gpg": true
-      },
-      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4849,16 +4181,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
         "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
-        "check_gpg": true
-      },
-      {
-        "name": "shared-mime-info",
-        "epoch": 0,
-        "version": "2.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
         "check_gpg": true
       },
       {
@@ -5022,26 +4344,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "055",
@@ -5169,16 +4471,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.x86_64.rpm",
         "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
-        "check_gpg": true
-      },
-      {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.68.4",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.x86_64.rpm",
-        "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
         "check_gpg": true
       },
       {
@@ -5312,16 +4604,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -5339,16 +4621,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -5412,16 +4684,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -5439,26 +4701,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -5642,16 +4884,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -5702,46 +4934,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -5769,26 +4961,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {
@@ -5892,16 +5064,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -5909,16 +5071,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -5949,16 +5101,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -145,22 +145,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -178,30 +162,6 @@
                   },
                   {
                     "id": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -337,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
                     "options": {
                       "metadata": {
@@ -386,14 +338,6 @@
                   },
                   {
                     "id": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -458,14 +402,6 @@
                   },
                   {
                     "id": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
                     "options": {
                       "metadata": {
@@ -642,14 +570,6 @@
                   },
                   {
                     "id": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,31 +745,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -873,14 +769,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -890,22 +778,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1058,22 +930,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1329,14 +1185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1346,14 +1194,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1434,14 +1274,6 @@
                   },
                   {
                     "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1665,38 +1497,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1714,22 +1514,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1833,23 +1617,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5605,9 +5373,6 @@
           "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm"
           },
-          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm"
           },
@@ -5770,9 +5535,6 @@
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
           },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
-          },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
           },
@@ -5920,9 +5682,6 @@
           "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm"
           },
-          "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:45bdc2199a232ec3599d9d19d8db88690e839af387f09ec7cd4b5dbbcc13da70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/ostree-2021.5-2.fc34.x86_64.rpm"
           },
@@ -5946,9 +5705,6 @@
           },
           "sha256:4ad9bea021eaf5f86ce06d4bc946183ba74ba50ca83b87edfb177850a96c64f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwl7260-firmware-25.30.13.0-127.fc34.noarch.rpm"
-          },
-          "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:4bd578b9b04edb7f80a0a4ec4ffd1b0b126e9a1ae5618a9e6539e0376118b368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/attr-2.5.1-1.fc34.x86_64.rpm"
@@ -6013,9 +5769,6 @@
           "sha256:591c30d595d031173e28a69734cc03e42515aae61b7bbaf977a901a1bd9368ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-mdraid-2.26-1.fc34.x86_64.rpm"
           },
-          "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm"
-          },
           "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm"
           },
@@ -6060,9 +5813,6 @@
           },
           "sha256:6641e65c042ee5cfbef9c2af52b090a0d9092da16bc278af6e7658376a810947": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpkgconf-1.7.3-6.fc34.x86_64.rpm"
-          },
-          "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm"
           },
           "sha256:68175fa45d6b8a34ae1fde5cab6c22b5a54944848cfed760013c1ed1dfe94486": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwd-1.17-1.fc34.x86_64.rpm"
@@ -6222,9 +5972,6 @@
           },
           "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm"
-          },
-          "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm"
           },
           "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.x86_64.rpm"
@@ -6436,9 +6183,6 @@
           "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm"
           },
-          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ad664cb06e2574b3d8847c0228e0beb479a5643b43a3f61cce8960faab9d7b41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.117-3.fc34.1.x86_64.rpm"
           },
@@ -6463,9 +6207,6 @@
           "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm"
           },
-          "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -6474,9 +6215,6 @@
           },
           "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm"
-          },
-          "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm"
@@ -6544,9 +6282,6 @@
           "sha256:ba2916d48b3a28e9bc2c9fbde19770c204b6ad4cdc94471c3c6bdbfbe8669461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lzo-2.10-4.fc34.x86_64.rpm"
           },
-          "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm"
           },
@@ -6570,9 +6305,6 @@
           },
           "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.x86_64.rpm"
-          },
-          "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:be3297aa224ed73cbc110b00e641f46d5b82c32e51a2961d9a85b87e741cb9eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-2.26-1.fc34.x86_64.rpm"
@@ -6643,9 +6375,6 @@
           "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
           },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
-          },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
           },
@@ -6682,9 +6411,6 @@
           "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
           },
-          "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm"
-          },
           "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -6699,12 +6425,6 @@
           },
           "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.x86_64.rpm"
-          },
-          "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm"
-          },
-          "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm"
@@ -6844,9 +6564,6 @@
           "sha256:ed021b5b969898455df94f4973ae5575baa466155f959afcdb230f41218941a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/j/json-glib-1.6.6-1.fc34.x86_64.rpm"
           },
-          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm"
           },
@@ -6909,9 +6626,6 @@
           },
           "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
-          },
-          "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm"
           },
           "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.x86_64.rpm"
@@ -7076,26 +6790,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7123,36 +6817,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
         "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
         "check_gpg": true
       },
       {
@@ -7316,16 +6980,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-        "check_gpg": true
-      },
-      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.14",
@@ -7383,16 +7037,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
         "check_gpg": true
       },
       {
@@ -7473,16 +7117,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm",
         "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
         "check_gpg": true
       },
       {
@@ -7666,16 +7300,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7703,16 +7327,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
         "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
         "check_gpg": true
       },
       {
@@ -7926,16 +7540,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7943,26 +7547,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7986,16 +7570,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -8013,26 +7587,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -8223,26 +7777,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -8556,16 +8090,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -8583,16 +8107,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -8693,16 +8207,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8976,46 +8480,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -9043,26 +8507,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {
@@ -9186,16 +8630,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -9203,16 +8637,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -151,22 +151,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -184,30 +168,6 @@
                   },
                   {
                     "id": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -343,14 +303,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
                     "options": {
                       "metadata": {
@@ -392,14 +344,6 @@
                   },
                   {
                     "id": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -464,14 +408,6 @@
                   },
                   {
                     "id": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -623,14 +559,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
                     "options": {
                       "metadata": {
@@ -648,14 +576,6 @@
                   },
                   {
                     "id": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -831,31 +751,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -879,14 +775,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -896,22 +784,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1064,22 +936,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1335,14 +1191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1352,14 +1200,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1440,14 +1280,6 @@
                   },
                   {
                     "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1671,38 +1503,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1720,22 +1520,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1839,23 +1623,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5611,9 +5379,6 @@
           "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm"
           },
-          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm"
           },
@@ -5773,9 +5538,6 @@
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
           },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
-          },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
           },
@@ -5923,9 +5685,6 @@
           "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm"
           },
-          "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:45bdc2199a232ec3599d9d19d8db88690e839af387f09ec7cd4b5dbbcc13da70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/ostree-2021.5-2.fc34.x86_64.rpm"
           },
@@ -5949,9 +5708,6 @@
           },
           "sha256:4ad9bea021eaf5f86ce06d4bc946183ba74ba50ca83b87edfb177850a96c64f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwl7260-firmware-25.30.13.0-127.fc34.noarch.rpm"
-          },
-          "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:4bd578b9b04edb7f80a0a4ec4ffd1b0b126e9a1ae5618a9e6539e0376118b368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/attr-2.5.1-1.fc34.x86_64.rpm"
@@ -6013,9 +5769,6 @@
           "sha256:591c30d595d031173e28a69734cc03e42515aae61b7bbaf977a901a1bd9368ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-mdraid-2.26-1.fc34.x86_64.rpm"
           },
-          "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm"
-          },
           "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm"
           },
@@ -6063,9 +5816,6 @@
           },
           "sha256:6641e65c042ee5cfbef9c2af52b090a0d9092da16bc278af6e7658376a810947": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpkgconf-1.7.3-6.fc34.x86_64.rpm"
-          },
-          "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm"
           },
           "sha256:68175fa45d6b8a34ae1fde5cab6c22b5a54944848cfed760013c1ed1dfe94486": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwd-1.17-1.fc34.x86_64.rpm"
@@ -6225,9 +5975,6 @@
           },
           "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm"
-          },
-          "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm"
           },
           "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.x86_64.rpm"
@@ -6436,9 +6183,6 @@
           "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm"
           },
-          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ad664cb06e2574b3d8847c0228e0beb479a5643b43a3f61cce8960faab9d7b41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.117-3.fc34.1.x86_64.rpm"
           },
@@ -6463,9 +6207,6 @@
           "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm"
           },
-          "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -6474,9 +6215,6 @@
           },
           "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm"
-          },
-          "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm"
@@ -6544,9 +6282,6 @@
           "sha256:ba2916d48b3a28e9bc2c9fbde19770c204b6ad4cdc94471c3c6bdbfbe8669461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lzo-2.10-4.fc34.x86_64.rpm"
           },
-          "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm"
           },
@@ -6570,9 +6305,6 @@
           },
           "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.x86_64.rpm"
-          },
-          "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:be3297aa224ed73cbc110b00e641f46d5b82c32e51a2961d9a85b87e741cb9eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-2.26-1.fc34.x86_64.rpm"
@@ -6643,9 +6375,6 @@
           "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
           },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
-          },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
           },
@@ -6682,9 +6411,6 @@
           "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
           },
-          "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm"
-          },
           "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -6699,12 +6425,6 @@
           },
           "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.x86_64.rpm"
-          },
-          "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm"
-          },
-          "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm"
@@ -6850,9 +6570,6 @@
           "sha256:ed021b5b969898455df94f4973ae5575baa466155f959afcdb230f41218941a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/j/json-glib-1.6.6-1.fc34.x86_64.rpm"
           },
-          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm"
           },
@@ -6915,9 +6632,6 @@
           },
           "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
-          },
-          "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm"
           },
           "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.x86_64.rpm"
@@ -7082,26 +6796,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7129,36 +6823,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
         "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
         "check_gpg": true
       },
       {
@@ -7322,16 +6986,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-        "check_gpg": true
-      },
-      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.14",
@@ -7389,16 +7043,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
         "check_gpg": true
       },
       {
@@ -7479,16 +7123,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm",
         "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
         "check_gpg": true
       },
       {
@@ -7672,16 +7306,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7709,16 +7333,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
         "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
         "check_gpg": true
       },
       {
@@ -7932,16 +7546,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7949,26 +7553,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7992,16 +7576,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -8019,26 +7593,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -8229,26 +7783,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -8562,16 +8096,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -8589,16 +8113,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -8699,16 +8213,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8982,46 +8486,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -9049,26 +8513,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {
@@ -9192,16 +8636,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -9209,16 +8643,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_container-boot.json
@@ -145,22 +145,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -178,30 +162,6 @@
                   },
                   {
                     "id": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -337,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
                     "options": {
                       "metadata": {
@@ -386,14 +338,6 @@
                   },
                   {
                     "id": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -458,14 +402,6 @@
                   },
                   {
                     "id": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
                     "options": {
                       "metadata": {
@@ -642,14 +570,6 @@
                   },
                   {
                     "id": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,31 +745,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -873,14 +769,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -890,22 +778,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1058,22 +930,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1329,14 +1185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1346,14 +1194,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1434,14 +1274,6 @@
                   },
                   {
                     "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1665,38 +1497,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1714,22 +1514,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1833,23 +1617,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7136,9 +6904,6 @@
           "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm"
           },
-          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm"
           },
@@ -7310,9 +7075,6 @@
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
           },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
-          },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
           },
@@ -7466,9 +7228,6 @@
           "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm"
           },
-          "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:45bdc2199a232ec3599d9d19d8db88690e839af387f09ec7cd4b5dbbcc13da70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/ostree-2021.5-2.fc34.x86_64.rpm"
           },
@@ -7492,9 +7251,6 @@
           },
           "sha256:4ad9bea021eaf5f86ce06d4bc946183ba74ba50ca83b87edfb177850a96c64f3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwl7260-firmware-25.30.13.0-127.fc34.noarch.rpm"
-          },
-          "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:4bd578b9b04edb7f80a0a4ec4ffd1b0b126e9a1ae5618a9e6539e0376118b368": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/attr-2.5.1-1.fc34.x86_64.rpm"
@@ -7559,9 +7315,6 @@
           "sha256:591c30d595d031173e28a69734cc03e42515aae61b7bbaf977a901a1bd9368ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-mdraid-2.26-1.fc34.x86_64.rpm"
           },
-          "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm"
-          },
           "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm"
           },
@@ -7606,9 +7359,6 @@
           },
           "sha256:6641e65c042ee5cfbef9c2af52b090a0d9092da16bc278af6e7658376a810947": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpkgconf-1.7.3-6.fc34.x86_64.rpm"
-          },
-          "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm"
           },
           "sha256:68175fa45d6b8a34ae1fde5cab6c22b5a54944848cfed760013c1ed1dfe94486": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iwd-1.17-1.fc34.x86_64.rpm"
@@ -7777,9 +7527,6 @@
           },
           "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm"
-          },
-          "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm"
           },
           "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.x86_64.rpm"
@@ -7997,9 +7744,6 @@
           "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm"
           },
-          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ad664cb06e2574b3d8847c0228e0beb479a5643b43a3f61cce8960faab9d7b41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.117-3.fc34.1.x86_64.rpm"
           },
@@ -8024,9 +7768,6 @@
           "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm"
           },
-          "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -8035,9 +7776,6 @@
           },
           "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm"
-          },
-          "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm"
@@ -8105,9 +7843,6 @@
           "sha256:ba2916d48b3a28e9bc2c9fbde19770c204b6ad4cdc94471c3c6bdbfbe8669461": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lzo-2.10-4.fc34.x86_64.rpm"
           },
-          "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm"
-          },
           "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm"
           },
@@ -8131,9 +7866,6 @@
           },
           "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.x86_64.rpm"
-          },
-          "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm"
           },
           "sha256:be3297aa224ed73cbc110b00e641f46d5b82c32e51a2961d9a85b87e741cb9eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libblockdev-2.26-1.fc34.x86_64.rpm"
@@ -8204,9 +7936,6 @@
           "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
           },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
-          },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
           },
@@ -8243,9 +7972,6 @@
           "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
           },
-          "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm"
-          },
           "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.x86_64.rpm"
           },
@@ -8260,12 +7986,6 @@
           },
           "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.x86_64.rpm"
-          },
-          "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm"
-          },
-          "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm"
           },
           "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm"
@@ -8408,9 +8128,6 @@
           "sha256:ed021b5b969898455df94f4973ae5575baa466155f959afcdb230f41218941a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/j/json-glib-1.6.6-1.fc34.x86_64.rpm"
           },
-          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
-          },
           "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm"
           },
@@ -8473,9 +8190,6 @@
           },
           "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
-          },
-          "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm"
           },
           "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.x86_64.rpm"
@@ -8640,26 +8354,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -8687,36 +8381,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
         "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
         "check_gpg": true
       },
       {
@@ -8880,16 +8544,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
-        "check_gpg": true
-      },
-      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.14",
@@ -8947,16 +8601,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
         "check_gpg": true
       },
       {
@@ -9037,16 +8681,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm",
         "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
         "check_gpg": true
       },
       {
@@ -9230,16 +8864,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.45.6",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
-        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -9267,16 +8891,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
         "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
         "check_gpg": true
       },
       {
@@ -9490,16 +9104,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -9507,26 +9111,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -9550,16 +9134,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -9577,26 +9151,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -9787,26 +9341,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -10120,16 +9654,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -10147,16 +9671,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -10257,16 +9771,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -10540,46 +10044,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -10607,26 +10071,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {
@@ -10750,16 +10194,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -10767,16 +10201,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_installer-boot.json
@@ -463,14 +463,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
                     "options": {
                       "metadata": {
@@ -752,14 +744,6 @@
                   },
                   {
                     "id": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1263,14 +1247,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
                     "options": {
                       "metadata": {
@@ -1384,14 +1360,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2152,14 +2120,6 @@
                   },
                   {
                     "id": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10351,9 +10311,6 @@
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
           },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
-          },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
           },
@@ -12090,9 +12047,6 @@
           },
           "sha256:c846322c855d3d2f12bb67ab5fdfbb89c759327274ad1eb6f2b0c705a06bf104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lohit-gurmukhi-fonts-2.91.2-12.fc34.noarch.rpm"
-          },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
           },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
@@ -22384,16 +22338,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -22751,16 +22695,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
         "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
         "check_gpg": true
       },
       {
@@ -23384,16 +23318,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -23541,16 +23465,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
         "check_gpg": true
       },
       {
@@ -24501,16 +24415,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
         "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_installer_with_users-boot.json
@@ -492,14 +492,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
                     "options": {
                       "metadata": {
@@ -781,14 +773,6 @@
                   },
                   {
                     "id": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1292,14 +1276,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
                     "options": {
                       "metadata": {
@@ -1413,14 +1389,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2181,14 +2149,6 @@
                   },
                   {
                     "id": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10403,9 +10363,6 @@
           "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
           },
-          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
-          },
           "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
           },
@@ -12142,9 +12099,6 @@
           },
           "sha256:c846322c855d3d2f12bb67ab5fdfbb89c759327274ad1eb6f2b0c705a06bf104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lohit-gurmukhi-fonts-2.91.2-12.fc34.noarch.rpm"
-          },
-          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
           },
           "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
@@ -22436,16 +22390,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "11.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
-        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
-        "check_gpg": true
-      },
-      {
         "name": "libargon2",
         "epoch": 0,
         "version": "20171227",
@@ -22803,16 +22747,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
         "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "0.7",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
-        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
         "check_gpg": true
       },
       {
@@ -23436,16 +23370,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -23593,16 +23517,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
         "check_gpg": true
       },
       {
@@ -24553,16 +24467,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
         "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "5.2.0",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
-        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_34-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-oci-boot.json
@@ -137,22 +137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -273,30 +257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -314,14 +274,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -393,14 +345,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -449,14 +393,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -490,14 +426,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -545,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -586,14 +506,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -641,14 +553,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -666,14 +570,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,14 +610,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -809,31 +697,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -857,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -874,22 +730,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -922,14 +762,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1042,22 +874,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1297,14 +1113,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1314,14 +1122,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1377,14 +1177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1394,22 +1186,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1561,14 +1337,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1609,38 +1377,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1658,14 +1394,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1761,23 +1489,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1802,14 +1514,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6199,26 +5903,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6369,36 +6053,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6426,16 +6080,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6519,16 +6163,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6589,16 +6223,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6646,16 +6270,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6709,16 +6323,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6766,16 +6370,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -6829,16 +6423,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6866,16 +6450,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -6926,16 +6500,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -7039,16 +6603,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7056,26 +6610,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7099,16 +6633,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7126,26 +6650,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7186,16 +6690,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7336,26 +6830,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7649,16 +7123,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7676,16 +7140,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -7749,16 +7203,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7776,26 +7220,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7979,16 +7403,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8039,46 +7453,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8106,16 +7480,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8229,16 +7593,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8246,16 +7600,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8286,16 +7630,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-openstack-boot.json
@@ -154,22 +154,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -290,30 +274,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -331,14 +291,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -410,14 +362,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -466,14 +410,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -507,14 +443,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -562,14 +490,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -603,14 +523,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -658,14 +570,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -683,14 +587,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -731,14 +627,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -826,31 +714,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -874,14 +738,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -891,22 +747,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -939,14 +779,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1059,22 +891,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1314,14 +1130,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1331,14 +1139,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1394,14 +1194,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1411,22 +1203,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1578,14 +1354,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1626,38 +1394,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1675,14 +1411,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1778,23 +1506,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1819,14 +1531,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5730,9 +5434,6 @@
           "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm"
           },
-          "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm"
-          },
           "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm"
           },
@@ -6483,26 +6184,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6653,36 +6334,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6710,16 +6361,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6803,16 +6444,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6873,16 +6504,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6930,16 +6551,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6993,16 +6604,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -7050,16 +6651,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -7113,16 +6704,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7150,16 +6731,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -7210,16 +6781,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -7323,16 +6884,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7340,26 +6891,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7383,16 +6914,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7410,26 +6931,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7470,16 +6971,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7620,26 +7111,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7933,16 +7404,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7960,16 +7421,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -8033,16 +7484,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -8060,26 +7501,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8263,16 +7684,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8323,46 +7734,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8390,16 +7761,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8513,16 +7874,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8530,16 +7881,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8570,16 +7911,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-qcow2-boot.json
@@ -151,22 +151,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -287,30 +271,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -328,14 +288,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -407,14 +359,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -463,14 +407,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -504,14 +440,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -559,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -600,14 +520,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -655,14 +567,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -680,14 +584,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -728,14 +624,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -823,31 +711,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -871,14 +735,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -888,22 +744,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -936,14 +776,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1056,22 +888,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1311,14 +1127,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1328,14 +1136,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1391,14 +1191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1408,22 +1200,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1575,14 +1351,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1623,38 +1391,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1672,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1775,23 +1503,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1816,14 +1528,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6223,26 +5927,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6393,36 +6077,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6450,16 +6104,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6543,16 +6187,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6613,16 +6247,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6670,16 +6294,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6733,16 +6347,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6790,16 +6394,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -6853,16 +6447,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6890,16 +6474,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -6950,16 +6524,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -7063,16 +6627,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7080,26 +6634,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7123,16 +6657,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7150,26 +6674,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7210,16 +6714,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7360,26 +6854,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7673,16 +7147,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7700,16 +7164,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -7773,16 +7227,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7800,26 +7244,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8003,16 +7427,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8063,46 +7477,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8130,16 +7504,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8253,16 +7617,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8270,16 +7624,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8310,16 +7654,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-qcow2_customize-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -345,30 +329,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -386,14 +346,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -465,14 +417,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -521,14 +465,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -562,14 +498,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -617,14 +545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -658,14 +578,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -713,14 +625,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -738,14 +642,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -786,14 +682,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -881,31 +769,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -929,14 +793,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -946,22 +802,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -994,14 +834,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1114,22 +946,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1369,14 +1185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1386,14 +1194,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1449,14 +1249,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1466,22 +1258,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1633,14 +1409,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1681,38 +1449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1730,14 +1466,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1833,23 +1561,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1874,14 +1586,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6544,26 +6248,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6714,36 +6398,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6771,16 +6425,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6864,16 +6508,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6934,16 +6568,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6991,16 +6615,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -7054,16 +6668,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -7111,16 +6715,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -7174,16 +6768,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7211,16 +6795,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -7271,16 +6845,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -7384,16 +6948,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7401,26 +6955,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7444,16 +6978,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7471,26 +6995,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7531,16 +7035,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7681,26 +7175,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7994,16 +7468,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -8021,16 +7485,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -8094,16 +7548,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -8121,26 +7565,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8324,16 +7748,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8384,46 +7798,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8451,16 +7825,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8574,16 +7938,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8591,16 +7945,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8631,16 +7975,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-vhd-boot.json
@@ -151,22 +151,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -287,30 +271,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -328,14 +288,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -407,14 +359,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -463,14 +407,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -504,14 +440,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -559,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -600,14 +520,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -655,14 +567,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -680,14 +584,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -728,14 +624,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -823,31 +711,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -871,14 +735,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -888,22 +744,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -936,14 +776,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1056,22 +888,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1311,14 +1127,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1328,14 +1136,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1391,14 +1191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1408,22 +1200,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1575,14 +1351,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1623,38 +1391,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1672,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1775,23 +1503,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1816,14 +1528,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5286,9 +4990,6 @@
           "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm"
           },
-          "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm"
-          },
           "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm"
           },
@@ -5979,26 +5680,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6149,36 +5830,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6206,16 +5857,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6299,16 +5940,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6369,16 +6000,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6426,16 +6047,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6489,16 +6100,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6546,16 +6147,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -6609,16 +6200,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6646,16 +6227,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -6706,16 +6277,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -6819,16 +6380,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -6836,26 +6387,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -6879,16 +6410,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -6906,26 +6427,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -6966,16 +6467,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7116,26 +6607,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7429,16 +6900,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7456,16 +6917,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -7529,16 +6980,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7556,26 +6997,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -7759,16 +7180,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -7819,46 +7230,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -7886,16 +7257,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8009,16 +7370,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8026,16 +7377,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8066,16 +7407,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_34-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-vmdk-boot.json
@@ -151,22 +151,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
                     "options": {
                       "metadata": {
@@ -287,30 +271,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
                     "options": {
                       "metadata": {
@@ -328,14 +288,6 @@
                   },
                   {
                     "id": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -407,14 +359,6 @@
                     }
                   },
                   {
-                    "id": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
                     "options": {
                       "metadata": {
@@ -463,14 +407,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
                     "options": {
                       "metadata": {
@@ -504,14 +440,6 @@
                   },
                   {
                     "id": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -559,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
                     "options": {
                       "metadata": {
@@ -600,14 +520,6 @@
                   },
                   {
                     "id": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -655,14 +567,6 @@
                     }
                   },
                   {
-                    "id": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
                     "options": {
                       "metadata": {
@@ -680,14 +584,6 @@
                   },
                   {
                     "id": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -728,14 +624,6 @@
                   },
                   {
                     "id": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -823,31 +711,7 @@
                     }
                   },
                   {
-                    "id": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -871,14 +735,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
                     "options": {
                       "metadata": {
@@ -888,22 +744,6 @@
                   },
                   {
                     "id": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -936,14 +776,6 @@
                   },
                   {
                     "id": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1056,22 +888,6 @@
                   },
                   {
                     "id": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1311,14 +1127,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
                     "options": {
                       "metadata": {
@@ -1328,14 +1136,6 @@
                   },
                   {
                     "id": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1391,14 +1191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
                     "options": {
                       "metadata": {
@@ -1408,22 +1200,6 @@
                   },
                   {
                     "id": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1575,14 +1351,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
                     "options": {
                       "metadata": {
@@ -1623,38 +1391,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
                     "options": {
                       "metadata": {
@@ -1672,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1775,23 +1503,7 @@
                     }
                   },
                   {
-                    "id": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1816,14 +1528,6 @@
                   },
                   {
                     "id": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6222,26 +5926,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
-        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "8.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
-        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6392,36 +6076,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.2.27",
-        "release": "4.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
-        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
-        "check_gpg": true
-      },
-      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -6449,16 +6103,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
         "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
-        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
         "check_gpg": true
       },
       {
@@ -6542,16 +6186,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
-        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6612,16 +6246,6 @@
         "check_gpg": true
       },
       {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
-        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
-        "check_gpg": true
-      },
-      {
         "name": "libfdisk",
         "epoch": 0,
         "version": "2.36.2",
@@ -6669,16 +6293,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
         "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
         "check_gpg": true
       },
       {
@@ -6732,16 +6346,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
-        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
-        "check_gpg": true
-      },
-      {
         "name": "libselinux",
         "epoch": 0,
         "version": "3.2",
@@ -6789,16 +6393,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.17",
-        "release": "3.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
-        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
         "check_gpg": true
       },
       {
@@ -6852,16 +6446,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusbx",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
-        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -6889,16 +6473,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
         "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
-        "check_gpg": true
-      },
-      {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "5.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
-        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
         "check_gpg": true
       },
       {
@@ -6949,16 +6523,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
         "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "6.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
-        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
         "check_gpg": true
       },
       {
@@ -7062,16 +6626,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.3.3",
-        "release": "7.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
-        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20190417",
@@ -7079,26 +6633,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
         "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
-        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
         "check_gpg": true
       },
       {
@@ -7122,16 +6656,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -7149,26 +6673,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
         "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.16.1.3",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
-        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
         "check_gpg": true
       },
       {
@@ -7209,16 +6713,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
         "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
-        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
         "check_gpg": true
       },
       {
@@ -7359,26 +6853,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
         "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
         "check_gpg": true
       },
       {
@@ -7672,16 +7146,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.76.1",
@@ -7699,16 +7163,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
         "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
         "check_gpg": true
       },
       {
@@ -7772,16 +7226,6 @@
         "check_gpg": true
       },
       {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "2.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
-        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -7799,26 +7243,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
         "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
-        "check_gpg": true
-      },
-      {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "2.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
-        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
         "check_gpg": true
       },
       {
@@ -8002,16 +7426,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
-        "check_gpg": true
-      },
-      {
         "name": "procps-ng",
         "epoch": 0,
         "version": "3.3.17",
@@ -8062,46 +7476,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc34",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
-        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
-        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.9.9",
@@ -8129,16 +7503,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
         "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
         "check_gpg": true
       },
       {
@@ -8252,16 +7616,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
-        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
-        "check_gpg": true
-      },
-      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -8269,16 +7623,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
         "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
-        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
         "check_gpg": true
       },
       {
@@ -8309,16 +7653,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
         "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "1.fc34",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
-        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -210,22 +194,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -321,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
                     "options": {
                       "metadata": {
@@ -394,14 +354,6 @@
                   },
                   {
                     "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -489,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
                     "options": {
                       "metadata": {
@@ -506,14 +450,6 @@
                   },
                   {
                     "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -561,14 +497,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -577,23 +505,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +554,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +617,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -754,14 +626,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -817,22 +681,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -873,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -898,14 +738,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +778,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1074,14 +882,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +905,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1169,14 +921,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1186,22 +930,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1233,22 +961,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1258,14 +970,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1026,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1441,14 +1137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
                     "options": {
                       "metadata": {
@@ -1474,30 +1162,6 @@
                   },
                   {
                     "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1538,14 +1202,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1657,47 +1313,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1729,23 +1345,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5623,9 +5223,6 @@
           "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
           },
-          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
-          },
           "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
           },
@@ -5685,9 +5282,6 @@
           },
           "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
-          },
-          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
           },
           "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
@@ -5872,9 +5466,6 @@
           "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
           },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
-          },
           "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
           },
@@ -5982,9 +5573,6 @@
           },
           "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
-          },
-          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
           },
           "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
@@ -6129,9 +5717,6 @@
           },
           "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -6381,26 +5966,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6428,26 +5993,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6561,16 +6106,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -6658,16 +6193,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
         "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
         "check_gpg": true
       },
       {
@@ -6771,16 +6296,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -6798,16 +6313,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
         "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
         "check_gpg": true
       },
       {
@@ -6861,16 +6366,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -6881,16 +6376,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -6898,16 +6383,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -6968,26 +6443,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -7061,36 +6516,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7108,16 +6533,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
         "check_gpg": true
       },
       {
@@ -7181,26 +6596,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7251,16 +6646,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7288,16 +6673,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -7348,16 +6723,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -7471,26 +6836,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7508,16 +6853,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -7541,66 +6876,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7621,16 +6896,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7648,26 +6913,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -7701,26 +6946,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7738,16 +6963,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -7818,16 +7033,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -7961,16 +7166,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.70.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.34",
@@ -8008,36 +7203,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
         "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
         "check_gpg": true
       },
       {
@@ -8088,16 +7253,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -8231,36 +7386,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8268,26 +7393,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -8321,16 +7426,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -8338,16 +7433,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-container-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-container-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -210,46 +194,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -314,14 +258,6 @@
                   },
                   {
                     "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -394,14 +330,6 @@
                   },
                   {
                     "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -489,14 +417,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
                     "options": {
                       "metadata": {
@@ -506,14 +426,6 @@
                   },
                   {
                     "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -561,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -577,23 +481,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +530,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +593,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -754,22 +602,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -817,22 +649,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -873,14 +689,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -898,14 +706,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +746,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +841,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1074,14 +850,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1169,14 +889,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1186,22 +898,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1241,14 +937,6 @@
                     }
                   },
                   {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1258,14 +946,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1002,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1441,14 +1113,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
                     "options": {
                       "metadata": {
@@ -1474,30 +1138,6 @@
                   },
                   {
                     "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1538,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1657,47 +1289,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1729,23 +1321,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3084,15 +2660,6 @@
     "sources": {
       "org.osbuild.curl": {
         "items": {
-          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
-          },
-          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
-          },
-          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
-          },
           "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
           },
@@ -3104,9 +2671,6 @@
           },
           "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
-          },
-          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
           },
           "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
@@ -3192,9 +2756,6 @@
           "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
           },
-          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
-          },
           "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
           },
@@ -3243,9 +2804,6 @@
           "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
           },
-          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
-          },
           "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
           },
@@ -3266,9 +2824,6 @@
           },
           "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
-          },
-          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
           },
           "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
@@ -3306,9 +2861,6 @@
           "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
           },
-          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
-          },
           "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
           },
@@ -3332,9 +2884,6 @@
           },
           "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
-          },
-          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
           },
           "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
@@ -3375,9 +2924,6 @@
           "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
           },
-          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
-          },
           "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
           },
@@ -3392,9 +2938,6 @@
           },
           "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
-          },
-          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
           },
           "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
@@ -3414,17 +2957,11 @@
           "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
           },
-          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
-          },
           "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
           },
           "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
-          },
-          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
           },
           "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
@@ -3483,9 +3020,6 @@
           "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
           },
-          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
-          },
           "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
           },
@@ -3506,9 +3040,6 @@
           },
           "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
-          },
-          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
           },
           "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
@@ -3539,9 +3070,6 @@
           },
           "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
-          },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
           "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
@@ -3593,9 +3121,6 @@
           },
           "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
-          },
-          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
           },
           "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
@@ -3651,9 +3176,6 @@
           "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
           },
-          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
-          },
           "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
           },
@@ -3684,14 +3206,8 @@
           "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
           },
-          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
-          },
           "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
-          },
-          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
           },
           "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
@@ -3711,17 +3227,8 @@
           "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
           },
-          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
-          },
-          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
-          },
           "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -3761,9 +3268,6 @@
           },
           "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
-          },
-          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
           },
           "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
@@ -3947,26 +3451,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -3994,56 +3478,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
-        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
         "check_gpg": true
       },
       {
@@ -4124,16 +3558,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
         "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
         "check_gpg": true
       },
       {
@@ -4224,16 +3648,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
         "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
         "check_gpg": true
       },
       {
@@ -4337,16 +3751,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -4364,16 +3768,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
         "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
         "check_gpg": true
       },
       {
@@ -4427,16 +3821,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -4447,16 +3831,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -4464,16 +3838,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -4534,26 +3898,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -4627,36 +3971,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -4674,26 +3988,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
         "check_gpg": true
       },
       {
@@ -4747,26 +4041,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -4817,16 +4091,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -4854,16 +4118,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -4914,16 +4168,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -5037,26 +4281,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -5074,16 +4298,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -5107,66 +4321,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -5187,16 +4341,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -5214,26 +4358,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -5277,16 +4401,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -5304,16 +4418,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -5384,16 +4488,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -5527,16 +4621,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.70.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.34",
@@ -5574,36 +4658,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
         "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
         "check_gpg": true
       },
       {
@@ -5654,16 +4708,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -5797,36 +4841,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -5834,26 +4848,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -5887,16 +4881,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -5904,16 +4888,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
@@ -185,22 +185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -218,46 +202,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -345,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
                     "options": {
                       "metadata": {
@@ -418,14 +354,6 @@
                   },
                   {
                     "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,14 +449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
                     "options": {
                       "metadata": {
@@ -593,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -609,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -761,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
                     "options": {
                       "metadata": {
@@ -794,14 +682,6 @@
                   },
                   {
                     "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                   },
                   {
                     "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1113,14 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
                     "options": {
                       "metadata": {
@@ -1130,54 +994,6 @@
                   },
                   {
                     "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1201,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1218,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1273,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1290,14 +1074,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1577,14 +1353,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
                     "options": {
                       "metadata": {
@@ -1777,23 +1545,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5691,9 +5443,6 @@
           "sha256:2b04a72168d77e8a916b1bf7e70cc1977064e19339132562e85d899e3a29b603": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/flashrom-1.2-7.fc35.aarch64.rpm"
           },
-          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
-          },
           "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
           },
@@ -5901,9 +5650,6 @@
           "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
           },
-          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
-          },
           "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
           },
@@ -5994,9 +5740,6 @@
           "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
           },
-          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
-          },
           "sha256:69e489e334c05ce06c984e189d73849853583c59aaf7c60a690bf3d02c137ea7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-overlayfs-1.7.1-2.fc35.aarch64.rpm"
           },
@@ -6011,9 +5754,6 @@
           },
           "sha256:6b70550aaff6f0a18cacec9d697d6e2697f1d12058f129e55dee3457a99bec30": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gdisk-1.0.8-2.fc35.aarch64.rpm"
-          },
-          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
           },
           "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
@@ -6246,14 +5986,8 @@
           "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
           },
-          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:97cba75d786761ac4a8dc22811c18403372671e4dc35ac326c83b91c10142296": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/traceroute-2.1.0-14.fc35.aarch64.rpm"
-          },
-          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
           },
           "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
@@ -6306,14 +6040,8 @@
           "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
           },
-          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
-          },
-          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
           },
           "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
@@ -6366,9 +6094,6 @@
           "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
           },
-          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
-          },
           "sha256:ac087df3c8ed872cd579f257ec347a51923535add93ebc6190de7f9c482f3e00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-libs-5.63-1.fc35.aarch64.rpm"
           },
@@ -6384,9 +6109,6 @@
           "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
           },
-          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
           },
@@ -6395,9 +6117,6 @@
           },
           "sha256:b005c546d9966003ae0c66faf1cea9b6acd2b6e9f7dee2d2e578a5b30f11686a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-m4-1.8.0-1.fc35.noarch.rpm"
-          },
-          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
           },
           "sha256:b0c4da2957a85cd15d93fb0b4aa074c8a6d978e443f66b0482b9b4ef3bbe1a23": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pciutils-libs-3.7.0-4.fc35.aarch64.rpm"
@@ -6419,9 +6138,6 @@
           },
           "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
-          },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
           "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm"
@@ -6482,9 +6198,6 @@
           },
           "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
-          },
-          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:be29b25a2f937e4442da2511c27ea07403b8476c01619d6a50b182e3c3f7f7aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dmidecode-3.3-2.fc35.aarch64.rpm"
@@ -6591,14 +6304,8 @@
           "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
           },
-          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
-          },
           "sha256:d1c5895bbbcbc78e11eb9164c07fd62562c84b8b3b6129b4ffff83173c71562c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqrtr-glib-1.0.0-2.fc35.aarch64.rpm"
-          },
-          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
@@ -6641,9 +6348,6 @@
           },
           "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
-          },
-          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
           },
           "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
@@ -6720,9 +6424,6 @@
           "sha256:ea89c837ae0f083755d3499adc8a4bf34e16c7f9f7ee776bf7623fb765997f57": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm2711-firmware-20210930-1.b5257da.fc35.aarch64.rpm"
           },
-          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
           },
@@ -6737,9 +6438,6 @@
           },
           "sha256:f05c62d78957eb1ecabf42d5f95303b9381453e9754f01edf094674626260765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/udisks2-2.9.4-1.fc35.aarch64.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -6788,9 +6486,6 @@
           },
           "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
-          },
-          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
           },
           "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
@@ -7002,26 +6697,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7049,56 +6724,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
-        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
         "check_gpg": true
       },
       {
@@ -7202,16 +6827,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -7299,16 +6914,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
         "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
         "check_gpg": true
       },
       {
@@ -7422,16 +7027,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -7512,16 +7107,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7532,16 +7117,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7549,16 +7124,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -7722,16 +7287,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
         "name": "libsecret",
         "epoch": 0,
         "version": "0.20.4",
@@ -7769,16 +7324,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
         "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
         "check_gpg": true
       },
       {
@@ -7829,16 +7374,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
         "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
         "check_gpg": true
       },
       {
@@ -8162,16 +7697,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20210518",
@@ -8189,66 +7714,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
         "check_gpg": true
       },
       {
@@ -8272,16 +7737,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8299,26 +7754,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -8362,16 +7797,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8389,16 +7814,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -8742,16 +8157,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -8992,16 +8397,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -9009,16 +8404,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_container-boot.json
@@ -185,22 +185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -218,46 +202,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -345,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
                     "options": {
                       "metadata": {
@@ -418,14 +354,6 @@
                   },
                   {
                     "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,14 +449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
                     "options": {
                       "metadata": {
@@ -593,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -609,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -761,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
                     "options": {
                       "metadata": {
@@ -794,14 +682,6 @@
                   },
                   {
                     "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                   },
                   {
                     "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1113,14 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
                     "options": {
                       "metadata": {
@@ -1130,54 +994,6 @@
                   },
                   {
                     "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1201,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1218,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1273,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1290,14 +1074,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1577,14 +1353,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
                     "options": {
                       "metadata": {
@@ -1777,23 +1545,7 @@
                     }
                   },
                   {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7199,9 +6951,6 @@
           "sha256:2b04a72168d77e8a916b1bf7e70cc1977064e19339132562e85d899e3a29b603": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/flashrom-1.2-7.fc35.aarch64.rpm"
           },
-          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
-          },
           "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
           },
@@ -7409,9 +7158,6 @@
           "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
           },
-          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
-          },
           "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
           },
@@ -7502,9 +7248,6 @@
           "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
           },
-          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
-          },
           "sha256:69e489e334c05ce06c984e189d73849853583c59aaf7c60a690bf3d02c137ea7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-overlayfs-1.7.1-2.fc35.aarch64.rpm"
           },
@@ -7519,9 +7262,6 @@
           },
           "sha256:6b70550aaff6f0a18cacec9d697d6e2697f1d12058f129e55dee3457a99bec30": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gdisk-1.0.8-2.fc35.aarch64.rpm"
-          },
-          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
           },
           "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
@@ -7757,14 +7497,8 @@
           "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
           },
-          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:97cba75d786761ac4a8dc22811c18403372671e4dc35ac326c83b91c10142296": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/traceroute-2.1.0-14.fc35.aarch64.rpm"
-          },
-          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
           },
           "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
@@ -7817,14 +7551,8 @@
           "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
           },
-          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
-          },
-          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
           },
           "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
@@ -7877,9 +7605,6 @@
           "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
           },
-          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
-          },
           "sha256:ac087df3c8ed872cd579f257ec347a51923535add93ebc6190de7f9c482f3e00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-libs-5.63-1.fc35.aarch64.rpm"
           },
@@ -7895,9 +7620,6 @@
           "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
           },
-          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
           },
@@ -7906,9 +7628,6 @@
           },
           "sha256:b005c546d9966003ae0c66faf1cea9b6acd2b6e9f7dee2d2e578a5b30f11686a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-m4-1.8.0-1.fc35.noarch.rpm"
-          },
-          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
           },
           "sha256:b0c4da2957a85cd15d93fb0b4aa074c8a6d978e443f66b0482b9b4ef3bbe1a23": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pciutils-libs-3.7.0-4.fc35.aarch64.rpm"
@@ -7933,9 +7652,6 @@
           },
           "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
-          },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
           "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm"
@@ -7999,9 +7715,6 @@
           },
           "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
-          },
-          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:be29b25a2f937e4442da2511c27ea07403b8476c01619d6a50b182e3c3f7f7aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dmidecode-3.3-2.fc35.aarch64.rpm"
@@ -8111,14 +7824,8 @@
           "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
           },
-          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
-          },
           "sha256:d1c5895bbbcbc78e11eb9164c07fd62562c84b8b3b6129b4ffff83173c71562c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqrtr-glib-1.0.0-2.fc35.aarch64.rpm"
-          },
-          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
@@ -8161,9 +7868,6 @@
           },
           "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
-          },
-          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
           },
           "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
@@ -8243,9 +7947,6 @@
           "sha256:ea9f6736e27eaf0ca847e0d4ce3408cb717c6232bd91300ca6b2e28bad60852f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-1.1.1l-2.fc35.aarch64.rpm"
           },
-          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
-          },
           "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
           },
@@ -8260,9 +7961,6 @@
           },
           "sha256:f05c62d78957eb1ecabf42d5f95303b9381453e9754f01edf094674626260765": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/udisks2-2.9.4-1.fc35.aarch64.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -8314,9 +8012,6 @@
           },
           "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
-          },
-          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
           },
           "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
@@ -8531,26 +8226,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -8578,56 +8253,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
-        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
         "check_gpg": true
       },
       {
@@ -8731,16 +8356,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -8828,16 +8443,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
         "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
         "check_gpg": true
       },
       {
@@ -8951,16 +8556,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -9041,16 +8636,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -9061,16 +8646,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -9078,16 +8653,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -9251,16 +8816,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
         "name": "libsecret",
         "epoch": 0,
         "version": "0.20.4",
@@ -9298,16 +8853,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
         "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
-        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
         "check_gpg": true
       },
       {
@@ -9358,16 +8903,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
         "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
         "check_gpg": true
       },
       {
@@ -9691,16 +9226,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20210518",
@@ -9718,66 +9243,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
         "check_gpg": true
       },
       {
@@ -9801,16 +9266,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -9828,26 +9283,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -9891,16 +9326,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -9918,16 +9343,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -10271,16 +9686,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -10521,16 +9926,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -10538,16 +9933,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_installer-boot.json
@@ -231,14 +231,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
@@ -376,14 +368,6 @@
                   },
                   {
                     "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -584,14 +568,6 @@
                   },
                   {
                     "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -960,14 +936,6 @@
                   },
                   {
                     "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1560,14 +1528,6 @@
                   },
                   {
                     "id": "sha256:a1c9e87c1754c81f785ff1f3a30b0071085b146860328ff25d84fb402455d651",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2208,14 +2168,6 @@
                   },
                   {
                     "id": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11738,9 +11690,6 @@
           "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
           },
-          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
-          },
           "sha256:8e5b9e74a5b59513f5473939cd6090c842dd161c90397031185db66b967069eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/boost-regex-1.76.0-4.fc35.aarch64.rpm"
           },
@@ -12199,9 +12148,6 @@
           },
           "sha256:b5a7d66f6387d6e6886e46fcf2a79c9221c5310c8364fbfa49b8314d6132ccb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lohit-gujarati-fonts-2.92.4-12.fc35.noarch.rpm"
-          },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
           "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm"
@@ -12898,9 +12844,6 @@
           },
           "sha256:f1a4a2b7e533699121dafb356f329e2729bf25885dc4a459d9e8316e741f23ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/binutils-gold-2.37-10.fc35.aarch64.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -22760,16 +22703,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.9.0",
@@ -22947,16 +22880,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
         "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
         "check_gpg": true
       },
       {
@@ -23207,16 +23130,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
         "check_gpg": true
       },
       {
@@ -23677,16 +23590,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
         "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
         "check_gpg": true
       },
       {
@@ -24427,16 +24330,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/squashfs-tools-4.5-3.20210913gite048580.fc35.aarch64.rpm",
         "checksum": "sha256:a1c9e87c1754c81f785ff1f3a30b0071085b146860328ff25d84fb402455d651",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
         "check_gpg": true
       },
       {
@@ -25237,16 +25130,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
         "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_installer_with_users-boot.json
@@ -260,14 +260,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
@@ -405,14 +397,6 @@
                   },
                   {
                     "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -613,14 +597,6 @@
                   },
                   {
                     "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -989,14 +965,6 @@
                   },
                   {
                     "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1589,14 +1557,6 @@
                   },
                   {
                     "id": "sha256:a1c9e87c1754c81f785ff1f3a30b0071085b146860328ff25d84fb402455d651",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2237,14 +2197,6 @@
                   },
                   {
                     "id": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11790,9 +11742,6 @@
           "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
           },
-          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
-          },
           "sha256:8e5b9e74a5b59513f5473939cd6090c842dd161c90397031185db66b967069eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/boost-regex-1.76.0-4.fc35.aarch64.rpm"
           },
@@ -12251,9 +12200,6 @@
           },
           "sha256:b5a7d66f6387d6e6886e46fcf2a79c9221c5310c8364fbfa49b8314d6132ccb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lohit-gujarati-fonts-2.92.4-12.fc35.noarch.rpm"
-          },
-          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
           "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm"
@@ -12950,9 +12896,6 @@
           },
           "sha256:f1a4a2b7e533699121dafb356f329e2729bf25885dc4a459d9e8316e741f23ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/binutils-gold-2.37-10.fc35.aarch64.rpm"
-          },
-          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
           },
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
@@ -22812,16 +22755,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.9.0",
@@ -22999,16 +22932,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
         "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
         "check_gpg": true
       },
       {
@@ -23259,16 +23182,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
-        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
         "check_gpg": true
       },
       {
@@ -23729,16 +23642,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
         "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
         "check_gpg": true
       },
       {
@@ -24479,16 +24382,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/squashfs-tools-4.5-3.20210913gite048580.fc35.aarch64.rpm",
         "checksum": "sha256:a1c9e87c1754c81f785ff1f3a30b0071085b146860328ff25d84fb402455d651",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
         "check_gpg": true
       },
       {
@@ -25289,16 +25182,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
         "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-oci-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -210,22 +194,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -401,14 +369,6 @@
                     }
                   },
                   {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
                     "options": {
                       "metadata": {
@@ -513,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
                     "options": {
                       "metadata": {
@@ -561,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -577,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +570,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +633,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -754,14 +642,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,14 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -873,14 +745,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -898,14 +762,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +802,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +897,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1074,14 +906,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +929,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1169,14 +945,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1186,22 +954,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1233,22 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1258,14 +994,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1050,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1481,30 +1201,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1538,14 +1234,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1657,47 +1345,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1722,14 +1370,6 @@
                   },
                   {
                     "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6359,26 +5999,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6406,26 +6026,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6639,16 +6239,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6779,16 +6369,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6839,16 +6419,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -6859,16 +6429,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -6876,16 +6436,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -6946,26 +6496,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -7039,36 +6569,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7086,16 +6586,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
         "check_gpg": true
       },
       {
@@ -7169,16 +6659,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7229,16 +6709,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7266,16 +6736,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -7326,16 +6786,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -7449,26 +6899,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7486,16 +6916,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -7519,66 +6939,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7599,16 +6959,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7626,26 +6976,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -7679,26 +7009,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7716,16 +7026,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -7796,16 +7096,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -7989,36 +7279,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8066,16 +7326,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -8209,36 +7459,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8246,26 +7466,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -8296,16 +7496,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-openstack-boot.json
@@ -194,22 +194,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -227,22 +211,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -418,14 +386,6 @@
                     }
                   },
                   {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
                     "options": {
                       "metadata": {
@@ -530,14 +490,6 @@
                     }
                   },
                   {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
                     "options": {
                       "metadata": {
@@ -578,14 +530,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -594,23 +538,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -659,22 +587,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -738,30 +650,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -771,14 +659,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                     }
                   },
                   {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -890,14 +762,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -915,14 +779,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,14 +819,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1066,22 +914,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1091,14 +923,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1122,54 +946,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1186,14 +962,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1203,22 +971,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1250,22 +1002,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1275,14 +1011,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1339,14 +1067,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1498,30 +1218,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1555,14 +1251,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1674,47 +1362,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1739,14 +1387,6 @@
                   },
                   {
                     "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6230,9 +5870,6 @@
           "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
           },
-          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
-          },
           "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.15.1-4.fc35.aarch64.rpm"
           },
@@ -6643,26 +6280,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6690,26 +6307,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6923,16 +6520,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -7063,16 +6650,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7123,16 +6700,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7143,16 +6710,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7160,16 +6717,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -7230,26 +6777,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -7323,36 +6850,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7370,16 +6867,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
         "check_gpg": true
       },
       {
@@ -7453,16 +6940,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7513,16 +6990,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7550,16 +7017,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -7610,16 +7067,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -7733,26 +7180,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7770,16 +7197,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -7803,66 +7220,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7883,16 +7240,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7910,26 +7257,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -7963,26 +7290,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8000,16 +7307,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -8080,16 +7377,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -8273,36 +7560,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8350,16 +7607,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -8493,36 +7740,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8530,26 +7747,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -8580,16 +7777,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
@@ -191,22 +191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -224,22 +208,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -415,14 +383,6 @@
                     }
                   },
                   {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
                     "options": {
                       "metadata": {
@@ -527,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
                     "options": {
                       "metadata": {
@@ -575,14 +527,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -591,23 +535,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -656,22 +584,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -735,30 +647,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -768,14 +656,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -839,14 +719,6 @@
                     }
                   },
                   {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -887,14 +759,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -912,14 +776,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -960,14 +816,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1063,22 +911,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1088,14 +920,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1119,54 +943,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1183,14 +959,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1200,22 +968,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1247,22 +999,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1272,14 +1008,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1336,14 +1064,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1495,30 +1215,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1552,14 +1248,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1671,47 +1359,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1736,14 +1384,6 @@
                   },
                   {
                     "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6383,26 +6023,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6430,26 +6050,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6663,16 +6263,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6803,16 +6393,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6863,16 +6443,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -6883,16 +6453,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -6900,16 +6460,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -6970,26 +6520,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -7063,36 +6593,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7110,16 +6610,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
         "check_gpg": true
       },
       {
@@ -7193,16 +6683,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7253,16 +6733,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7290,16 +6760,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -7350,16 +6810,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -7473,26 +6923,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7510,16 +6940,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -7543,66 +6963,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7623,16 +6983,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7650,26 +7000,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -7703,26 +7033,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7740,16 +7050,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -7820,16 +7120,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -8013,36 +7303,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8090,16 +7350,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -8233,36 +7483,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8270,26 +7490,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -8320,16 +7520,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
@@ -249,22 +249,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
                     "options": {
                       "metadata": {
@@ -282,22 +266,6 @@
                   },
                   {
                     "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -473,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
                     "options": {
                       "metadata": {
@@ -585,14 +545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
                     "options": {
                       "metadata": {
@@ -633,14 +585,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
                     "options": {
                       "metadata": {
@@ -649,23 +593,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,22 +642,6 @@
                   },
                   {
                     "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -793,30 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
                     "options": {
                       "metadata": {
@@ -826,14 +714,6 @@
                   },
                   {
                     "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -897,14 +777,6 @@
                     }
                   },
                   {
-                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
                     "options": {
                       "metadata": {
@@ -945,14 +817,6 @@
                     }
                   },
                   {
-                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                     "options": {
                       "metadata": {
@@ -970,14 +834,6 @@
                   },
                   {
                     "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1018,14 +874,6 @@
                   },
                   {
                     "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1121,22 +969,6 @@
                     }
                   },
                   {
-                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
                     "options": {
                       "metadata": {
@@ -1146,14 +978,6 @@
                   },
                   {
                     "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1177,54 +1001,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
                     "options": {
                       "metadata": {
@@ -1241,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                     "options": {
                       "metadata": {
@@ -1258,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1305,22 +1057,6 @@
                     }
                   },
                   {
-                    "id": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
                     "options": {
                       "metadata": {
@@ -1330,14 +1066,6 @@
                   },
                   {
                     "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1394,14 +1122,6 @@
                   },
                   {
                     "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1553,30 +1273,6 @@
                     }
                   },
                   {
-                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1610,14 +1306,6 @@
                   },
                   {
                     "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1729,47 +1417,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1794,14 +1442,6 @@
                   },
                   {
                     "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6682,26 +6322,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
-        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6729,26 +6349,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
         "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6962,16 +6562,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
-        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -7102,16 +6692,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
-        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7162,16 +6742,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7182,16 +6752,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7199,16 +6759,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
-        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
         "check_gpg": true
       },
       {
@@ -7269,26 +6819,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
         "check_gpg": true
       },
       {
@@ -7362,36 +6892,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7409,16 +6909,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
         "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
-        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
         "check_gpg": true
       },
       {
@@ -7492,16 +6982,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
-        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7552,16 +7032,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
-        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7589,16 +7059,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
         "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
         "check_gpg": true
       },
       {
@@ -7649,16 +7109,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
-        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
         "check_gpg": true
       },
       {
@@ -7772,26 +7222,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
-        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7809,16 +7239,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
         "check_gpg": true
       },
       {
@@ -7842,66 +7262,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7922,16 +7282,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7949,26 +7299,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
         "check_gpg": true
       },
       {
@@ -8002,26 +7332,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
-        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
-        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8039,16 +7349,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
         "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
         "check_gpg": true
       },
       {
@@ -8119,16 +7419,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
         "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
         "check_gpg": true
       },
       {
@@ -8312,36 +7602,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
-        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8389,16 +7649,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
         "check_gpg": true
       },
       {
@@ -8532,36 +7782,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
-        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8569,26 +7789,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
-        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
         "check_gpg": true
       },
       {
@@ -8619,16 +7819,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-ami-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -210,22 +194,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -321,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
                     "options": {
                       "metadata": {
@@ -394,14 +354,6 @@
                   },
                   {
                     "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -489,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
                     "options": {
                       "metadata": {
@@ -506,14 +450,6 @@
                   },
                   {
                     "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -561,14 +497,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -577,23 +505,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +554,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +617,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -754,14 +626,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -817,22 +681,6 @@
                     }
                   },
                   {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -873,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -898,14 +738,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +778,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1074,14 +882,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +905,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1169,14 +921,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1186,22 +930,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1233,22 +961,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1258,14 +970,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1026,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1441,14 +1137,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
                     "options": {
                       "metadata": {
@@ -1474,30 +1162,6 @@
                   },
                   {
                     "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1554,14 +1218,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1681,47 +1337,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1753,23 +1369,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5152,9 +4752,6 @@
           "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
           },
@@ -5503,9 +5100,6 @@
           "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm"
           },
-          "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm"
-          },
           "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
           },
@@ -5812,9 +5406,6 @@
           "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
           "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
           },
@@ -5874,9 +5465,6 @@
           },
           "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
-          },
-          "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm"
           },
           "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
@@ -5979,9 +5567,6 @@
           },
           "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
-          },
-          "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm"
           },
           "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
@@ -6384,26 +5969,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6431,26 +5996,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6564,16 +6109,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -6661,16 +6196,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
         "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
         "check_gpg": true
       },
       {
@@ -6774,16 +6299,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -6801,16 +6316,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
         "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
         "check_gpg": true
       },
       {
@@ -6864,16 +6369,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -6884,16 +6379,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -6901,16 +6386,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -6971,26 +6446,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7064,36 +6519,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7111,16 +6536,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7184,26 +6599,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7254,16 +6649,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7291,16 +6676,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7351,16 +6726,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7474,26 +6839,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7511,16 +6856,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7544,66 +6879,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7624,16 +6899,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7651,26 +6916,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -7704,26 +6949,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7741,16 +6966,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -7821,16 +7036,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -7964,16 +7169,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.70.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.34",
@@ -8011,36 +7206,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
         "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
         "check_gpg": true
       },
       {
@@ -8111,16 +7276,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8264,36 +7419,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8301,26 +7426,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8354,16 +7459,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -8371,16 +7466,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-container-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -210,46 +194,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -314,14 +258,6 @@
                   },
                   {
                     "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -394,14 +330,6 @@
                   },
                   {
                     "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -489,14 +417,6 @@
                     }
                   },
                   {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
                     "options": {
                       "metadata": {
@@ -506,14 +426,6 @@
                   },
                   {
                     "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -561,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -577,23 +481,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +530,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +593,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -754,22 +602,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -817,22 +649,6 @@
                     }
                   },
                   {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -873,14 +689,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -898,14 +706,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +746,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +841,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1074,14 +850,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1169,14 +889,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1186,22 +898,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1241,14 +937,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1258,14 +946,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1002,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1441,14 +1113,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
                     "options": {
                       "metadata": {
@@ -1474,30 +1138,6 @@
                   },
                   {
                     "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1538,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1665,47 +1297,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1737,23 +1329,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3098,9 +2674,6 @@
           "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm"
           },
-          "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm"
-          },
           "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm"
           },
@@ -3121,9 +2694,6 @@
           },
           "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm"
-          },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
           },
           "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
@@ -3161,9 +2731,6 @@
           "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm"
           },
-          "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm"
-          },
           "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm"
           },
@@ -3182,17 +2749,11 @@
           "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
           },
-          "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm"
-          },
           "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm"
           },
           "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm"
-          },
-          "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm"
           },
           "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
@@ -3220,9 +2781,6 @@
           },
           "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm"
-          },
-          "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm"
           },
           "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm"
@@ -3272,9 +2830,6 @@
           "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm"
           },
-          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
-          },
           "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
           },
@@ -3299,17 +2854,11 @@
           "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm"
           },
-          "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm"
-          },
           "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm"
           },
           "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm"
-          },
-          "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm"
           },
           "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm"
@@ -3329,20 +2878,11 @@
           "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
           },
-          "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
-          },
           "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm"
           },
-          "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm"
-          },
           "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm"
-          },
-          "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm"
           },
           "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
@@ -3391,9 +2931,6 @@
           },
           "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
-          },
-          "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm"
           },
           "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
@@ -3491,9 +3028,6 @@
           "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm"
           },
-          "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm"
-          },
           "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm"
           },
@@ -3511,9 +3045,6 @@
           },
           "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm"
-          },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
           },
           "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
@@ -3557,17 +3088,11 @@
           "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm"
           },
-          "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm"
-          },
           "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
           },
           "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm"
-          },
-          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
           },
           "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
@@ -3577,9 +3102,6 @@
           },
           "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
-          },
-          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
           },
           "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
@@ -3623,9 +3145,6 @@
           "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm"
           },
-          "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm"
-          },
           "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
           },
@@ -3653,14 +3172,8 @@
           "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
           },
-          "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
-          },
           "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
-          },
-          "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm"
           },
           "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm"
@@ -3670,9 +3183,6 @@
           },
           "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm"
-          },
-          "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm"
           },
           "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm"
@@ -3740,14 +3250,8 @@
           "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm"
           },
-          "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm"
-          },
           "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm"
-          },
-          "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm"
           },
           "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm"
@@ -3958,26 +3462,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -4005,56 +3489,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
-        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
         "check_gpg": true
       },
       {
@@ -4135,16 +3569,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
         "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
         "check_gpg": true
       },
       {
@@ -4235,16 +3659,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
         "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
         "check_gpg": true
       },
       {
@@ -4348,16 +3762,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -4375,16 +3779,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
         "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
         "check_gpg": true
       },
       {
@@ -4438,16 +3832,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -4458,16 +3842,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -4475,16 +3849,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -4545,26 +3909,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -4638,36 +3982,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -4685,26 +3999,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
         "check_gpg": true
       },
       {
@@ -4758,26 +4052,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -4828,16 +4102,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -4865,16 +4129,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -4925,16 +4179,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -5048,26 +4292,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -5085,16 +4309,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -5118,66 +4332,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -5198,16 +4352,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -5225,26 +4369,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -5288,16 +4412,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -5315,16 +4429,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -5395,16 +4499,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -5538,16 +4632,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.70.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.34",
@@ -5585,36 +4669,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
         "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
         "check_gpg": true
       },
       {
@@ -5665,16 +4719,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -5818,36 +4862,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -5855,26 +4869,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -5908,16 +4902,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -5925,16 +4909,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -185,22 +185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -218,46 +202,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -345,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
                     "options": {
                       "metadata": {
@@ -418,14 +354,6 @@
                   },
                   {
                     "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,14 +449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
                     "options": {
                       "metadata": {
@@ -593,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -609,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -761,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
                     "options": {
                       "metadata": {
@@ -794,14 +682,6 @@
                   },
                   {
                     "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                   },
                   {
                     "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1113,14 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
                     "options": {
                       "metadata": {
@@ -1130,54 +994,6 @@
                   },
                   {
                     "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1201,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1218,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1273,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1290,14 +1074,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1593,14 +1369,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
                     "options": {
                       "metadata": {
@@ -1801,23 +1569,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5650,9 +5402,6 @@
           "sha256:09ee7525b78cced99cfacd14ade46aacbe9b3c2b32913231c631a4fa0cb266cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/containernetworking-plugins-1.0.1-1.fc35.x86_64.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
           },
@@ -5800,9 +5549,6 @@
           "sha256:274a0a8f4fd44bf75f16c6c97ffde555e852986c9660817a2b6f5fad12dce4b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/b/bluez-5.63-1.fc35.x86_64.rpm"
           },
-          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
           },
@@ -5814,9 +5560,6 @@
           },
           "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
-          },
-          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
@@ -5893,9 +5636,6 @@
           "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
           },
-          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
-          },
           "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
           },
@@ -5922,9 +5662,6 @@
           },
           "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
-          },
-          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
           },
           "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
@@ -6015,9 +5752,6 @@
           },
           "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
-          },
-          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
@@ -6136,9 +5870,6 @@
           "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
           },
-          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
-          },
           "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.x86_64.rpm"
           },
@@ -6234,9 +5965,6 @@
           },
           "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
-          },
-          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
@@ -6469,12 +6197,6 @@
           "sha256:a07c2f43b34c0b04e75a26109593b4b40d09eca1de5e7308a529709a4ee456a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcab1-1.4-5.fc35.x86_64.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
-          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:a2af66b27f27ead63c30c405f9983437272dbaa5786edf6dce1571ecc0449693": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ntfs-3g-libs-2021.8.22-2.fc35.x86_64.rpm"
           },
@@ -6490,9 +6212,6 @@
           "sha256:a42a9d83e0f1f7fc35c38070234c673a58967e2c011ed31679c0fdba7acc726c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwd-1.21-1.fc35.x86_64.rpm"
           },
-          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
-          },
           "sha256:a4cf31d1dae8558af63f60fa1729a7ce530b8861f4620f0306eaa05c14ccf718": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libftdi-1.5-2.fc35.x86_64.rpm"
           },
@@ -6501,9 +6220,6 @@
           },
           "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
-          },
-          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:a5ebce6a5c132f728e5e973b997b39f48962bc89f0e8aaab00db8a16dd7a89eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/nss-softokn-freebl-3.73.0-1.fc35.x86_64.rpm"
@@ -6543,9 +6259,6 @@
           },
           "sha256:aba6591f3c3cab3ba81302ede73e33cfc37a3e6b8d4cefc7faab8baf7ac4b49b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmbios-2.4.3-4.fc35.x86_64.rpm"
-          },
-          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
@@ -6589,9 +6302,6 @@
           "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
           },
-          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
-          },
           "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
           },
@@ -6600,9 +6310,6 @@
           },
           "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
-          },
-          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
           },
           "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
@@ -6637,17 +6344,11 @@
           "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
           },
-          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:bebc23cec7d1bc45348dcedbd19681285d878347d451d74339f79105872b0ec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl2030-firmware-18.168.6.1-127.fc35.noarch.rpm"
           },
           "sha256:bf87752a240b93de85b6d295c366530ec910ff137890cd82e0b2e1f7ce6563e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbsd-0.10.0-8.fc35.x86_64.rpm"
-          },
-          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.x86_64.rpm"
@@ -6709,9 +6410,6 @@
           "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-python-utils-3.3-1.fc35.noarch.rpm"
           },
-          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
           },
@@ -6729,9 +6427,6 @@
           },
           "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
-          },
-          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:d27af662fc8b5d565fe06482df565ddc2e34859103c72c9e106dbfea799a7cec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl100-firmware-39.31.5.1-127.fc35.noarch.rpm"
@@ -7147,26 +6842,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7194,56 +6869,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
-        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
         "check_gpg": true
       },
       {
@@ -7347,16 +6972,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -7444,16 +7059,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
         "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
         "check_gpg": true
       },
       {
@@ -7567,16 +7172,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -7657,16 +7252,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7677,16 +7262,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7694,16 +7269,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7867,16 +7432,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
         "name": "libsecret",
         "epoch": 0,
         "version": "0.20.4",
@@ -7914,16 +7469,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
         "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
         "check_gpg": true
       },
       {
@@ -7974,16 +7519,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
         "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
         "check_gpg": true
       },
       {
@@ -8307,16 +7842,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20210518",
@@ -8334,66 +7859,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
         "check_gpg": true
       },
       {
@@ -8417,16 +7882,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8444,26 +7899,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -8507,16 +7942,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8534,16 +7959,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -8907,16 +8322,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -9167,16 +8572,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -9184,16 +8579,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -191,22 +191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -224,46 +208,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -351,14 +295,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
                     "options": {
                       "metadata": {
@@ -424,14 +360,6 @@
                   },
                   {
                     "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -527,14 +455,6 @@
                     }
                   },
                   {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
                     "options": {
                       "metadata": {
@@ -599,14 +519,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -615,23 +527,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -767,14 +663,6 @@
                     }
                   },
                   {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
                     "options": {
                       "metadata": {
@@ -800,14 +688,6 @@
                   },
                   {
                     "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -848,14 +728,6 @@
                   },
                   {
                     "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1119,14 +991,6 @@
                     }
                   },
                   {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
                     "options": {
                       "metadata": {
@@ -1136,54 +1000,6 @@
                   },
                   {
                     "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1207,14 +1023,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1224,22 +1032,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1279,14 +1071,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1296,14 +1080,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1599,14 +1375,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
                     "options": {
                       "metadata": {
@@ -1807,23 +1575,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5656,9 +5408,6 @@
           "sha256:09ee7525b78cced99cfacd14ade46aacbe9b3c2b32913231c631a4fa0cb266cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/containernetworking-plugins-1.0.1-1.fc35.x86_64.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
           },
@@ -5806,9 +5555,6 @@
           "sha256:274a0a8f4fd44bf75f16c6c97ffde555e852986c9660817a2b6f5fad12dce4b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/b/bluez-5.63-1.fc35.x86_64.rpm"
           },
-          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
           },
@@ -5820,9 +5566,6 @@
           },
           "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
-          },
-          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
@@ -5899,9 +5642,6 @@
           "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
           },
-          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
-          },
           "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
           },
@@ -5928,9 +5668,6 @@
           },
           "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
-          },
-          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
           },
           "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
@@ -6024,9 +5761,6 @@
           },
           "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
-          },
-          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
@@ -6145,9 +5879,6 @@
           "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
           },
-          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
-          },
           "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.x86_64.rpm"
           },
@@ -6243,9 +5974,6 @@
           },
           "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
-          },
-          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
@@ -6475,12 +6203,6 @@
           "sha256:a07c2f43b34c0b04e75a26109593b4b40d09eca1de5e7308a529709a4ee456a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcab1-1.4-5.fc35.x86_64.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
-          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:a2af66b27f27ead63c30c405f9983437272dbaa5786edf6dce1571ecc0449693": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ntfs-3g-libs-2021.8.22-2.fc35.x86_64.rpm"
           },
@@ -6496,9 +6218,6 @@
           "sha256:a42a9d83e0f1f7fc35c38070234c673a58967e2c011ed31679c0fdba7acc726c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwd-1.21-1.fc35.x86_64.rpm"
           },
-          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
-          },
           "sha256:a4cf31d1dae8558af63f60fa1729a7ce530b8861f4620f0306eaa05c14ccf718": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libftdi-1.5-2.fc35.x86_64.rpm"
           },
@@ -6507,9 +6226,6 @@
           },
           "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
-          },
-          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:a5ebce6a5c132f728e5e973b997b39f48962bc89f0e8aaab00db8a16dd7a89eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/nss-softokn-freebl-3.73.0-1.fc35.x86_64.rpm"
@@ -6549,9 +6265,6 @@
           },
           "sha256:aba6591f3c3cab3ba81302ede73e33cfc37a3e6b8d4cefc7faab8baf7ac4b49b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmbios-2.4.3-4.fc35.x86_64.rpm"
-          },
-          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
@@ -6595,9 +6308,6 @@
           "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
           },
-          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
-          },
           "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
           },
@@ -6606,9 +6316,6 @@
           },
           "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
-          },
-          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
           },
           "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
@@ -6643,17 +6350,11 @@
           "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
           },
-          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:bebc23cec7d1bc45348dcedbd19681285d878347d451d74339f79105872b0ec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl2030-firmware-18.168.6.1-127.fc35.noarch.rpm"
           },
           "sha256:bf87752a240b93de85b6d295c366530ec910ff137890cd82e0b2e1f7ce6563e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbsd-0.10.0-8.fc35.x86_64.rpm"
-          },
-          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.x86_64.rpm"
@@ -6715,9 +6416,6 @@
           "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-python-utils-3.3-1.fc35.noarch.rpm"
           },
-          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
           },
@@ -6735,9 +6433,6 @@
           },
           "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
-          },
-          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:d27af662fc8b5d565fe06482df565ddc2e34859103c72c9e106dbfea799a7cec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl100-firmware-39.31.5.1-127.fc35.noarch.rpm"
@@ -7153,26 +6848,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7200,56 +6875,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
-        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
         "check_gpg": true
       },
       {
@@ -7353,16 +6978,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -7450,16 +7065,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
         "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
         "check_gpg": true
       },
       {
@@ -7573,16 +7178,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -7663,16 +7258,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7683,16 +7268,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7700,16 +7275,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7873,16 +7438,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
         "name": "libsecret",
         "epoch": 0,
         "version": "0.20.4",
@@ -7920,16 +7475,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
         "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
         "check_gpg": true
       },
       {
@@ -7980,16 +7525,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
         "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
         "check_gpg": true
       },
       {
@@ -8313,16 +7848,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20210518",
@@ -8340,66 +7865,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
         "check_gpg": true
       },
       {
@@ -8423,16 +7888,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8450,26 +7905,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -8513,16 +7948,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8540,16 +7965,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -8913,16 +8328,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -9173,16 +8578,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -9190,16 +8585,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_container-boot.json
@@ -185,22 +185,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -218,46 +202,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -345,14 +289,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
                     "options": {
                       "metadata": {
@@ -418,14 +354,6 @@
                   },
                   {
                     "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,14 +449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
                     "options": {
                       "metadata": {
@@ -593,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -609,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -761,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
                     "options": {
                       "metadata": {
@@ -794,14 +682,6 @@
                   },
                   {
                     "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                   },
                   {
                     "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1113,14 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
                     "options": {
                       "metadata": {
@@ -1130,54 +994,6 @@
                   },
                   {
                     "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1201,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1218,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1273,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1290,14 +1074,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1593,14 +1369,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
                     "options": {
                       "metadata": {
@@ -1801,23 +1569,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7157,9 +6909,6 @@
           "sha256:09ee7525b78cced99cfacd14ade46aacbe9b3c2b32913231c631a4fa0cb266cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/containernetworking-plugins-1.0.1-1.fc35.x86_64.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
           },
@@ -7316,9 +7065,6 @@
           "sha256:274a0a8f4fd44bf75f16c6c97ffde555e852986c9660817a2b6f5fad12dce4b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/b/bluez-5.63-1.fc35.x86_64.rpm"
           },
-          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
           },
@@ -7330,9 +7076,6 @@
           },
           "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
-          },
-          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
@@ -7409,9 +7152,6 @@
           "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
           },
-          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
-          },
           "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
           },
@@ -7441,9 +7181,6 @@
           },
           "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
-          },
-          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
           },
           "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
@@ -7534,9 +7271,6 @@
           },
           "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
-          },
-          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
@@ -7655,9 +7389,6 @@
           "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
           },
-          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
-          },
           "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.x86_64.rpm"
           },
@@ -7753,9 +7484,6 @@
           },
           "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
-          },
-          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
           },
           "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
@@ -7988,12 +7716,6 @@
           "sha256:a07c2f43b34c0b04e75a26109593b4b40d09eca1de5e7308a529709a4ee456a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcab1-1.4-5.fc35.x86_64.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
-          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:a2af66b27f27ead63c30c405f9983437272dbaa5786edf6dce1571ecc0449693": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ntfs-3g-libs-2021.8.22-2.fc35.x86_64.rpm"
           },
@@ -8009,9 +7731,6 @@
           "sha256:a42a9d83e0f1f7fc35c38070234c673a58967e2c011ed31679c0fdba7acc726c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwd-1.21-1.fc35.x86_64.rpm"
           },
-          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
-          },
           "sha256:a4cf31d1dae8558af63f60fa1729a7ce530b8861f4620f0306eaa05c14ccf718": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libftdi-1.5-2.fc35.x86_64.rpm"
           },
@@ -8020,9 +7739,6 @@
           },
           "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
-          },
-          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:a5ebce6a5c132f728e5e973b997b39f48962bc89f0e8aaab00db8a16dd7a89eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/nss-softokn-freebl-3.73.0-1.fc35.x86_64.rpm"
@@ -8062,9 +7778,6 @@
           },
           "sha256:aba6591f3c3cab3ba81302ede73e33cfc37a3e6b8d4cefc7faab8baf7ac4b49b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmbios-2.4.3-4.fc35.x86_64.rpm"
-          },
-          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
           },
           "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
@@ -8111,9 +7824,6 @@
           "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
           },
-          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
-          },
           "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
           },
@@ -8122,9 +7832,6 @@
           },
           "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
-          },
-          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
           },
           "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
@@ -8162,17 +7869,11 @@
           "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
           },
-          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
-          },
           "sha256:bebc23cec7d1bc45348dcedbd19681285d878347d451d74339f79105872b0ec6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl2030-firmware-18.168.6.1-127.fc35.noarch.rpm"
           },
           "sha256:bf87752a240b93de85b6d295c366530ec910ff137890cd82e0b2e1f7ce6563e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbsd-0.10.0-8.fc35.x86_64.rpm"
-          },
-          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
           },
           "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.x86_64.rpm"
@@ -8237,9 +7938,6 @@
           "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-python-utils-3.3-1.fc35.noarch.rpm"
           },
-          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
-          },
           "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
           },
@@ -8257,9 +7955,6 @@
           },
           "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
-          },
-          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
           "sha256:d27af662fc8b5d565fe06482df565ddc2e34859103c72c9e106dbfea799a7cec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/i/iwl100-firmware-39.31.5.1-127.fc35.noarch.rpm"
@@ -8684,26 +8379,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -8731,56 +8406,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
-        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
         "check_gpg": true
       },
       {
@@ -8884,16 +8509,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.0",
@@ -8981,16 +8596,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
         "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
         "check_gpg": true
       },
       {
@@ -9104,16 +8709,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -9194,16 +8789,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -9214,16 +8799,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -9231,16 +8806,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -9404,16 +8969,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
         "name": "libsecret",
         "epoch": 0,
         "version": "0.20.4",
@@ -9451,16 +9006,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
         "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.3",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
-        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
         "check_gpg": true
       },
       {
@@ -9511,16 +9056,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
         "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
         "check_gpg": true
       },
       {
@@ -9844,16 +9379,6 @@
         "check_gpg": true
       },
       {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
-        "check_gpg": true
-      },
-      {
         "name": "publicsuffix-list-dafsa",
         "epoch": 0,
         "version": "20210518",
@@ -9871,66 +9396,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
         "check_gpg": true
       },
       {
@@ -9954,16 +9419,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -9981,26 +9436,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -10044,16 +9479,6 @@
         "check_gpg": true
       },
       {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -10071,16 +9496,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -10444,16 +9859,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "11.2.1",
@@ -10704,16 +10109,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -10721,16 +10116,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_installer-boot.json
@@ -231,14 +231,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
@@ -376,14 +368,6 @@
                   },
                   {
                     "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -592,14 +576,6 @@
                   },
                   {
                     "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -968,14 +944,6 @@
                   },
                   {
                     "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1584,14 +1552,6 @@
                   },
                   {
                     "id": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2264,14 +2224,6 @@
                   },
                   {
                     "id": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10473,9 +10425,6 @@
           "sha256:0a01362489e3ca2441685bffe10a2c96fdfafdb0311a0f84b10f8a48d864e7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gsettings-desktop-schemas-41.0-1.fc35.x86_64.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0a380ddf5afe7f2c2d49910e9f55c3370ca376ac95ebf8a60040fdcec6e59b36": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pipewire-libs-0.3.43-1.fc35.x86_64.rpm"
           },
@@ -12237,9 +12186,6 @@
           "sha256:a1a0ad7148d672e4b363ce96c4cd636d369a51e9a2038f23f47cd43ce4c33fe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-koji-1.27.0-3.fc35.noarch.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
           "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
           },
@@ -12419,9 +12365,6 @@
           },
           "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
-          },
-          "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm"
           },
           "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
@@ -23174,16 +23117,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.9.0",
@@ -23361,16 +23294,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
         "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
         "check_gpg": true
       },
       {
@@ -23631,16 +23554,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
         "check_gpg": true
       },
       {
@@ -24101,16 +24014,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
         "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
         "check_gpg": true
       },
       {
@@ -24871,16 +24774,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-nonlinux-6.04-0.18.fc35.noarch.rpm",
         "checksum": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
         "check_gpg": true
       },
       {
@@ -25721,16 +25614,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
         "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_installer_with_users-boot.json
@@ -260,14 +260,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
@@ -405,14 +397,6 @@
                   },
                   {
                     "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -621,14 +605,6 @@
                   },
                   {
                     "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -997,14 +973,6 @@
                   },
                   {
                     "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1613,14 +1581,6 @@
                   },
                   {
                     "id": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2293,14 +2253,6 @@
                   },
                   {
                     "id": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10525,9 +10477,6 @@
           "sha256:0a01362489e3ca2441685bffe10a2c96fdfafdb0311a0f84b10f8a48d864e7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gsettings-desktop-schemas-41.0-1.fc35.x86_64.rpm"
           },
-          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
-          },
           "sha256:0a380ddf5afe7f2c2d49910e9f55c3370ca376ac95ebf8a60040fdcec6e59b36": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pipewire-libs-0.3.43-1.fc35.x86_64.rpm"
           },
@@ -12289,9 +12238,6 @@
           "sha256:a1a0ad7148d672e4b363ce96c4cd636d369a51e9a2038f23f47cd43ce4c33fe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-koji-1.27.0-3.fc35.noarch.rpm"
           },
-          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
-          },
           "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
           },
@@ -12471,9 +12417,6 @@
           },
           "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
-          },
-          "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm"
           },
           "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
@@ -23226,16 +23169,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.9.0",
@@ -23413,16 +23346,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
         "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
-        "check_gpg": true
-      },
-      {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
         "check_gpg": true
       },
       {
@@ -23683,16 +23606,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "12.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
-        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
         "check_gpg": true
       },
       {
@@ -24153,16 +24066,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
         "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
         "check_gpg": true
       },
       {
@@ -24923,16 +24826,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-nonlinux-6.04-0.18.fc35.noarch.rpm",
         "checksum": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
-        "check_gpg": true
-      },
-      {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
         "check_gpg": true
       },
       {
@@ -25773,16 +25666,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
         "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
-        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-oci-boot.json
@@ -177,22 +177,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -210,22 +194,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -401,14 +369,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -513,14 +473,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -561,14 +513,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -577,23 +521,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -642,22 +570,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,30 +633,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -754,14 +642,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -825,14 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -873,14 +745,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -898,14 +762,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -946,14 +802,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1049,22 +897,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1074,14 +906,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1105,54 +929,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1169,14 +945,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1186,22 +954,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1233,22 +985,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1258,14 +994,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1322,14 +1050,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1481,30 +1201,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1554,14 +1250,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1681,47 +1369,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1746,14 +1394,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6531,26 +6171,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6578,26 +6198,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6811,16 +6411,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6951,16 +6541,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7011,16 +6591,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7031,16 +6601,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7048,16 +6608,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7118,26 +6668,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7211,36 +6741,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7258,16 +6758,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7341,16 +6831,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7401,16 +6881,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7438,16 +6908,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7498,16 +6958,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7621,26 +7071,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7658,16 +7088,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7691,66 +7111,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7771,16 +7131,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7798,26 +7148,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -7851,26 +7181,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7888,16 +7198,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -7968,16 +7268,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -8161,36 +7451,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8258,16 +7518,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8411,36 +7661,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8448,26 +7668,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8498,16 +7698,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-openstack-boot.json
@@ -194,22 +194,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -227,22 +211,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -418,14 +386,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -530,14 +490,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -578,14 +530,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -594,23 +538,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -659,22 +587,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -738,30 +650,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -771,14 +659,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -842,14 +722,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -890,14 +762,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -915,14 +779,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,14 +819,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1066,22 +914,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1091,14 +923,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1122,54 +946,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1186,14 +962,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1203,22 +971,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1250,22 +1002,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1275,14 +1011,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1339,14 +1067,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1498,30 +1218,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1571,14 +1267,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1698,47 +1386,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1763,14 +1411,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6288,9 +5928,6 @@
           "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
           },
-          "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm"
-          },
           "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
           },
@@ -6716,26 +6353,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6763,26 +6380,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6996,16 +6593,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -7136,16 +6723,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7196,16 +6773,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7216,16 +6783,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7233,16 +6790,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7303,26 +6850,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7396,36 +6923,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7443,16 +6940,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7526,16 +7013,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7586,16 +7063,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7623,16 +7090,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7683,16 +7140,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7806,26 +7253,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7843,16 +7270,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7876,66 +7293,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7956,16 +7313,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7983,26 +7330,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -8036,26 +7363,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8073,16 +7380,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -8153,16 +7450,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -8346,36 +7633,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8443,16 +7700,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8596,36 +7843,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8633,26 +7850,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8683,16 +7880,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
@@ -191,22 +191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -224,22 +208,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -415,14 +383,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -527,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -575,14 +527,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -591,23 +535,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -656,22 +584,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -735,30 +647,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -768,14 +656,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -839,14 +719,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -887,14 +759,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -912,14 +776,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -960,14 +816,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1063,22 +911,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1088,14 +920,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1119,54 +943,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1183,14 +959,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1200,22 +968,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1247,22 +999,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1272,14 +1008,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1336,14 +1064,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1495,30 +1215,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1568,14 +1264,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1695,47 +1383,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1760,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6555,26 +6195,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6602,26 +6222,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6835,16 +6435,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6975,16 +6565,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7035,16 +6615,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7055,16 +6625,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7072,16 +6632,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7142,26 +6692,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7235,36 +6765,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7282,16 +6782,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7365,16 +6855,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7425,16 +6905,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7462,16 +6932,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7522,16 +6982,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7645,26 +7095,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7682,16 +7112,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7715,66 +7135,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7795,16 +7155,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7822,26 +7172,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -7875,26 +7205,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7912,16 +7222,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -7992,16 +7292,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -8185,36 +7475,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8282,16 +7542,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8435,36 +7685,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8472,26 +7692,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8522,16 +7722,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
@@ -249,22 +249,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -282,22 +266,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -473,14 +441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -585,14 +545,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -633,14 +585,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -649,23 +593,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -714,22 +642,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -793,30 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -826,14 +714,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -897,14 +777,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -945,14 +817,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -970,14 +834,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1018,14 +874,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1121,22 +969,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1146,14 +978,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1177,54 +1001,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1241,14 +1017,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1258,22 +1026,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1305,22 +1057,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1330,14 +1066,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1394,14 +1122,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1553,30 +1273,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1626,14 +1322,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1753,47 +1441,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1818,14 +1466,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6854,26 +6494,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6901,26 +6521,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -7134,16 +6734,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -7274,16 +6864,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7334,16 +6914,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7354,16 +6924,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7371,16 +6931,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7441,26 +6991,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7534,36 +7064,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7581,16 +7081,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7664,16 +7154,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7724,16 +7204,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7761,16 +7231,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7821,16 +7281,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7944,26 +7394,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7981,16 +7411,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -8014,66 +7434,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -8094,16 +7454,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8121,26 +7471,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -8174,26 +7504,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -8211,16 +7521,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -8291,16 +7591,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -8484,36 +7774,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8581,16 +7841,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8734,36 +7984,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8771,26 +7991,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8821,16 +8021,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vhd-boot.json
@@ -191,22 +191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -224,22 +208,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -415,14 +383,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -527,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -575,14 +527,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -591,23 +535,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -656,22 +584,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -735,30 +647,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -768,14 +656,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -839,14 +719,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -887,14 +759,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -912,14 +776,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -960,14 +816,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1063,22 +911,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1088,14 +920,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1119,54 +943,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1183,14 +959,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1200,22 +968,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1247,22 +999,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1272,14 +1008,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1336,14 +1064,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1495,30 +1215,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1568,14 +1264,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1695,47 +1383,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1760,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5795,9 +5435,6 @@
           "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
           },
-          "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm"
-          },
           "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
           },
@@ -6190,26 +5827,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6237,26 +5854,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6470,16 +6067,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6610,16 +6197,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6670,16 +6247,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -6690,16 +6257,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -6707,16 +6264,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -6777,26 +6324,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -6870,36 +6397,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -6917,16 +6414,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7000,16 +6487,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7060,16 +6537,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7097,16 +6564,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7157,16 +6614,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7280,26 +6727,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7317,16 +6744,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7350,66 +6767,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7430,16 +6787,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7457,26 +6804,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -7510,26 +6837,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7547,16 +6854,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -7627,16 +6924,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -7820,36 +7107,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -7917,16 +7174,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8070,36 +7317,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8107,26 +7324,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8157,16 +7354,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
@@ -191,22 +191,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
                     "options": {
                       "metadata": {
@@ -224,22 +208,6 @@
                   },
                   {
                     "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -415,14 +383,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
                     "options": {
                       "metadata": {
@@ -527,14 +487,6 @@
                     }
                   },
                   {
-                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
                     "options": {
                       "metadata": {
@@ -575,14 +527,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
                     "options": {
                       "metadata": {
@@ -591,23 +535,7 @@
                     }
                   },
                   {
-                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -656,22 +584,6 @@
                   },
                   {
                     "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -735,30 +647,6 @@
                     }
                   },
                   {
-                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
                     "options": {
                       "metadata": {
@@ -768,14 +656,6 @@
                   },
                   {
                     "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -839,14 +719,6 @@
                     }
                   },
                   {
-                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
                     "options": {
                       "metadata": {
@@ -887,14 +759,6 @@
                     }
                   },
                   {
-                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
                     "options": {
                       "metadata": {
@@ -912,14 +776,6 @@
                   },
                   {
                     "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -960,14 +816,6 @@
                   },
                   {
                     "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1063,22 +911,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
                     "options": {
                       "metadata": {
@@ -1088,14 +920,6 @@
                   },
                   {
                     "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1119,54 +943,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
                     "options": {
                       "metadata": {
@@ -1183,14 +959,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
                     "options": {
                       "metadata": {
@@ -1200,22 +968,6 @@
                   },
                   {
                     "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1247,22 +999,6 @@
                     }
                   },
                   {
-                    "id": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
                     "options": {
                       "metadata": {
@@ -1272,14 +1008,6 @@
                   },
                   {
                     "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1336,14 +1064,6 @@
                   },
                   {
                     "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1495,30 +1215,6 @@
                     }
                   },
                   {
-                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
                     "options": {
                       "metadata": {
@@ -1568,14 +1264,6 @@
                   },
                   {
                     "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1695,47 +1383,7 @@
                     }
                   },
                   {
-                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1760,14 +1408,6 @@
                   },
                   {
                     "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6554,26 +6194,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.12.20",
-        "release": "5.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
-        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
-        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6601,26 +6221,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
         "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
         "check_gpg": true
       },
       {
@@ -6834,16 +6434,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.3.2",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
-        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-legacy-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -6974,16 +6564,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
-        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7034,16 +6614,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -7054,16 +6624,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7071,16 +6631,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
         "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
-        "check_gpg": true
-      },
-      {
-        "name": "libevent",
-        "epoch": 0,
-        "version": "2.1.12",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
-        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
         "check_gpg": true
       },
       {
@@ -7141,26 +6691,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
         "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
-        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.13.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
         "check_gpg": true
       },
       {
@@ -7234,36 +6764,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.15.2",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
-        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.4",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
-        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
-        "check_gpg": true
-      },
-      {
         "name": "libsigsegv",
         "epoch": 0,
         "version": "2.13",
@@ -7281,16 +6781,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
         "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.19",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
         "check_gpg": true
       },
       {
@@ -7364,16 +6854,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.24",
-        "release": "4.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
-        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7424,16 +6904,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
-        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -7461,16 +6931,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
         "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs78",
-        "epoch": 0,
-        "version": "78.15.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
         "check_gpg": true
       },
       {
@@ -7521,16 +6981,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
         "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "7.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
-        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
         "check_gpg": true
       },
       {
@@ -7644,26 +7094,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "20.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
-        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
-        "check_gpg": true
-      },
-      {
         "name": "popt",
         "epoch": 0,
         "version": "1.18",
@@ -7681,16 +7111,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
         "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
         "check_gpg": true
       },
       {
@@ -7714,66 +7134,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
-        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
-        "check_gpg": true
-      },
-      {
         "name": "readline",
         "epoch": 0,
         "version": "8.1",
@@ -7794,16 +7154,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -7821,26 +7171,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
         "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
-        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
         "check_gpg": true
       },
       {
@@ -7874,26 +7204,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
-        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
-        "check_gpg": true
-      },
-      {
-        "name": "tpm2-tss",
-        "epoch": 0,
-        "version": "3.1.0",
-        "release": "3.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
-        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
-        "check_gpg": true
-      },
-      {
         "name": "trousers",
         "epoch": 0,
         "version": "0.3.15",
@@ -7911,16 +7221,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
         "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
-        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
         "check_gpg": true
       },
       {
@@ -7991,16 +7291,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
         "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.1.15",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
-        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
         "check_gpg": true
       },
       {
@@ -8184,36 +7474,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
-        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
-        "check_gpg": true
-      },
-      {
         "name": "grub2-common",
         "epoch": 1,
         "version": "2.06",
@@ -8281,16 +7541,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
         "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
-        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
         "check_gpg": true
       },
       {
@@ -8434,36 +7684,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.4.36",
-        "release": "2.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
-        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
-        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8471,26 +7691,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
         "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "1.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
-        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
         "check_gpg": true
       },
       {
@@ -8521,16 +7721,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
         "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
-        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-ami-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -228,22 +212,6 @@
                   },
                   {
                     "id": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -411,14 +379,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5cc5f58f46dc56a3c641bf5360e5159e54a7f0da54e7bea72d60b7353a0fe745",
                     "options": {
                       "metadata": {
@@ -459,14 +419,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bc49b0b3bb18302cad4591b2dee37f649d867e05690c20580ec99ca3075c89b4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5b66368c60de33e92799ae29ba345ca9073759c0840699c83199bfce37c1e171",
                     "options": {
                       "metadata": {
@@ -500,38 +452,6 @@
                   },
                   {
                     "id": "sha256:d81491c2a94d97343ffde5c6f1f6055e232db0103a5f5967c37c3d2f70b26f09",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -580,14 +500,6 @@
                   },
                   {
                     "id": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -667,14 +579,6 @@
                     }
                   },
                   {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:23f2ccb549730b1f387231be98a020821edeaef71aaf0049b55776370141f5c2",
                     "options": {
                       "metadata": {
@@ -684,14 +588,6 @@
                   },
                   {
                     "id": "sha256:35499c34b3fcb18c0cd18abbe1880c8c22a47ecc226d6fb5f7434b5764bc674b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -763,14 +659,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -780,14 +668,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -835,14 +715,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -875,14 +747,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -900,22 +764,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,31 +811,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1036,14 +860,6 @@
                   },
                   {
                     "id": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1107,22 +923,6 @@
                     }
                   },
                   {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76c88a3a324f5a277fce5788d9fb03668682c64093ed0595de2a44fc64d3d2cf",
                     "options": {
                       "metadata": {
@@ -1171,14 +971,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1219,14 +1011,6 @@
                     }
                   },
                   {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:afc6df21cc64482ce3f8946506977cfd9521a9bfbf9d144f4fad4e4f33e37760",
                     "options": {
                       "metadata": {
@@ -1252,22 +1036,6 @@
                   },
                   {
                     "id": "sha256:0c31f21d5958b0744a977a265ad3e4339c0115baf24b7241ce4675131071f341",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1363,30 +1131,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1395,39 +1139,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1444,14 +1156,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1499,71 +1203,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1595,14 +1235,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1612,22 +1244,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1731,14 +1347,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:45b2609ac41444eb3baafa654285e540ef10269cac18cd1f40fac813b00e29f5",
                     "options": {
                       "metadata": {
@@ -1748,14 +1356,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1804,14 +1404,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5498,9 +5090,6 @@
           "sha256:10414450911180ee8ac1bf5fbf97a3fe9c984681c1e6ba7af35994038a4d30a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-oauthlib-3.2.0-1.fc37.noarch.rpm"
           },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
-          },
           "sha256:115f187fccd13c43761e8830b579e631992b9c23c931de7416e9f95122ece018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
           },
@@ -5521,9 +5110,6 @@
           },
           "sha256:134be74516b8728a6329bb164b2140adf098ef3fb5e6a44f680f29a246f2a4fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libblkid-2.38-3.fc37.aarch64.rpm"
-          },
-          "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse3-libs-3.10.5-4.fc37.aarch64.rpm"
           },
           "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
@@ -5842,9 +5428,6 @@
           },
           "sha256:4e768c02018c788700b5937132886a2a1773200d371b0f325bcd1b8ae9dc5ca1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gdisk-1.0.9-1.fc37.aarch64.rpm"
-          },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
           },
           "sha256:4f67a7123db128cce32f907e2c7b17b5d757deffe2ba571868c99e08abb4ed0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/parted-3.5-1.fc37.aarch64.rpm"
@@ -6275,9 +5858,6 @@
           "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
           },
-          "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm"
-          },
           "sha256:ab88c488911c98d5b3ee1492ac1a630659c7babe809d578a3c757faabe3fab90": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nftables-1.0.1-4.fc37.aarch64.rpm"
           },
@@ -6472,9 +6052,6 @@
           },
           "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
-          },
-          "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm"
           },
           "sha256:db61c431f92a9ffd840cc35fa2aeca8f2186e5700db429ba18fb2e9f7abbd9b8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm"
@@ -6854,26 +6431,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6901,26 +6458,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
         "checksum": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
         "check_gpg": true
       },
       {
@@ -7124,16 +6661,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "4.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse3-libs-3.10.5-4.fc37.aarch64.rpm",
-        "checksum": "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.1",
@@ -7184,16 +6711,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.72.1",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/glib2-2.72.1-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bc49b0b3bb18302cad4591b2dee37f649d867e05690c20580ec99ca3075c89b4",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.35.9000",
@@ -7241,46 +6758,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
         "checksum": "sha256:d81491c2a94d97343ffde5c6f1f6055e232db0103a5f5967c37c3d2f70b26f09",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
-        "name": "gnutls",
-        "epoch": 0,
-        "version": "3.7.4",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
-        "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -7341,16 +6818,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gzip-1.12-1.fc37.aarch64.rpm",
         "checksum": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
         "check_gpg": true
       },
       {
@@ -7444,16 +6911,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.1",
@@ -7471,16 +6928,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libargon2-20171227-9.fc37.aarch64.rpm",
         "checksum": "sha256:35499c34b3fcb18c0cd18abbe1880c8c22a47ecc226d6fb5f7434b5764bc674b",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
         "check_gpg": true
       },
       {
@@ -7564,16 +7011,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -7591,16 +7028,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -7654,16 +7081,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7704,16 +7121,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7741,26 +7148,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -7814,26 +7201,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7841,16 +7208,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -7911,16 +7268,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsmartcols-2.38-3.fc37.aarch64.rpm",
         "checksum": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
         "check_gpg": true
       },
       {
@@ -7994,26 +7341,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8074,16 +7401,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8134,16 +7451,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -8181,26 +7488,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/ncurses-libs-6.3-1.20220416.fc37.aarch64.rpm",
         "checksum": "sha256:0c31f21d5958b0744a977a265ad3e4339c0115baf24b7241ce4675131071f341",
-        "check_gpg": true
-      },
-      {
-        "name": "nettle",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
-        "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -8314,36 +7601,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8354,16 +7611,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -8371,36 +7618,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -8421,16 +7638,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -8484,56 +7691,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -8541,36 +7698,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {
@@ -8604,16 +7731,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -8631,26 +7748,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -8774,16 +7871,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
-        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8801,16 +7888,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {
@@ -8871,16 +7948,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-container-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -235,47 +219,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -411,14 +355,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5cc5f58f46dc56a3c641bf5360e5159e54a7f0da54e7bea72d60b7353a0fe745",
                     "options": {
                       "metadata": {
@@ -459,14 +395,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bc49b0b3bb18302cad4591b2dee37f649d867e05690c20580ec99ca3075c89b4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5b66368c60de33e92799ae29ba345ca9073759c0840699c83199bfce37c1e171",
                     "options": {
                       "metadata": {
@@ -500,38 +428,6 @@
                   },
                   {
                     "id": "sha256:d81491c2a94d97343ffde5c6f1f6055e232db0103a5f5967c37c3d2f70b26f09",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -580,14 +476,6 @@
                   },
                   {
                     "id": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -667,14 +555,6 @@
                     }
                   },
                   {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:23f2ccb549730b1f387231be98a020821edeaef71aaf0049b55776370141f5c2",
                     "options": {
                       "metadata": {
@@ -684,14 +564,6 @@
                   },
                   {
                     "id": "sha256:35499c34b3fcb18c0cd18abbe1880c8c22a47ecc226d6fb5f7434b5764bc674b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -763,14 +635,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -780,14 +644,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -835,14 +691,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -875,14 +723,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -900,22 +740,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,31 +787,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1043,22 +843,6 @@
                     }
                   },
                   {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7daef29a904a197e4209c3bee8d597b59a44c8844770c1af35e5020cd005444f",
                     "options": {
                       "metadata": {
@@ -1100,22 +884,6 @@
                   },
                   {
                     "id": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1171,14 +939,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1219,14 +979,6 @@
                     }
                   },
                   {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:afc6df21cc64482ce3f8946506977cfd9521a9bfbf9d144f4fad4e4f33e37760",
                     "options": {
                       "metadata": {
@@ -1252,22 +1004,6 @@
                   },
                   {
                     "id": "sha256:0c31f21d5958b0744a977a265ad3e4339c0115baf24b7241ce4675131071f341",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1363,30 +1099,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1395,39 +1107,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1444,14 +1124,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1499,71 +1171,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1595,14 +1203,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1612,22 +1212,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1755,14 +1339,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f0d9b6d802fce4557db29138ef5cd6bbb8a946f03c3a99c7130e3be7505116af",
                     "options": {
                       "metadata": {
@@ -1804,14 +1380,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3153,9 +2721,6 @@
           "sha256:09fb2a3349e9e7c14aecf0c5cf0846a8a1292ee24e69387d0f48d361bf651188": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libxml2-2.9.14-1.fc37.aarch64.rpm"
           },
-          "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm"
-          },
           "sha256:0c31f21d5958b0744a977a265ad3e4339c0115baf24b7241ce4675131071f341": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/ncurses-libs-6.3-1.20220416.fc37.aarch64.rpm"
           },
@@ -3174,9 +2739,6 @@
           "sha256:10290bddbd82ae619c4840fd8b4f28c305469359d03ed3f422451f833610cae8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/ncurses-base-6.3-1.20220416.fc37.noarch.rpm"
           },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
-          },
           "sha256:115fae3cedbf44486a9f59b8df8c9d7290b571824aca5b879008f1cf9986e39e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libuuid-2.38-3.fc37.aarch64.rpm"
           },
@@ -3186,12 +2748,6 @@
           "sha256:134be74516b8728a6329bb164b2140adf098ef3fb5e6a44f680f29a246f2a4fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libblkid-2.38-3.fc37.aarch64.rpm"
           },
-          "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse3-libs-3.10.5-4.fc37.aarch64.rpm"
-          },
-          "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
-          },
           "sha256:153eb7a48914492ae3a9994f95e5d15d57f5a17ee3ae0b443dfe40791fa87a41": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmount-2.38-3.fc37.aarch64.rpm"
           },
@@ -3200,12 +2756,6 @@
           },
           "sha256:19dddc7d08c65bde5e7fadb299665f62150ac630afd7b91228cb4cf40cb0fab3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fedora-release-common-37-0.5.noarch.rpm"
-          },
-          "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm"
-          },
-          "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm"
           },
           "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dracut-056-2.fc37.aarch64.rpm"
@@ -3255,9 +2805,6 @@
           "sha256:2e9f358dffa5376a938859d2625c285bab14907742b0ba2cb4e79330c9e6d9e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc37.noarch.rpm"
           },
-          "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm"
-          },
           "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm"
           },
@@ -3273,9 +2820,6 @@
           "sha256:327adcbb43fce119720c7c3540a3abaab27084b6461b6d84cdc98ed01334d76b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm"
           },
-          "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm"
-          },
           "sha256:35499c34b3fcb18c0cd18abbe1880c8c22a47ecc226d6fb5f7434b5764bc674b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libargon2-20171227-9.fc37.aarch64.rpm"
           },
@@ -3290,9 +2834,6 @@
           },
           "sha256:3674d5da29310ce5455852dfe4a9f48e7a626ef371e6471cdcbe625b12e2bcfb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gettext-libs-0.21-13.fc37.0.20220203.aarch64.rpm"
-          },
-          "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm"
           },
           "sha256:388bf48ccf86fb1c1bd5d1a0b7aac169121e4c5aeef8fb70076d4571d33b63a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-3.10.4-1.fc37.aarch64.rpm"
@@ -3320,12 +2861,6 @@
           },
           "sha256:41ab545e43faab4571a972985e871123b55ec5a719211bfd1345fa01208bc871": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/coreutils-9.1-2.fc37.aarch64.rpm"
-          },
-          "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm"
-          },
-          "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm"
           },
           "sha256:4583e81de9b2037a1ce5b5a6f5c7378d6b9c230f36acf6ab929c84df5fb1875e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsemanage-3.4-0.rc2.1.fc37.aarch64.rpm"
@@ -3357,14 +2892,8 @@
           "sha256:4b5c95bbde51d41debb21eedcb6e366d3a75a83e5e99283331e8069123d133bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm"
           },
-          "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm"
-          },
           "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm"
-          },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
           },
           "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm"
@@ -3408,9 +2937,6 @@
           "sha256:5de211d1ece7a1f09974701f2920ab89d19c990a2eb98e3bbaddd3d4918ad732": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/systemd-udev-251~rc1-3.fc37.aarch64.rpm"
           },
-          "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm"
-          },
           "sha256:625c77e961a04c96c07f48a426dab93aba89e5b544c41faef18dcb579e4d6946": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm"
           },
@@ -3446,12 +2972,6 @@
           },
           "sha256:718b976b63219d415f85b073c4fedbbbe96e113ad79ee5d5f7f372ab2ad2eae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
-          },
-          "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm"
-          },
-          "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm"
           },
           "sha256:753a8cb1df924d2def40553c2354663ffb37170b7cc2e64fb1358551d75d2297": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/glibc-gconv-extra-2.35.9000-15.fc37.aarch64.rpm"
@@ -3495,9 +3015,6 @@
           "sha256:818dd59eaf8861971405ab8101d41945ba5a8b7aa7657978a2bdcf6a3d466d44": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/o/openssl-libs-3.0.2-4.fc37.aarch64.rpm"
           },
-          "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm"
-          },
           "sha256:82568424139a783bfd48f549f14a9a5189cd0a421d890a0fff6c57b73e7fdf0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
           },
@@ -3512,9 +3029,6 @@
           },
           "sha256:854b0c7a34a537bedca7196263757f2ed9c8ec231c225b57a571bfbba314243d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/selinux-policy-targeted-36.8-1.fc37.noarch.rpm"
-          },
-          "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm"
           },
           "sha256:85e68051d6cded748256c8c738daa1b24610cf82a80cbf626ea9f0a8cceccae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/selinux-policy-36.8-1.fc37.noarch.rpm"
@@ -3531,14 +3045,8 @@
           "sha256:89f8c7b24dca1deaee9be56ae8162a5aec76b29b7856970118ac35af9fb0efd1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libgomp-12.0.1-0.17.fc37.aarch64.rpm"
           },
-          "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm"
-          },
           "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
-          },
-          "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm"
           },
           "sha256:8f52b51f008c1b47b98e40aa41d67697cdf7dd5c1d8cbf626bb291d33ad4941b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libstdc++-12.0.1-0.17.fc37.aarch64.rpm"
@@ -3642,9 +3150,6 @@
           "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm"
           },
-          "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm"
-          },
           "sha256:bb3d49eddfe74a7e01cd2f907a246dd25597385513ff7692ed6d6af259742d8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/a/authselect-1.3.0-10.fc37.aarch64.rpm"
           },
@@ -3705,9 +3210,6 @@
           "sha256:d4a6f083589a2ad396d3e30f6d728a2503f368540d3daac8bbd3aab28d80f574": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
-          "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm"
-          },
           "sha256:d81491c2a94d97343ffde5c6f1f6055e232db0103a5f5967c37c3d2f70b26f09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm"
           },
@@ -3719,9 +3221,6 @@
           },
           "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
-          },
-          "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm"
           },
           "sha256:dbfb863d7a17224db71786cbdcd0f68e57ee101af91521c8d3daeeb01967b0cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm"
@@ -3735,12 +3234,6 @@
           "sha256:e459d7d07e1979eff572b5ac7985100bdff0fee2afabf405b4992e08ef2e402e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/systemd-networkd-251~rc1-3.fc37.aarch64.rpm"
           },
-          "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
-          },
-          "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
-          },
           "sha256:e6c2b38d17b144596a2e72dacfdfe10c3f1fa2f4f999705d5d363ebcc5195080": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libselinux-3.4-0.rc2.1.fc37.aarch64.rpm"
           },
@@ -3752,9 +3245,6 @@
           },
           "sha256:ea73bbbeb5b573b0e506a6f60a277eedacc97b7d2122b194197f781ea50d275e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fedora-release-container-37-0.5.noarch.rpm"
-          },
-          "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm"
           },
           "sha256:eb11dbb1aee05b89a9e5ed7d34e672a1db4b9f41967b14d13fb2db6c580711c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/krb5-libs-1.19.2-9.fc37.aarch64.rpm"
@@ -4023,26 +3513,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -4073,36 +3543,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
-        "checksum": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -4110,26 +3550,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dracut-056-2.fc37.aarch64.rpm",
         "checksum": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
         "check_gpg": true
       },
       {
@@ -4293,16 +3713,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "4.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse3-libs-3.10.5-4.fc37.aarch64.rpm",
-        "checksum": "sha256:1415ef461c9c599424efa918bb72d36556641e69c0d7eadbd2e0c390c11b802e",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.1",
@@ -4353,16 +3763,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.72.1",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/glib2-2.72.1-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bc49b0b3bb18302cad4591b2dee37f649d867e05690c20580ec99ca3075c89b4",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.35.9000",
@@ -4410,46 +3810,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
         "checksum": "sha256:d81491c2a94d97343ffde5c6f1f6055e232db0103a5f5967c37c3d2f70b26f09",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
-        "name": "gnutls",
-        "epoch": 0,
-        "version": "3.7.4",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
-        "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -4510,16 +3870,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gzip-1.12-1.fc37.aarch64.rpm",
         "checksum": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
         "check_gpg": true
       },
       {
@@ -4613,16 +3963,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.1",
@@ -4640,16 +3980,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libargon2-20171227-9.fc37.aarch64.rpm",
         "checksum": "sha256:35499c34b3fcb18c0cd18abbe1880c8c22a47ecc226d6fb5f7434b5764bc674b",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
         "check_gpg": true
       },
       {
@@ -4733,16 +4063,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -4760,16 +4080,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -4823,16 +4133,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -4873,16 +4173,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -4910,26 +4200,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -4983,26 +4253,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -5010,16 +4260,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -5083,26 +4323,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -5160,26 +4380,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
         "checksum": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
         "check_gpg": true
       },
       {
@@ -5243,16 +4443,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -5303,16 +4493,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -5350,26 +4530,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/ncurses-libs-6.3-1.20220416.fc37.aarch64.rpm",
         "checksum": "sha256:0c31f21d5958b0744a977a265ad3e4339c0115baf24b7241ce4675131071f341",
-        "check_gpg": true
-      },
-      {
-        "name": "nettle",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
-        "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -5483,36 +4643,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -5523,16 +4653,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -5540,36 +4660,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -5590,16 +4680,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -5653,56 +4733,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -5710,36 +4740,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {
@@ -5773,16 +4773,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -5800,26 +4790,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -5973,16 +4943,6 @@
         "check_gpg": true
       },
       {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
-        "check_gpg": true
-      },
-      {
         "name": "util-linux",
         "epoch": 0,
         "version": "2.38",
@@ -6040,16 +5000,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_commit-boot.json
@@ -251,22 +251,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -291,47 +275,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -675,14 +619,6 @@
                     }
                   },
                   {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:be90ca1c6fe9ad844b0859a3f8fb0e2182591e1ebdf0fc265fca13fbc680f407",
                     "options": {
                       "metadata": {
@@ -772,14 +708,6 @@
                   },
                   {
                     "id": "sha256:625c77e961a04c96c07f48a426dab93aba89e5b544c41faef18dcb579e4d6946",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -883,14 +811,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -900,14 +820,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -956,14 +868,6 @@
                   },
                   {
                     "id": "sha256:c51421efb238942333571b360a2e1887d64895a8ca0631d80db3bce1a70f7267",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1163,14 +1067,6 @@
                     }
                   },
                   {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
                     "options": {
                       "metadata": {
@@ -1251,14 +1147,6 @@
                     }
                   },
                   {
-                    "id": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7daef29a904a197e4209c3bee8d597b59a44c8844770c1af35e5020cd005444f",
                     "options": {
                       "metadata": {
@@ -1300,14 +1188,6 @@
                   },
                   {
                     "id": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1731,71 +1611,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1820,14 +1636,6 @@
                   },
                   {
                     "id": "sha256:d4a6f083589a2ad396d3e30f6d728a2503f368540d3daac8bbd3aab28d80f574",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1860,22 +1668,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2012,14 +1804,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5740,9 +5524,6 @@
           "sha256:0b8140e9be58d83ce9761a553f0dca84a52bb3bf008e34ad729c8633a77f2241": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-ostree-libs-2022.8-1.fc37.aarch64.rpm"
           },
-          "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm"
-          },
           "sha256:0bd293575a704c371475b36567148cee64ba450b81dd9c10af2252427c09f451": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm"
           },
@@ -5758,9 +5539,6 @@
           "sha256:0df30c295e45a5589ca2ede03ab15ca4490241efda12abba30bc855df3c66570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.aarch64.rpm"
           },
-          "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm"
-          },
           "sha256:0e9166114abc3d9724163fe7d8da4ce4d6e297ad38b95c6da34a44ea3838094e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc37.noarch.rpm"
           },
@@ -5775,9 +5553,6 @@
           },
           "sha256:10290bddbd82ae619c4840fd8b4f28c305469359d03ed3f422451f833610cae8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/ncurses-base-6.3-1.20220416.fc37.noarch.rpm"
-          },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
           },
           "sha256:115f187fccd13c43761e8830b579e631992b9c23c931de7416e9f95122ece018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
@@ -5911,9 +5686,6 @@
           "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm"
           },
-          "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm"
-          },
           "sha256:29ef175473888414bffd2a9e886f617e3ab9fd8d319f593aa37a91837911229b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/b/btrfs-progs-5.16.2-1.fc37.aarch64.rpm"
           },
@@ -6025,9 +5797,6 @@
           "sha256:388bf48ccf86fb1c1bd5d1a0b7aac169121e4c5aeef8fb70076d4571d33b63a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-3.10.4-1.fc37.aarch64.rpm"
           },
-          "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm"
-          },
           "sha256:3a783046155d168a822f79b04060fe2d5639986184016a7ed45758c2d64c5104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
           },
@@ -6094,9 +5863,6 @@
           "sha256:41ab545e43faab4571a972985e871123b55ec5a719211bfd1345fa01208bc871": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/coreutils-9.1-2.fc37.aarch64.rpm"
           },
-          "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm"
-          },
           "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm"
           },
@@ -6157,9 +5923,6 @@
           "sha256:4e768c02018c788700b5937132886a2a1773200d371b0f325bcd1b8ae9dc5ca1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gdisk-1.0.9-1.fc37.aarch64.rpm"
           },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
-          },
           "sha256:4f67a7123db128cce32f907e2c7b17b5d757deffe2ba571868c99e08abb4ed0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/parted-3.5-1.fc37.aarch64.rpm"
           },
@@ -6186,9 +5949,6 @@
           },
           "sha256:56479c57ea5de8ad51c7050142a43d0e2a974119b19403778f2bdf13f0d088da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse-common-3.10.5-4.fc37.aarch64.rpm"
-          },
-          "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm"
           },
           "sha256:5739b09fe5f1377d0d79729b57065ea9e2d0b8a43c913b944ab237701934a55b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nss-altfiles-2.18.1-20.fc36.aarch64.rpm"
@@ -6313,9 +6073,6 @@
           "sha256:701b3d6092198101857e9ee36290f925baa10d04dee43a90c41f3c7fc89cbf6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/file-5.41-5.fc37.aarch64.rpm"
           },
-          "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm"
-          },
           "sha256:718b976b63219d415f85b073c4fedbbbe96e113ad79ee5d5f7f372ab2ad2eae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
           },
@@ -6330,9 +6087,6 @@
           },
           "sha256:753a8cb1df924d2def40553c2354663ffb37170b7cc2e64fb1358551d75d2297": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/glibc-gconv-extra-2.35.9000-15.fc37.aarch64.rpm"
-          },
-          "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:75e4b3ec5e030f38377a7e330c23f533bb7db9de8af42286f418f74f546195aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcap-ng-0.8.3-1.fc37.aarch64.rpm"
@@ -6351,9 +6105,6 @@
           },
           "sha256:7aca328f4304dd462be5c9396a19d5f977fd3fa74ebc6bbcbf456ac78169d6f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcap-ng-python3-0.8.3-1.fc37.aarch64.rpm"
-          },
-          "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm"
           },
           "sha256:7c7923c679e65339710d658665b5292f69afbcf4ecca308c3de32e72b5e66dcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tpm2-tools-5.2-2.fc36.aarch64.rpm"
@@ -6418,9 +6169,6 @@
           "sha256:846463e52f0af04b4becd164a6fbf6a278ac6c2e13924c7305aa2e016f988a19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libuser-0.63-10.fc37.aarch64.rpm"
           },
-          "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm"
-          },
           "sha256:8545baa3af3f0b8ffbeb138fdcdd737246fa6cdc0fe2badb2147669b1fab240f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/crun-1.4.5-1.fc37.aarch64.rpm"
           },
@@ -6468,9 +6216,6 @@
           },
           "sha256:8aca72ad62805189f2fc617af117d375c7a6ac3a11628d0346384f628dd9c23f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/NetworkManager-1.37.91-1.fc37.aarch64.rpm"
-          },
-          "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:8d2c5862014e47267fc6a39ba9dca58f646c7f122dac77dc4505df33f7277975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnsmasq-2.86-6.fc37.aarch64.rpm"
@@ -6562,9 +6307,6 @@
           "sha256:9f7bb142413bd764414ece5eac4cd45c1c5fa339f8f38532f14a051aabc98afa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
           },
-          "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
-          },
           "sha256:a0c7ba852ddd155fdd48251274cd37e7506930c08be4b89f4f80eedff96e189e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-persistent-data-0.9.0-7.fc36.aarch64.rpm"
           },
@@ -6585,9 +6327,6 @@
           },
           "sha256:a3c4547e3f37f722bde11c4201fa243b559161251d09050e34ad4c4855730f1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/linux-firmware-20220411-131.fc37.noarch.rpm"
-          },
-          "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm"
           },
           "sha256:a4dfb2d9453916a7f26a73fb78860bc374398d0acecd7625335f8707b150b1ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-ostree-2022.8-1.fc37.aarch64.rpm"
@@ -6690,9 +6429,6 @@
           },
           "sha256:ba76fc721809df37d26b9fa66730c87f53fc6c6d4b8cff86cb5fb61f4adb03f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/kernel-modules-5.18.0-0.rc5.40.fc37.aarch64.rpm"
-          },
-          "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm"
           },
           "sha256:bb3d49eddfe74a7e01cd2f907a246dd25597385513ff7692ed6d6af259742d8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/a/authselect-1.3.0-10.fc37.aarch64.rpm"
@@ -6826,9 +6562,6 @@
           "sha256:d8d3e3b9a9715ab5224836c1ec8cbb3e1cf9cbe8f7a73e3da9b9e0469aecfa22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gobject-base-3.42.1-1.fc37.aarch64.rpm"
           },
-          "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
-          },
           "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm"
           },
@@ -6870,9 +6603,6 @@
           },
           "sha256:e459d7d07e1979eff572b5ac7985100bdff0fee2afabf405b4992e08ef2e402e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/systemd-networkd-251~rc1-3.fc37.aarch64.rpm"
-          },
-          "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
@@ -6996,9 +6726,6 @@
           },
           "sha256:feaf91c5c593748ba76e9716b71cb04f58a1ffac797f405001b3082e52a0f2e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/passwd-0.80-12.fc36.aarch64.rpm"
-          },
-          "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm"
           },
           "sha256:fed94fc5d5bd061c028d13b4fe7774032226e4f2c8e95583a489cc0d05656dd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/grub2-common-2.06-38.fc37.noarch.rpm"
@@ -7289,26 +7016,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7339,36 +7046,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
-        "checksum": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -7376,26 +7053,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dracut-056-2.fc37.aarch64.rpm",
         "checksum": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
         "check_gpg": true
       },
       {
@@ -7819,16 +7476,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -7946,16 +7593,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
         "checksum": "sha256:625c77e961a04c96c07f48a426dab93aba89e5b544c41faef18dcb579e4d6946",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
         "check_gpg": true
       },
       {
@@ -8079,16 +7716,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -8106,16 +7733,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -8176,16 +7793,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfido2-1.10.0-3.fc37.aarch64.rpm",
         "checksum": "sha256:c51421efb238942333571b360a2e1887d64895a8ca0631d80db3bce1a70f7267",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
         "check_gpg": true
       },
       {
@@ -8429,16 +8036,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8539,16 +8136,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -8606,16 +8193,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
         "checksum": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
         "check_gpg": true
       },
       {
@@ -9139,56 +8716,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -9196,36 +8723,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {
@@ -9256,16 +8753,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:d4a6f083589a2ad396d3e30f6d728a2503f368540d3daac8bbd3aab28d80f574",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
         "check_gpg": true
       },
       {
@@ -9306,26 +8793,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -9496,16 +8963,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_container-boot.json
@@ -251,22 +251,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -291,47 +275,7 @@
                     }
                   },
                   {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -675,14 +619,6 @@
                     }
                   },
                   {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:be90ca1c6fe9ad844b0859a3f8fb0e2182591e1ebdf0fc265fca13fbc680f407",
                     "options": {
                       "metadata": {
@@ -772,14 +708,6 @@
                   },
                   {
                     "id": "sha256:625c77e961a04c96c07f48a426dab93aba89e5b544c41faef18dcb579e4d6946",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -883,14 +811,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -900,14 +820,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -956,14 +868,6 @@
                   },
                   {
                     "id": "sha256:c51421efb238942333571b360a2e1887d64895a8ca0631d80db3bce1a70f7267",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1163,14 +1067,6 @@
                     }
                   },
                   {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
                     "options": {
                       "metadata": {
@@ -1251,14 +1147,6 @@
                     }
                   },
                   {
-                    "id": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7daef29a904a197e4209c3bee8d597b59a44c8844770c1af35e5020cd005444f",
                     "options": {
                       "metadata": {
@@ -1300,14 +1188,6 @@
                   },
                   {
                     "id": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1731,71 +1611,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1820,14 +1636,6 @@
                   },
                   {
                     "id": "sha256:d4a6f083589a2ad396d3e30f6d728a2503f368540d3daac8bbd3aab28d80f574",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1860,22 +1668,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2012,14 +1804,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7232,9 +7016,6 @@
           "sha256:0b8140e9be58d83ce9761a553f0dca84a52bb3bf008e34ad729c8633a77f2241": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-ostree-libs-2022.8-1.fc37.aarch64.rpm"
           },
-          "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm"
-          },
           "sha256:0bd293575a704c371475b36567148cee64ba450b81dd9c10af2252427c09f451": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm"
           },
@@ -7249,9 +7030,6 @@
           },
           "sha256:0df30c295e45a5589ca2ede03ab15ca4490241efda12abba30bc855df3c66570": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/slirp4netns-1.2.0-0.2.beta.0.fc36.aarch64.rpm"
-          },
-          "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm"
           },
           "sha256:0e9166114abc3d9724163fe7d8da4ce4d6e297ad38b95c6da34a44ea3838094e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc37.noarch.rpm"
@@ -7270,9 +7048,6 @@
           },
           "sha256:10d7bfa9fc4358392cba3b6285bf51f80b1744abacc7f5dbe6238e140e599a45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fedora-logos-httpd-36.0.0-2.fc37.noarch.rpm"
-          },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
           },
           "sha256:115f187fccd13c43761e8830b579e631992b9c23c931de7416e9f95122ece018": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
@@ -7409,9 +7184,6 @@
           "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm"
           },
-          "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm"
-          },
           "sha256:29ef175473888414bffd2a9e886f617e3ab9fd8d319f593aa37a91837911229b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/b/btrfs-progs-5.16.2-1.fc37.aarch64.rpm"
           },
@@ -7532,9 +7304,6 @@
           "sha256:388bf48ccf86fb1c1bd5d1a0b7aac169121e4c5aeef8fb70076d4571d33b63a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-3.10.4-1.fc37.aarch64.rpm"
           },
-          "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm"
-          },
           "sha256:3a783046155d168a822f79b04060fe2d5639986184016a7ed45758c2d64c5104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
           },
@@ -7601,9 +7370,6 @@
           "sha256:41ab545e43faab4571a972985e871123b55ec5a719211bfd1345fa01208bc871": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/coreutils-9.1-2.fc37.aarch64.rpm"
           },
-          "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm"
-          },
           "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm"
           },
@@ -7664,9 +7430,6 @@
           "sha256:4e768c02018c788700b5937132886a2a1773200d371b0f325bcd1b8ae9dc5ca1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gdisk-1.0.9-1.fc37.aarch64.rpm"
           },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
-          },
           "sha256:4f67a7123db128cce32f907e2c7b17b5d757deffe2ba571868c99e08abb4ed0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/parted-3.5-1.fc37.aarch64.rpm"
           },
@@ -7693,9 +7456,6 @@
           },
           "sha256:56479c57ea5de8ad51c7050142a43d0e2a974119b19403778f2bdf13f0d088da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/fuse-common-3.10.5-4.fc37.aarch64.rpm"
-          },
-          "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm"
           },
           "sha256:5739b09fe5f1377d0d79729b57065ea9e2d0b8a43c913b944ab237701934a55b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nss-altfiles-2.18.1-20.fc36.aarch64.rpm"
@@ -7823,9 +7583,6 @@
           "sha256:701b3d6092198101857e9ee36290f925baa10d04dee43a90c41f3c7fc89cbf6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/f/file-5.41-5.fc37.aarch64.rpm"
           },
-          "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm"
-          },
           "sha256:718b976b63219d415f85b073c4fedbbbe96e113ad79ee5d5f7f372ab2ad2eae7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
           },
@@ -7840,9 +7597,6 @@
           },
           "sha256:753a8cb1df924d2def40553c2354663ffb37170b7cc2e64fb1358551d75d2297": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/glibc-gconv-extra-2.35.9000-15.fc37.aarch64.rpm"
-          },
-          "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:75e4b3ec5e030f38377a7e330c23f533bb7db9de8af42286f418f74f546195aa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcap-ng-0.8.3-1.fc37.aarch64.rpm"
@@ -7861,9 +7615,6 @@
           },
           "sha256:7aca328f4304dd462be5c9396a19d5f977fd3fa74ebc6bbcbf456ac78169d6f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcap-ng-python3-0.8.3-1.fc37.aarch64.rpm"
-          },
-          "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm"
           },
           "sha256:7c7923c679e65339710d658665b5292f69afbcf4ecca308c3de32e72b5e66dcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tpm2-tools-5.2-2.fc36.aarch64.rpm"
@@ -7928,9 +7679,6 @@
           "sha256:846463e52f0af04b4becd164a6fbf6a278ac6c2e13924c7305aa2e016f988a19": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libuser-0.63-10.fc37.aarch64.rpm"
           },
-          "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm"
-          },
           "sha256:8545baa3af3f0b8ffbeb138fdcdd737246fa6cdc0fe2badb2147669b1fab240f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/c/crun-1.4.5-1.fc37.aarch64.rpm"
           },
@@ -7978,9 +7726,6 @@
           },
           "sha256:8aca72ad62805189f2fc617af117d375c7a6ac3a11628d0346384f628dd9c23f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/NetworkManager-1.37.91-1.fc37.aarch64.rpm"
-          },
-          "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:8d2c5862014e47267fc6a39ba9dca58f646c7f122dac77dc4505df33f7277975": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnsmasq-2.86-6.fc37.aarch64.rpm"
@@ -8072,9 +7817,6 @@
           "sha256:9f7bb142413bd764414ece5eac4cd45c1c5fa339f8f38532f14a051aabc98afa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
           },
-          "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
-          },
           "sha256:a0c7ba852ddd155fdd48251274cd37e7506930c08be4b89f4f80eedff96e189e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-persistent-data-0.9.0-7.fc36.aarch64.rpm"
           },
@@ -8095,9 +7837,6 @@
           },
           "sha256:a3c4547e3f37f722bde11c4201fa243b559161251d09050e34ad4c4855730f1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/linux-firmware-20220411-131.fc37.noarch.rpm"
-          },
-          "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm"
           },
           "sha256:a4dfb2d9453916a7f26a73fb78860bc374398d0acecd7625335f8707b150b1ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-ostree-2022.8-1.fc37.aarch64.rpm"
@@ -8200,9 +7939,6 @@
           },
           "sha256:ba76fc721809df37d26b9fa66730c87f53fc6c6d4b8cff86cb5fb61f4adb03f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/k/kernel-modules-5.18.0-0.rc5.40.fc37.aarch64.rpm"
-          },
-          "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm"
           },
           "sha256:bb3d49eddfe74a7e01cd2f907a246dd25597385513ff7692ed6d6af259742d8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/a/authselect-1.3.0-10.fc37.aarch64.rpm"
@@ -8339,9 +8075,6 @@
           "sha256:d8d3e3b9a9715ab5224836c1ec8cbb3e1cf9cbe8f7a73e3da9b9e0469aecfa22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gobject-base-3.42.1-1.fc37.aarch64.rpm"
           },
-          "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
-          },
           "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm"
           },
@@ -8383,9 +8116,6 @@
           },
           "sha256:e459d7d07e1979eff572b5ac7985100bdff0fee2afabf405b4992e08ef2e402e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/s/systemd-networkd-251~rc1-3.fc37.aarch64.rpm"
-          },
-          "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm"
           },
           "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
@@ -8515,9 +8245,6 @@
           },
           "sha256:feaf91c5c593748ba76e9716b71cb04f58a1ffac797f405001b3082e52a0f2e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/passwd-0.80-12.fc36.aarch64.rpm"
-          },
-          "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm"
           },
           "sha256:fed94fc5d5bd061c028d13b4fe7774032226e4f2c8e95583a489cc0d05656dd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/grub2-common-2.06-38.fc37.noarch.rpm"
@@ -8808,26 +8535,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -8858,36 +8565,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
-        "checksum": "sha256:1b03cf9da04e90f91290f25c3c8f1fc1f90aaa93169a99d3438fa42457397c74",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -8895,26 +8572,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dracut-056-2.fc37.aarch64.rpm",
         "checksum": "sha256:1b4da6d9346093991cb0a2abf44c6620ff47905eb37ea987d8658dbae6e519c8",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:1518fc546d86867a8c243cb047564216ea03f55257cdb52440b5b207869dbda7",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:8e12092fee3e4a74b6e5af04c41d4094fd9413f7af1f83d21ec5fedeb42ec1d4",
         "check_gpg": true
       },
       {
@@ -9338,16 +8995,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -9465,16 +9112,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
         "checksum": "sha256:625c77e961a04c96c07f48a426dab93aba89e5b544c41faef18dcb579e4d6946",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
         "check_gpg": true
       },
       {
@@ -9598,16 +9235,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -9625,16 +9252,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -9695,16 +9312,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfido2-1.10.0-3.fc37.aarch64.rpm",
         "checksum": "sha256:c51421efb238942333571b360a2e1887d64895a8ca0631d80db3bce1a70f7267",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
         "check_gpg": true
       },
       {
@@ -9948,16 +9555,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -10058,16 +9655,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:857e1948b7da96d4dc50fad271a6ff2b027194d2b8cbf766b5edc19f018fa3cc",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -10125,16 +9712,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
         "checksum": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
         "check_gpg": true
       },
       {
@@ -10658,56 +10235,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -10715,36 +10242,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {
@@ -10775,16 +10272,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:d4a6f083589a2ad396d3e30f6d728a2503f368540d3daac8bbd3aab28d80f574",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
         "check_gpg": true
       },
       {
@@ -10825,26 +10312,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -11015,16 +10482,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_installer-boot.json
@@ -297,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
@@ -881,14 +873,6 @@
                     }
                   },
                   {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:23f2ccb549730b1f387231be98a020821edeaef71aaf0049b55776370141f5c2",
                     "options": {
                       "metadata": {
@@ -1458,14 +1442,6 @@
                   },
                   {
                     "id": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2186,14 +2162,6 @@
                   },
                   {
                     "id": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10895,9 +10863,6 @@
           "sha256:10b06196eee47bce1165d7ec99402e5d593e2d1a66ec8c503ea29b7d189d688c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libtracker-sparql-3.3.0-1.fc37.aarch64.rpm"
           },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
-          },
           "sha256:11291bd24299ce93e0f9d4aebe4ac0bbdaf722f01bf81b221ff1c8a7ea9585b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libbabeltrace-1.5.8-9.fc36.aarch64.rpm"
           },
@@ -11635,9 +11600,6 @@
           },
           "sha256:4e817c3b309db94658edbaca41d6b2e28fc8d0b6170c160c578a83cb8b38aa17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/lame-libs-3.100-12.fc36.aarch64.rpm"
-          },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
           },
           "sha256:4f67a7123db128cce32f907e2c7b17b5d757deffe2ba571868c99e08abb4ed0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/parted-3.5-1.fc37.aarch64.rpm"
@@ -23861,16 +23823,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.11.1",
@@ -24591,16 +24543,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.1",
@@ -25318,16 +25260,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
         "checksum": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
         "check_gpg": true
       },
       {
@@ -26228,16 +26160,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-urllib3-1.26.8-2.fc36.noarch.rpm",
         "checksum": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_installer_with_users-boot.json
@@ -326,14 +326,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
@@ -910,14 +902,6 @@
                     }
                   },
                   {
-                    "id": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:23f2ccb549730b1f387231be98a020821edeaef71aaf0049b55776370141f5c2",
                     "options": {
                       "metadata": {
@@ -1487,14 +1471,6 @@
                   },
                   {
                     "id": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2215,14 +2191,6 @@
                   },
                   {
                     "id": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -10947,9 +10915,6 @@
           "sha256:10b06196eee47bce1165d7ec99402e5d593e2d1a66ec8c503ea29b7d189d688c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libtracker-sparql-3.3.0-1.fc37.aarch64.rpm"
           },
-          "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm"
-          },
           "sha256:11291bd24299ce93e0f9d4aebe4ac0bbdaf722f01bf81b221ff1c8a7ea9585b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libbabeltrace-1.5.8-9.fc36.aarch64.rpm"
           },
@@ -11687,9 +11652,6 @@
           },
           "sha256:4e817c3b309db94658edbaca41d6b2e28fc8d0b6170c160c578a83cb8b38aa17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/lame-libs-3.100-12.fc36.aarch64.rpm"
-          },
-          "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm"
           },
           "sha256:4f67a7123db128cce32f907e2c7b17b5d757deffe2ba571868c99e08abb4ed0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/parted-3.5-1.fc37.aarch64.rpm"
@@ -23913,16 +23875,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.11.1",
@@ -24643,16 +24595,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libaio-0.3.111-13.fc36.aarch64.rpm",
-        "checksum": "sha256:db3925cd5f726c920aa125b384836a4fa85d4b3c73ac9d3e876a75cdbf23375c",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.1",
@@ -25370,16 +25312,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
         "checksum": "sha256:2eac8247416e7efb6e2365c5aee2319a921b946ac4dfec0b188eeead0a827706",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/liburing-2.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:111f03fab0e731b53e2893a206b75f4ba25eb3d991dbffa544414de1ae532e8e",
         "check_gpg": true
       },
       {
@@ -26280,16 +26212,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-urllib3-1.26.8-2.fc36.noarch.rpm",
         "checksum": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "7.0.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/q/qemu-img-7.0.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4ea6ddf42ab944ebf05a6f7e96a8223075f53fc77572bd7e796640c7dfe0e205",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-oci-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -228,22 +212,6 @@
                   },
                   {
                     "id": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -507,31 +475,7 @@
                     }
                   },
                   {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -580,14 +524,6 @@
                   },
                   {
                     "id": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -691,14 +627,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9",
                     "options": {
                       "metadata": {
@@ -763,14 +691,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -780,14 +700,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -835,14 +747,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -875,14 +779,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -900,22 +796,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,31 +843,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1036,14 +892,6 @@
                   },
                   {
                     "id": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1115,14 +963,6 @@
                     }
                   },
                   {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76c88a3a324f5a277fce5788d9fb03668682c64093ed0595de2a44fc64d3d2cf",
                     "options": {
                       "metadata": {
@@ -1171,14 +1011,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1219,14 +1051,6 @@
                     }
                   },
                   {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:afc6df21cc64482ce3f8946506977cfd9521a9bfbf9d144f4fad4e4f33e37760",
                     "options": {
                       "metadata": {
@@ -1260,14 +1084,6 @@
                   },
                   {
                     "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1363,30 +1179,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1395,39 +1187,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1444,14 +1204,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1499,63 +1251,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1595,14 +1291,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1612,22 +1300,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1731,14 +1403,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:45b2609ac41444eb3baafa654285e540ef10269cac18cd1f40fac813b00e29f5",
                     "options": {
                       "metadata": {
@@ -1748,14 +1412,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1804,14 +1460,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6788,26 +6436,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6835,26 +6463,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
         "checksum": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
         "check_gpg": true
       },
       {
@@ -7178,26 +6786,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.4",
@@ -7205,16 +6793,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -7275,16 +6853,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gzip-1.12-1.fc37.aarch64.rpm",
         "checksum": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
         "check_gpg": true
       },
       {
@@ -7408,16 +6976,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7498,16 +7056,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -7525,16 +7073,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -7588,16 +7126,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7638,16 +7166,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7675,26 +7193,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -7748,26 +7246,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7775,16 +7253,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -7845,16 +7313,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsmartcols-2.38-3.fc37.aarch64.rpm",
         "checksum": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
         "check_gpg": true
       },
       {
@@ -7938,16 +7396,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8008,16 +7456,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8068,16 +7506,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -8125,16 +7553,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
         "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -8248,36 +7666,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8288,16 +7676,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -8305,36 +7683,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -8355,16 +7703,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -8418,56 +7756,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -8475,26 +7763,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
         "check_gpg": true
       },
       {
@@ -8538,16 +7806,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -8565,26 +7823,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -8708,16 +7946,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
-        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8735,16 +7963,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {
@@ -8805,16 +8023,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-openstack-boot.json
@@ -212,22 +212,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -245,22 +229,6 @@
                   },
                   {
                     "id": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -524,31 +492,7 @@
                     }
                   },
                   {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -597,14 +541,6 @@
                   },
                   {
                     "id": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -708,14 +644,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9",
                     "options": {
                       "metadata": {
@@ -780,14 +708,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -797,14 +717,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -852,14 +764,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -892,14 +796,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -917,22 +813,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -980,31 +860,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1053,14 +909,6 @@
                   },
                   {
                     "id": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1132,14 +980,6 @@
                     }
                   },
                   {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76c88a3a324f5a277fce5788d9fb03668682c64093ed0595de2a44fc64d3d2cf",
                     "options": {
                       "metadata": {
@@ -1188,14 +1028,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1236,14 +1068,6 @@
                     }
                   },
                   {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:afc6df21cc64482ce3f8946506977cfd9521a9bfbf9d144f4fad4e4f33e37760",
                     "options": {
                       "metadata": {
@@ -1277,14 +1101,6 @@
                   },
                   {
                     "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1380,30 +1196,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1412,39 +1204,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1461,14 +1221,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1516,63 +1268,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1612,14 +1308,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1629,22 +1317,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1748,14 +1420,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:45b2609ac41444eb3baafa654285e540ef10269cac18cd1f40fac813b00e29f5",
                     "options": {
                       "metadata": {
@@ -1765,14 +1429,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1821,14 +1477,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6519,9 +6167,6 @@
           "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
           },
-          "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm"
-          },
           "sha256:ab88c488911c98d5b3ee1492ac1a630659c7babe809d578a3c757faabe3fab90": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nftables-1.0.1-4.fc37.aarch64.rpm"
           },
@@ -7116,26 +6761,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7163,26 +6788,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
         "checksum": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
         "check_gpg": true
       },
       {
@@ -7506,26 +7111,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.4",
@@ -7533,16 +7118,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -7603,16 +7178,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gzip-1.12-1.fc37.aarch64.rpm",
         "checksum": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
         "check_gpg": true
       },
       {
@@ -7736,16 +7301,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7826,16 +7381,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -7853,16 +7398,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -7916,16 +7451,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7966,16 +7491,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -8003,26 +7518,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -8076,26 +7571,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8103,16 +7578,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -8173,16 +7638,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsmartcols-2.38-3.fc37.aarch64.rpm",
         "checksum": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
         "check_gpg": true
       },
       {
@@ -8266,16 +7721,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8336,16 +7781,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8396,16 +7831,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -8453,16 +7878,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
         "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -8576,36 +7991,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8616,16 +8001,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -8633,36 +8008,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -8683,16 +8028,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -8746,56 +8081,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -8803,26 +8088,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
         "check_gpg": true
       },
       {
@@ -8866,16 +8131,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -8893,26 +8148,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -9036,16 +8271,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
-        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -9063,16 +8288,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {
@@ -9133,16 +8348,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
                     "options": {
                       "metadata": {
@@ -242,22 +226,6 @@
                   },
                   {
                     "id": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,31 +489,7 @@
                     }
                   },
                   {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -594,14 +538,6 @@
                   },
                   {
                     "id": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -705,14 +641,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9",
                     "options": {
                       "metadata": {
@@ -777,14 +705,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -794,14 +714,6 @@
                   },
                   {
                     "id": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -849,14 +761,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -889,14 +793,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -914,22 +810,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -977,31 +857,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1050,14 +906,6 @@
                   },
                   {
                     "id": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1129,14 +977,6 @@
                     }
                   },
                   {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76c88a3a324f5a277fce5788d9fb03668682c64093ed0595de2a44fc64d3d2cf",
                     "options": {
                       "metadata": {
@@ -1185,14 +1025,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1233,14 +1065,6 @@
                     }
                   },
                   {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:afc6df21cc64482ce3f8946506977cfd9521a9bfbf9d144f4fad4e4f33e37760",
                     "options": {
                       "metadata": {
@@ -1274,14 +1098,6 @@
                   },
                   {
                     "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1377,30 +1193,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1409,39 +1201,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1458,14 +1218,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1513,63 +1265,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1609,14 +1305,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1626,22 +1314,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1745,14 +1417,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:45b2609ac41444eb3baafa654285e540ef10269cac18cd1f40fac813b00e29f5",
                     "options": {
                       "metadata": {
@@ -1762,14 +1426,6 @@
                   },
                   {
                     "id": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1818,14 +1474,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6812,26 +6460,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6859,26 +6487,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
         "checksum": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
         "check_gpg": true
       },
       {
@@ -7202,26 +6810,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.4",
@@ -7229,16 +6817,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -7299,16 +6877,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gzip-1.12-1.fc37.aarch64.rpm",
         "checksum": "sha256:cc5a6529710baa7c6799a0b4eb116f294ef746669defb59deab04c0cad746d70",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
         "check_gpg": true
       },
       {
@@ -7432,16 +7000,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7522,16 +7080,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -7549,16 +7097,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdb-5.3.28-52.fc37.aarch64.rpm",
         "checksum": "sha256:f312d29be224278e17c5133c0de95ef8f0f9e43bb0300cc7ac791f599df93d6e",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
         "check_gpg": true
       },
       {
@@ -7612,16 +7150,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7662,16 +7190,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7699,26 +7217,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -7772,26 +7270,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7799,16 +7277,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -7869,16 +7337,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsmartcols-2.38-3.fc37.aarch64.rpm",
         "checksum": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
         "check_gpg": true
       },
       {
@@ -7962,16 +7420,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8032,16 +7480,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8092,16 +7530,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -8149,16 +7577,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
         "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -8272,36 +7690,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8312,16 +7700,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -8329,36 +7707,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -8379,16 +7727,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -8442,56 +7780,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -8499,26 +7787,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
         "check_gpg": true
       },
       {
@@ -8562,16 +7830,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -8589,26 +7847,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -8732,16 +7970,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
-        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8759,16 +7987,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tzdata-2022a-1.fc37.noarch.rpm",
         "checksum": "sha256:9c344e57ee96634821fc42434812c4f4743f464c514681166228675044718fde",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
         "check_gpg": true
       },
       {
@@ -8829,16 +8047,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
@@ -273,23 +273,23 @@
                     }
                   },
                   {
-                    "id": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b5b9ce39d5a79029b69751e8de56e7a284a209c7ca68286a677a9b4fdd5dfd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a7a54848c8c44c11170cc3426ac1b05129fd16d24d37b3db4a82fff70aea5d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -305,23 +305,15 @@
                     }
                   },
                   {
+                    "id": "sha256:a0c7ba852ddd155fdd48251274cd37e7506930c08be4b89f4f80eedff96e189e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -585,31 +577,7 @@
                     }
                   },
                   {
-                    "id": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -665,7 +633,7 @@
                     }
                   },
                   {
-                    "id": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
+                    "id": "sha256:3e940f398443f98e01e7ac095003328b3eb7b061aa6f77de3ff1bbf6321c7bd9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -769,14 +737,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a9d8f5c993a6b9ac6d27f3ff694e5acc09e3bbe1af2211f35af1be44c924e2c9",
                     "options": {
                       "metadata": {
@@ -841,14 +801,6 @@
                     }
                   },
                   {
-                    "id": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c9ba6a0d121a07db5fe04ac74011cf9f95dbdb32db7346d6032a76cbc821170e",
                     "options": {
                       "metadata": {
@@ -865,7 +817,7 @@
                     }
                   },
                   {
-                    "id": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
+                    "id": "sha256:f91f257fc03696a3fedbcdf241b8cde1f45d6b8506f269ea4ffc215e08ca2949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -873,7 +825,7 @@
                     }
                   },
                   {
-                    "id": "sha256:f91f257fc03696a3fedbcdf241b8cde1f45d6b8506f269ea4ffc215e08ca2949",
+                    "id": "sha256:1242e3cac511f047b4fa7b885c2ce0e8d39a6431e77fec98c4b1c75c323c4596",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -913,14 +865,6 @@
                     }
                   },
                   {
-                    "id": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:30ff2d7eab28d6340795f8cd11f460051db05aa0c461d637403a6223ad81336d",
                     "options": {
                       "metadata": {
@@ -953,14 +897,6 @@
                     }
                   },
                   {
-                    "id": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:b63cc4f35234049d6336d4fe5c4bac222188e2f33b9953f5b0f63341086a861c",
                     "options": {
                       "metadata": {
@@ -978,22 +914,6 @@
                   },
                   {
                     "id": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1041,31 +961,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1114,14 +1010,6 @@
                   },
                   {
                     "id": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1193,14 +1081,6 @@
                     }
                   },
                   {
-                    "id": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:76c88a3a324f5a277fce5788d9fb03668682c64093ed0595de2a44fc64d3d2cf",
                     "options": {
                       "metadata": {
@@ -1249,14 +1129,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:311cf29255bb1e11020037b79a079769291c0db0ec176bd07bb72056592c0944",
                     "options": {
                       "metadata": {
@@ -1266,6 +1138,22 @@
                   },
                   {
                     "id": "sha256:a50b9357d9022376e7535e077e088d2fb98bce248dbb2aefca7836b5d16fc225",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c3495c6ebc1326f003af7295170a233773603cab837fd26227de7cd16a0271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89f9eeba7f5b4d6f8a563dfdde43d5eb3ea1cdac3baafa23576af83308af1c85",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1290,14 +1178,6 @@
                   },
                   {
                     "id": "sha256:b1d9292065a0b522b3416d354e665856b34e6839ce9f597f9fefafeb3d85fb9a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1338,14 +1218,6 @@
                   },
                   {
                     "id": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1441,30 +1313,6 @@
                     }
                   },
                   {
-                    "id": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:97933f745dbcf26a283d15ef4544c13a0f4a9213b3377295ad24b68917ea07d9",
                     "options": {
                       "metadata": {
@@ -1473,39 +1321,7 @@
                     }
                   },
                   {
-                    "id": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1522,14 +1338,6 @@
                   },
                   {
                     "id": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1577,63 +1385,7 @@
                     }
                   },
                   {
-                    "id": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1673,14 +1425,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:a981788b219d2adfb2064d97cf79b61b9500b01e9ecaf1f91b13920ccbb1abb5",
                     "options": {
                       "metadata": {
@@ -1690,22 +1434,6 @@
                   },
                   {
                     "id": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1809,14 +1537,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:45b2609ac41444eb3baafa654285e540ef10269cac18cd1f40fac813b00e29f5",
                     "options": {
                       "metadata": {
@@ -1833,7 +1553,7 @@
                     }
                   },
                   {
-                    "id": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
+                    "id": "sha256:98c5583313204582a14d33eaf7cb0baeb8ddd42a00fa6305300e43c1bc7f3ec8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1865,6 +1585,14 @@
                     }
                   },
                   {
+                    "id": "sha256:f844e6f2944a663e26e34c22818789054c2cb3fdd915e66a9344188d41023706",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9d4abf661fa90e195280e6ee773d5bb1681250ce35c34ee6a47e6009c80b87d3",
                     "options": {
                       "metadata": {
@@ -1882,14 +1610,6 @@
                   },
                   {
                     "id": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7346,26 +7066,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dbus-libs-1.14.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2ea7af55f5388c1ab4c716b678dcfdf5654acaf56fa2d72ab40ae6ff7dffbefd",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/deltarpm-3.6.3-2.fc37.aarch64.rpm",
-        "checksum": "sha256:0ba1e59541ac4dc5392b4637c75ad657d682d8e2778129c17c56f4ef591c1e1e",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7373,6 +7073,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
         "checksum": "sha256:128cfdd2f4f396931884188b1da861b7a42184ffa35145dc3c50abb03db67fe4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-event-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:2b5b9ce39d5a79029b69751e8de56e7a284a209c7ca68286a677a9b4fdd5dfd2",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-event-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:86a7a54848c8c44c11170cc3426ac1b05129fd16d24d37b3db4a82fff70aea5d",
         "check_gpg": true
       },
       {
@@ -7386,6 +7106,16 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/device-mapper-persistent-data-0.9.0-7.fc36.aarch64.rpm",
+        "checksum": "sha256:a0c7ba852ddd155fdd48251274cd37e7506930c08be4b89f4f80eedff96e189e",
+        "check_gpg": true
+      },
+      {
         "name": "diffutils",
         "epoch": 0,
         "version": "3.8",
@@ -7393,26 +7123,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
         "checksum": "sha256:ca4d3be1d2b1064fb4e29c7c14bb626a77d5b21d067b0c3adfc975d9d3145f41",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:a423225545ac216deaeee870565eeba1c25e4dd5d112492d2837ec12ff2ccd25",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/d/dnf-data-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:84c172a60d80c15bbb08be947f65f9442f20b9e4a2ad73d956da55453d738227",
         "check_gpg": true
       },
       {
@@ -7736,26 +7446,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:ecbeeab019f50c6be592a8a67aa62943e2c19387c1aee06aea788bc2dc0088cb",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.6",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnupg2-smime-2.3.6-1.fc37.aarch64.rpm",
-        "checksum": "sha256:5fd8f7038d439d5ac0382f4208207a7a9846a761a0b6db9f7550163aa035a156",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.4",
@@ -7763,16 +7453,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gnutls-3.7.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:adc7b1bf1d1107b0ae16922790063f13a8d249589bfbdb793411c59c79832043",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/g/gpgme-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:4c4fe3543200d7a414293cca71a3d67e55b11709812489d9f9502f72b716c59f",
         "check_gpg": true
       },
       {
@@ -7836,13 +7516,13 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
+        "name": "inih",
         "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
+        "version": "55",
+        "release": "1.fc37",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
-        "checksum": "sha256:96fba015d1d9aa2985a3b0d0e42b40e1a9a7a5318d032bf5e95a7b2eedbfa340",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/i/inih-55-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3e940f398443f98e01e7ac095003328b3eb7b061aa6f77de3ff1bbf6321c7bd9",
         "check_gpg": true
       },
       {
@@ -7966,16 +7646,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
-        "checksum": "sha256:1fc88c71d6f2c6131c154a6a5b3205a20207f74e3f882e709b0cedcbc4e78cdb",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -8056,16 +7726,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:564917779fbb68d156e6cb405e341565cdb7480f084f088b9a9e11856408e8ac",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.83.0",
@@ -8086,16 +7746,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:febb9b100da1926908661bd921969ca9672f744139af4b8b85097756a1461b5f",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -8103,6 +7753,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
         "checksum": "sha256:f91f257fc03696a3fedbcdf241b8cde1f45d6b8506f269ea4ffc215e08ca2949",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm",
+        "checksum": "sha256:1242e3cac511f047b4fa7b885c2ce0e8d39a6431e77fec98c4b1c75c323c4596",
         "check_gpg": true
       },
       {
@@ -8146,16 +7806,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
-        "checksum": "sha256:29230c77c3ee0686faf5d880c95460c87fc522f928a1f58b03f0d2cac812284d",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -8196,16 +7846,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libicu-69.1-5.fc36.aarch64.rpm",
-        "checksum": "sha256:82242e1387bd0a8bf57a8eed7200dcc98443741c4deecd7467d08847f9ecf4cf",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -8233,26 +7873,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
         "checksum": "sha256:46dfcbdf0787c1cfe2233458e6e0db174508f32e6f3484fe04ad5539de196843",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
-        "checksum": "sha256:b08972de4d0d2bf8d55966f49f76f470bfe40463f0fab37efbae19c6bc465a8f",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:bda756c766688f0b6c58fd7b8f05f388424ccd3ae29c0b88304bc1b1391f2402",
         "check_gpg": true
       },
       {
@@ -8306,26 +7926,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/librepo-1.14.2-2.fc36.aarch64.rpm",
-        "checksum": "sha256:7d94abdd89f407874520a76a12523acd6c5a186daa871ecc4a1fe481d18f789f",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8333,16 +7933,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
         "checksum": "sha256:50dac68ff524493a8402e5cbd78c5dadeb45145fa3be5353e5f80c75096f545d",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsecret-0.20.5-1.fc37.aarch64.rpm",
-        "checksum": "sha256:1b1c52b9b311b130f129fb81c9489de934b23cb7b583c45603ab5e3d644b378e",
         "check_gpg": true
       },
       {
@@ -8403,16 +7993,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsmartcols-2.38-3.fc37.aarch64.rpm",
         "checksum": "sha256:1cf1259c7935f042a06bf21ce59d7ff6679ccd04b9724eff54cb75112b58a017",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.22",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libsolv-0.7.22-1.fc37.aarch64.rpm",
-        "checksum": "sha256:99a81a7b537ecd235b049a39bf16632f23231854a1c4b7a1edf953169e5991d3",
         "check_gpg": true
       },
       {
@@ -8496,16 +8076,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libusb1-1.0.25-8.fc37.aarch64.rpm",
-        "checksum": "sha256:71eea7a0803780e7b95829882b87d6b890420796407e877dbd4ab1ca9aeddf73",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8566,16 +8136,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
-        "checksum": "sha256:ce95a3ce3aff51f86963ec7193a7fabce3f94c5cadb1f14796ed69eef9b06d62",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8593,6 +8153,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/lua-libs-5.4.4-2.fc37.aarch64.rpm",
         "checksum": "sha256:a50b9357d9022376e7535e077e088d2fb98bce248dbb2aefca7836b5d16fc225",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/lvm2-2.03.11-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d6c3495c6ebc1326f003af7295170a233773603cab837fd26227de7cd16a0271",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/l/lvm2-libs-2.03.11-7.fc36.aarch64.rpm",
+        "checksum": "sha256:89f9eeba7f5b4d6f8a563dfdde43d5eb3ea1cdac3baafa23576af83308af1c85",
         "check_gpg": true
       },
       {
@@ -8623,16 +8203,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mkpasswd-5.5.12-2.fc37.aarch64.rpm",
         "checksum": "sha256:b1d9292065a0b522b3416d354e665856b34e6839ce9f597f9fefafeb3d85fb9a",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.8.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/m/mozjs91-91.8.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:451336a40379264ca0763d390f119fe620e6a7d72a3dfe7be29caa72fb0e92fb",
         "check_gpg": true
       },
       {
@@ -8683,16 +8253,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/nettle-3.7.3-3.fc36.aarch64.rpm",
         "checksum": "sha256:0dbb53b71e4cb83dfe7257c55faadbf4b2b6cd34301af1b656e2606cf34d9f1b",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
-        "checksum": "sha256:7ca837fbdb1181152da495087652760a23de890537663f60e2e42b7b451a659b",
         "check_gpg": true
       },
       {
@@ -8806,36 +8366,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:34ac501a46deeb1641eebe7dc29feef2e17aea7beeaec569bf4d934de32e401b",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
-        "checksum": "sha256:8a7a2efee8c020fa91bc8cff07ca0988060ee6c53b002777e21646e6da709633",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.aarch64.rpm",
-        "checksum": "sha256:384415e0e7ff450539114d2524a0b5b973abf16f854f3379069f0bd246ea9164",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8846,16 +8376,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
-        "checksum": "sha256:eaa8a1895aa76b29eb5c609b769bf4c3ce2fcf9dbaf69f24eb74e166dc1ee302",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.4",
@@ -8863,36 +8383,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/policycoreutils-3.4-0.rc2.1.fc37.aarch64.rpm",
         "checksum": "sha256:93501508605a81c298a5c1fd0796319020b7ddd3d524c5f8213cf80d1262e102",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:d703cf7e5b57a6b96b58fe763e24d284a7e63188bbb3bfba6620aaa0a01da070",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-libs-0.120-5.fc37.aarch64.rpm",
-        "checksum": "sha256:71d435a9672a2281c5e89805daac7c2e6c864f3b808499577547765f80592b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
-        "checksum": "sha256:e624051823e401799d0a6a3b887279c60e3e1d5551ef519fb1cdf82df1161074",
         "check_gpg": true
       },
       {
@@ -8913,16 +8403,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/procps-ng-3.3.17-5.fc37.aarch64.rpm",
         "checksum": "sha256:f05adad6e6b729e77faf7e744519b3f60d9cae8ce1c7ece537c5c39d2546adba",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
-        "checksum": "sha256:4bf68c9bc20e58571e6e4c8e01389fd2cc51f988a55f25578b71cdbdf98b7949",
         "check_gpg": true
       },
       {
@@ -8976,56 +8456,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "3.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-dnf-4.11.1-3.fc37.noarch.rpm",
-        "checksum": "sha256:0e4042df5cba70d7dfb9cf522b5be1429685fc92a142e767b37b7e1c18a262ba",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-gpg-1.17.0-2.fc37.aarch64.rpm",
-        "checksum": "sha256:70a76fe74cfab9e0a14ef61de570db3a076891f6d9d7b9180991954c3316b31b",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-hawkey-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:393ee600f0ab8431d22236325244546ec99573dfbda4229125e2990dff4a054d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
-        "checksum": "sha256:db31b8f7d5a4c3fbd686920b1385cbaa2d0b0074fd12bce0772d061bcaf6d31d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libdnf-0.66.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:7c2514d648c0ad56eb4b802268a73c74834831f7d9333f66c96be96d4b5a9717",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.4",
@@ -9033,26 +8463,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-libs-3.10.4-1.fc37.aarch64.rpm",
         "checksum": "sha256:943a67e7c3b6f58d08422f0a63cfd42dc3773d62dd94b91e589d819fca8cd702",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-rpm-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:a091e31e53b3ef672240006f75736aefe0878ce39cd190fec7ef974482a29b7a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/p/python3-unbound-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:4502a962aa636e19b8c3ea5035e1b68c5c3a5ff1bd972b12afe7a5122980d898",
         "check_gpg": true
       },
       {
@@ -9096,16 +8506,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-build-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:8be6a5201baa8ed8881b17e5d2b48f8cf481d109361c086de7f9a1dae48fb394",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.18.0",
@@ -9123,26 +8523,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-selinux-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
         "checksum": "sha256:ecced388de7096f47afab124e2ef93745bc2fb7e360841c8f544a0f7ed038353",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:e4897fb5c63f179e381a6cce5b8e66a4d1211271b8823be048cf92dc98ca78e8",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.18.0",
-        "release": "0.alpha1.6.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/r/rpm-sign-libs-4.18.0-0.alpha1.6.fc37.aarch64.rpm",
-        "checksum": "sha256:757d62395f9935e3f8782ac71100cf12c66c63ddcfa26a3635f5f3bca14a61bd",
         "check_gpg": true
       },
       {
@@ -9266,16 +8646,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/t/tar-1.34-3.fc36.aarch64.rpm",
-        "checksum": "sha256:aaf96349b2c31132cac07d8a448dae9a692083e27b04971ddc9427d307559af1",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -9296,13 +8666,13 @@
         "check_gpg": true
       },
       {
-        "name": "unbound-libs",
+        "name": "userspace-rcu",
         "epoch": 0,
-        "version": "1.15.0",
-        "release": "1.fc37",
+        "version": "0.13.0",
+        "release": "4.fc36",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/unbound-libs-1.15.0-1.fc37.aarch64.rpm",
-        "checksum": "sha256:bb321ba10766904bd19e32614bece20ab8ed4d9796ce81500e06a1ae03ce8749",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:98c5583313204582a14d33eaf7cb0baeb8ddd42a00fa6305300e43c1bc7f3ec8",
         "check_gpg": true
       },
       {
@@ -9336,6 +8706,16 @@
         "check_gpg": true
       },
       {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xfsprogs-5.15.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f844e6f2944a663e26e34c22818789054c2cb3fdd915e66a9344188d41023706",
+        "check_gpg": true
+      },
+      {
         "name": "xkeyboard-config",
         "epoch": 0,
         "version": "2.35.1",
@@ -9363,16 +8743,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/x/xz-libs-5.2.5-9.fc37.aarch64.rpm",
         "checksum": "sha256:a0e3906c6a0b0cb30f8b04a2a5da5a67015bc5f64c8c1d6d5e37d7fbb029ca9e",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.2",
-        "release": "1.fc37",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-rawhide-20220504/Packages/z/zchunk-libs-1.2.2-1.fc37.aarch64.rpm",
-        "checksum": "sha256:2eaeb5a337c2ed5be75a31a39a756ba6b465e49d51892f0bc59160e54fece593",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-ami-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -228,22 +212,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -411,14 +379,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:db3928cbf141b83000653b3419e89b3fdf8b781faeb7bde4565312deb3de4364",
                     "options": {
                       "metadata": {
@@ -459,14 +419,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9957d16206802f86f4b0f148ce6b01c626f09958f73490622aadfe1a05cf0cd2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:eb61e40230a2f1280d74bc132f2718dc0800ea3c04078e98da3a471a57135033",
                     "options": {
                       "metadata": {
@@ -500,38 +452,6 @@
                   },
                   {
                     "id": "sha256:5e24d693cf8267f478e100023d613ec0fc96940d51d5f46b3fdaa02d0cdaea6d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -596,14 +516,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -683,14 +595,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca678e16c32fe14846114ba1c27d59b67c474b6b97f39c3f82c5392660d4b2e4",
                     "options": {
                       "metadata": {
@@ -700,14 +604,6 @@
                   },
                   {
                     "id": "sha256:f1bded2211f4b1eb76cf3e7d2ec827ef89aa5623fac7815267d042c5b8bcf5ce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -779,14 +675,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -796,14 +684,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -851,14 +731,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -891,14 +763,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -916,22 +780,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -979,31 +827,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1052,14 +876,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1123,22 +939,6 @@
                     }
                   },
                   {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1195,14 +995,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1243,14 +1035,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32d5a5f4b1d18f7511f5aab79c74bc322f9d292c3d4277b61b7ba463e0cb0152",
                     "options": {
                       "metadata": {
@@ -1283,31 +1067,7 @@
                     }
                   },
                   {
-                    "id": "sha256:df4af8f9dd71cf93651ed0eb47a1f2cb39a6801b09ecc48b81c45300c536b153",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1395,30 +1155,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1427,39 +1163,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1476,14 +1180,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1531,71 +1227,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1627,14 +1259,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1644,22 +1268,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1763,14 +1371,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1780,14 +1380,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1844,14 +1436,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5203,9 +4787,6 @@
           "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm"
           },
-          "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm"
-          },
           "sha256:133cf11166efa15a423e5aa4eeaf74cb97047077c3e36602a2551e58bdcebf13": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-policycoreutils-3.3-4.fc37.noarch.rpm"
           },
@@ -5271,9 +4852,6 @@
           },
           "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm"
-          },
-          "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse3-libs-3.10.5-4.fc37.x86_64.rpm"
           },
           "sha256:2171b58ce9986f8a32dff4622d1d658a0ae2661c15d9bd69baaed80ffb55b572": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/selinux-policy-36.5-1.fc37.noarch.rpm"
@@ -5508,9 +5086,6 @@
           },
           "sha256:55e3b38bf0f93778f7c18fa7b479674367e9520ad4c9100b184caae8a431adec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
-          },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
           },
           "sha256:5768d2860adfb7798fa048a10053d151b0ce3916f522b6358d11cbb5c86f2a65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iproute-5.17.0-1.fc37.x86_64.rpm"
@@ -5802,9 +5377,6 @@
           },
           "sha256:979823a3ec28bd2c523f43140c5f7d863e0606395ba5d7316da6ce75ec83c4ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-charset-normalizer-2.0.12-1.fc37.noarch.rpm"
-          },
-          "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm"
           },
           "sha256:9801b2631f15ec5e8b86a8cc4d2142124723e73fb4c107a17a6841ecba381411": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/parted-3.4-12.fc37.x86_64.rpm"
@@ -6217,9 +5789,6 @@
           "sha256:fd27c9772fc0d86a8fc8e2b6c2c2ebae82503b3c854b2aa174b4a09b41bb6acb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openssl-3.0.2-1.fc37.x86_64.rpm"
           },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
-          },
           "sha256:ffabc9f84e9fe0d373f68a1ded02af04f1afcf9d4a2789bfd1560e0e99cc651c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-distro-1.7.0-1.fc37.noarch.rpm"
           },
@@ -6433,26 +6002,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6480,26 +6029,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -6703,16 +6232,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "4.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse3-libs-3.10.5-4.fc37.x86_64.rpm",
-        "checksum": "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.1",
@@ -6763,16 +6282,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.72.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/glib2-2.72.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:9957d16206802f86f4b0f148ce6b01c626f09958f73490622aadfe1a05cf0cd2",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.35.9000",
@@ -6820,46 +6329,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:5e24d693cf8267f478e100023d613ec0fc96940d51d5f46b3fdaa02d0cdaea6d",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
-        "name": "gnutls",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
-        "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -6940,16 +6409,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -7043,16 +6502,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.0",
@@ -7070,16 +6519,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libargon2-20171227-8.fc36.x86_64.rpm",
         "checksum": "sha256:f1bded2211f4b1eb76cf3e7d2ec827ef89aa5623fac7815267d042c5b8bcf5ce",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
         "check_gpg": true
       },
       {
@@ -7163,16 +6602,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7190,16 +6619,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7253,16 +6672,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7303,16 +6712,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7340,26 +6739,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7413,26 +6792,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7440,16 +6799,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7510,16 +6859,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7593,26 +6932,6 @@
         "check_gpg": true
       },
       {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7683,16 +7002,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -7743,16 +7052,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -7793,26 +7092,6 @@
         "check_gpg": true
       },
       {
-        "name": "nettle",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nettle-3.7.3-3.fc36.x86_64.rpm",
-        "checksum": "sha256:df4af8f9dd71cf93651ed0eb47a1f2cb39a6801b09ecc48b81c45300c536b153",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -7820,16 +7099,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -7933,36 +7202,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -7973,16 +7212,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -7990,36 +7219,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8040,16 +7239,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8103,56 +7292,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8160,36 +7299,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {
@@ -8223,16 +7332,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8250,26 +7349,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8393,16 +7472,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8420,16 +7489,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8500,16 +7559,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-container-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -235,47 +219,7 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -411,14 +355,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:db3928cbf141b83000653b3419e89b3fdf8b781faeb7bde4565312deb3de4364",
                     "options": {
                       "metadata": {
@@ -459,14 +395,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9957d16206802f86f4b0f148ce6b01c626f09958f73490622aadfe1a05cf0cd2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:eb61e40230a2f1280d74bc132f2718dc0800ea3c04078e98da3a471a57135033",
                     "options": {
                       "metadata": {
@@ -500,38 +428,6 @@
                   },
                   {
                     "id": "sha256:5e24d693cf8267f478e100023d613ec0fc96940d51d5f46b3fdaa02d0cdaea6d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -580,14 +476,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -667,14 +555,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca678e16c32fe14846114ba1c27d59b67c474b6b97f39c3f82c5392660d4b2e4",
                     "options": {
                       "metadata": {
@@ -684,14 +564,6 @@
                   },
                   {
                     "id": "sha256:f1bded2211f4b1eb76cf3e7d2ec827ef89aa5623fac7815267d042c5b8bcf5ce",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -763,14 +635,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -780,14 +644,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -835,14 +691,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -875,14 +723,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -900,22 +740,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -963,31 +787,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1043,22 +843,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703",
                     "options": {
                       "metadata": {
@@ -1100,22 +884,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1179,14 +947,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1227,14 +987,6 @@
                     }
                   },
                   {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:32d5a5f4b1d18f7511f5aab79c74bc322f9d292c3d4277b61b7ba463e0cb0152",
                     "options": {
                       "metadata": {
@@ -1267,31 +1019,7 @@
                     }
                   },
                   {
-                    "id": "sha256:df4af8f9dd71cf93651ed0eb47a1f2cb39a6801b09ecc48b81c45300c536b153",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1379,30 +1107,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1411,39 +1115,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1460,14 +1132,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1515,71 +1179,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1611,14 +1211,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1628,22 +1220,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1771,14 +1347,6 @@
                     }
                   },
                   {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c297c0afee35e67d8049cfe22ace11e185afbee54caa9e6ad8176a3ee3e8b100",
                     "options": {
                       "metadata": {
@@ -1828,14 +1396,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3186,17 +2746,8 @@
           "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm"
           },
-          "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm"
-          },
-          "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm"
-          },
           "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm"
-          },
-          "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm"
           },
           "sha256:14cc6fd825ff3f1a444314d8f60962b0dd01213db13b5796b96e6064eacbf235": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm"
@@ -3212,9 +2763,6 @@
           },
           "sha256:170a77a3b12e3404f6385158e82c4f90f25100649004fb40043ed8d59467eadb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/systemd-pam-250.4-2.fc37.x86_64.rpm"
-          },
-          "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm"
           },
           "sha256:18ae3d633edc0433c9c3571a6c808ae32903817cbd8de5bf0018e442486a4a7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
@@ -3233,9 +2781,6 @@
           },
           "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm"
-          },
-          "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse3-libs-3.10.5-4.fc37.x86_64.rpm"
           },
           "sha256:2171b58ce9986f8a32dff4622d1d658a0ae2661c15d9bd69baaed80ffb55b572": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/selinux-policy-36.5-1.fc37.noarch.rpm"
@@ -3291,12 +2836,6 @@
           "sha256:362aad209608a8f9509e1770d2d71971feca02f1f708eb83a35d0652c79ec36e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fedora-repos-rawhide-37-0.1.noarch.rpm"
           },
-          "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm"
-          },
-          "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm"
-          },
           "sha256:3a3e5af063f42e0176214993b14c8eb81d8702aef1367becfc2c364c6f394de3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/v/vim-data-8.2.4579-1.fc37.noarch.rpm"
           },
@@ -3317,9 +2856,6 @@
           },
           "sha256:3ee5cfbd9d2e0a533b76bf4e7fd1e06354d6a93df17660bc4ece3d6d653d36a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-broker-29-5.fc36.x86_64.rpm"
-          },
-          "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm"
           },
           "sha256:40141915d0970dff3005d085fe5008b34d20d168f06321b44438fb8358cdd353": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libgomp-12.0.1-0.12.fc37.x86_64.rpm"
@@ -3366,9 +2902,6 @@
           "sha256:521a89b3ff76b302baaf1b53747fd1d9c15ba02536642b0d599a85636ccbdb45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfdisk-2.38-0.4.fc37.x86_64.rpm"
           },
-          "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm"
-          },
           "sha256:52b7c618b69e70d94b124119193f6eefb60586352b6941d95e3b8948e5784924": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-3.10.3-1.fc37.x86_64.rpm"
           },
@@ -3384,14 +2917,8 @@
           "sha256:55e3b38bf0f93778f7c18fa7b479674367e9520ad4c9100b184caae8a431adec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm"
-          },
-          "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm"
           },
           "sha256:590921c5793488594dde85e984fba9be97993d4ede2a8ac476c4ac7a61227861": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/cpio-2.13-12.fc36.x86_64.rpm"
@@ -3453,9 +2980,6 @@
           "sha256:6a887968bb4ca7572c66e64821d8f24418c7b1f0c4aed4e099797e3d4aeb62ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
           },
-          "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm"
-          },
           "sha256:6c71a4d0c730f5d690eb8474e72517fe4aefbfd4817fa9c55e984cb52809f7de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-common-1.14.0-1.fc37.noarch.rpm"
           },
@@ -3483,9 +3007,6 @@
           "sha256:7851fd6514c3614be6bd3654b814e910e8173c08f9b47fdb745bb324cc3cbc7f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openssl-libs-3.0.2-1.fc37.x86_64.rpm"
           },
-          "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm"
-          },
           "sha256:795d865c4417ee6568d937c7584fa954daef08efed4c744306faa2cf89c16681": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
           },
@@ -3494,9 +3015,6 @@
           },
           "sha256:7ab6d181c8806788731f238c0a5f30c68e3c093826c9435e9a2577bdcfbe0695": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm"
-          },
-          "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm"
           },
           "sha256:7c47a939c086b67468cf79bf16bcbf8cd4d572a346a97a06b29883fa98eb4869": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-5.2.5-8.fc36.x86_64.rpm"
@@ -3524,9 +3042,6 @@
           },
           "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-056-1.fc37.x86_64.rpm"
-          },
-          "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm"
           },
           "sha256:84090bb0e84075c544a554aaf29eb9c8b8bd8786f05786b001e2547d2f2c5bb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gettext-0.21-12.fc37.0.20220203.x86_64.rpm"
@@ -3573,9 +3088,6 @@
           "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm"
           },
-          "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm"
-          },
           "sha256:953ab34fa12d1ef9da70ab77deeac6a6083ddc963f20d14164d4eb32d209f6e9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libgcrypt-1.10.0-1.fc36.x86_64.rpm"
           },
@@ -3603,9 +3115,6 @@
           "sha256:9f7bb142413bd764414ece5eac4cd45c1c5fa339f8f38532f14a051aabc98afa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
           },
-          "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm"
-          },
           "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm"
           },
@@ -3615,12 +3124,6 @@
           "sha256:a4b484db8f19c3c9e9e9911ef1eca6804da97f96a10920ec73a1003488e91d52": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libgpg-error-1.44-1.fc36.x86_64.rpm"
           },
-          "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm"
-          },
-          "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm"
-          },
           "sha256:aaaad3a5d68ad506d1975fdfb8a1beb63e9c2ba9063e13d9ffb4c1585d398b1b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pam-1.5.2-12.fc37.x86_64.rpm"
           },
@@ -3629,9 +3132,6 @@
           },
           "sha256:afd748bfcfc56d8a28cc1f12d1518a5baa858e8bbc6df9833c9b7eeb043faa7a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fedora-repos-modular-37-0.1.noarch.rpm"
-          },
-          "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm"
           },
           "sha256:b0bbf2929bebb68968539b0a3b61e3c771836b33e268741165de907e063d68ab": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm"
@@ -3696,9 +3196,6 @@
           "sha256:ca678e16c32fe14846114ba1c27d59b67c474b6b97f39c3f82c5392660d4b2e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libarchive-3.6.0-1.fc37.x86_64.rpm"
           },
-          "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm"
-          },
           "sha256:cba4889468eb9266569baeb8f00d72e6932c37ae1cc7408d7cfb5a1c891c59f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm"
           },
@@ -3741,9 +3238,6 @@
           "sha256:d605af2be4ab8c161a00a1bdf11301ac9f91fb995cf8f917da30f5293472d835": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/crypto-policies-20220203-2.git112f859.fc36.noarch.rpm"
           },
-          "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm"
-          },
           "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
           },
@@ -3783,9 +3277,6 @@
           "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm"
           },
-          "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm"
-          },
           "sha256:eb61e40230a2f1280d74bc132f2718dc0800ea3c04078e98da3a471a57135033": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/glibc-2.35.9000-11.fc37.x86_64.rpm"
           },
@@ -3822,9 +3313,6 @@
           "sha256:f6931239c70b56d086b44047c17826b51a0bf67de728a99efe65254a46c79a66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python-setuptools-wheel-60.9.3-1.fc37.noarch.rpm"
           },
-          "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm"
-          },
           "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm"
           },
@@ -3834,14 +3322,8 @@
           "sha256:f9ba35e8b20913cc29a2239365c480dec40c0e49ce6daa96e7ad3b4e3cfd746f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libbpf-0.7.0-3.fc37.x86_64.rpm"
           },
-          "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm"
-          },
           "sha256:fd03c888a957d6e2b4c8b8e2270ee57c282df70d621102810aad37fa79ec95c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:ffb816370fa37678846063243dbe3d72ee0c9f60711fb7192bdf6eaf5aadf96d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/elfutils-default-yama-scope-0.186-1.fc36.noarch.rpm"
@@ -4053,26 +3535,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -4103,36 +3565,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
-        "checksum": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -4140,26 +3572,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-056-1.fc37.x86_64.rpm",
         "checksum": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
         "check_gpg": true
       },
       {
@@ -4323,16 +3735,6 @@
         "check_gpg": true
       },
       {
-        "name": "fuse3-libs",
-        "epoch": 0,
-        "version": "3.10.5",
-        "release": "4.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fuse3-libs-3.10.5-4.fc37.x86_64.rpm",
-        "checksum": "sha256:1faf6c0dabd4bcd73c51399c6eb7f59217b3a6ea1caf32e5ea8afd183fefcb58",
-        "check_gpg": true
-      },
-      {
         "name": "gawk",
         "epoch": 0,
         "version": "5.1.1",
@@ -4383,16 +3785,6 @@
         "check_gpg": true
       },
       {
-        "name": "glib2",
-        "epoch": 0,
-        "version": "2.72.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/glib2-2.72.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:9957d16206802f86f4b0f148ce6b01c626f09958f73490622aadfe1a05cf0cd2",
-        "check_gpg": true
-      },
-      {
         "name": "glibc",
         "epoch": 0,
         "version": "2.35.9000",
@@ -4440,46 +3832,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:5e24d693cf8267f478e100023d613ec0fc96940d51d5f46b3fdaa02d0cdaea6d",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
-        "name": "gnutls",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
-        "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -4540,16 +3892,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -4643,16 +3985,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.0",
@@ -4670,16 +4002,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libargon2-20171227-8.fc36.x86_64.rpm",
         "checksum": "sha256:f1bded2211f4b1eb76cf3e7d2ec827ef89aa5623fac7815267d042c5b8bcf5ce",
-        "check_gpg": true
-      },
-      {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
         "check_gpg": true
       },
       {
@@ -4763,16 +4085,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -4790,16 +4102,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -4853,16 +4155,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -4903,16 +4195,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -4940,26 +4222,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -5013,26 +4275,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -5040,16 +4282,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -5113,26 +4345,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
-        "check_gpg": true
-      },
-      {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -5190,26 +4402,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
-        "check_gpg": true
-      },
-      {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
         "check_gpg": true
       },
       {
@@ -5283,16 +4475,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -5343,16 +4525,6 @@
         "check_gpg": true
       },
       {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
-        "check_gpg": true
-      },
-      {
         "name": "mpdecimal",
         "epoch": 0,
         "version": "2.5.1",
@@ -5393,26 +4565,6 @@
         "check_gpg": true
       },
       {
-        "name": "nettle",
-        "epoch": 0,
-        "version": "3.7.3",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nettle-3.7.3-3.fc36.x86_64.rpm",
-        "checksum": "sha256:df4af8f9dd71cf93651ed0eb47a1f2cb39a6801b09ecc48b81c45300c536b153",
-        "check_gpg": true
-      },
-      {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -5420,16 +4572,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -5533,36 +4675,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -5573,16 +4685,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -5590,36 +4692,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -5640,16 +4712,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -5703,56 +4765,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -5760,36 +4772,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {
@@ -5823,16 +4805,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -5850,26 +4822,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -6023,16 +4975,6 @@
         "check_gpg": true
       },
       {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
-        "check_gpg": true
-      },
-      {
         "name": "util-linux",
         "epoch": 0,
         "version": "2.38",
@@ -6100,16 +5042,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit-boot.json
@@ -251,22 +251,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -291,47 +275,7 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -691,14 +635,6 @@
                     }
                   },
                   {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e69ef5e15c4355587435176b018d887e77e803fe8706090a1bc8258a1c99cf4",
                     "options": {
                       "metadata": {
@@ -788,14 +724,6 @@
                   },
                   {
                     "id": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -899,14 +827,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -916,14 +836,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -972,14 +884,6 @@
                   },
                   {
                     "id": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1179,14 +1083,6 @@
                     }
                   },
                   {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
                     "options": {
                       "metadata": {
@@ -1267,14 +1163,6 @@
                     }
                   },
                   {
-                    "id": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703",
                     "options": {
                       "metadata": {
@@ -1316,14 +1204,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1763,71 +1643,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1852,14 +1668,6 @@
                   },
                   {
                     "id": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1892,22 +1700,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2044,14 +1836,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6058,9 +5842,6 @@
           "sha256:310e0ea550a8eaf23bb33427988710162d7a9d0fb46b89cd1ae11da9bc18cdee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grubby-8.40-58.fc37.x86_64.rpm"
           },
-          "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
-          },
           "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
           },
@@ -6093,9 +5874,6 @@
           },
           "sha256:362aad209608a8f9509e1770d2d71971feca02f1f708eb83a35d0652c79ec36e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fedora-repos-rawhide-37-0.1.noarch.rpm"
-          },
-          "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:37383c40693c3d5ca5b82757fda27dd51734e576e88488c594eb36ad88900c0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
@@ -6181,9 +5959,6 @@
           "sha256:43747c25da3f74e4d7298a87295fd43fae1cd19f9c8306444ae41660a8435b15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/coreutils-9.0-5.fc37.x86_64.rpm"
           },
-          "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm"
           },
@@ -6229,9 +6004,6 @@
           "sha256:516db50ec0be7ed5712e5d4df4914f2e8516e00ffe3b7b37b0e943b17bc5aaeb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rsync-3.2.4-2pre3.fc37.x86_64.rpm"
           },
-          "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:51c00a1bd14a7cfd832bc9ccfdbcce209fa8a6fbb932f8f97ddee52b15491b48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
           },
@@ -6243,9 +6015,6 @@
           },
           "sha256:526749f925f29fb3232d6767d4838f7de189ea1d8c366eca1bc8e1a35a68840f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/a/aardvark-dns-1.0.1-2.fc37.x86_64.rpm"
-          },
-          "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm"
           },
           "sha256:52b0eb34a804165853a39ec93825f8865286f863766429bb2661180a90646ed4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tpm2-tools-5.2-2.fc36.x86_64.rpm"
@@ -6280,9 +6049,6 @@
           "sha256:56717547a895edbd62f4704a7f4a85c7406a196e6577aa550b3e1c87382bab24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/greenboot-0.14.0-2.fc36.x86_64.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:57674043c1fbed55f5e5343243237c130efa618e75507038be1b0d8cfc1bb46b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/clevis-luks-18-6.fc36.x86_64.rpm"
           },
@@ -6291,9 +6057,6 @@
           },
           "sha256:5800f6a5bd66f42930bb89facaccd67e10ef874298d0e5100b9bda9d1b77fea7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fwupd-1.7.6-1.fc37.x86_64.rpm"
-          },
-          "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm"
@@ -6330,9 +6093,6 @@
           },
           "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
-          },
-          "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
           },
           "sha256:6050180631c83e948c9df94d5cb0999254b0af09c5410ccecc8fbc20807497ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-config-generic-056-1.fc37.x86_64.rpm"
@@ -6469,9 +6229,6 @@
           "sha256:7890377928aafafcbda3ca47ae8b21f50fb085861cdc77602b636f844ea94f09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
           },
-          "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm"
-          },
           "sha256:795d865c4417ee6568d937c7584fa954daef08efed4c744306faa2cf89c16681": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
           },
@@ -6513,12 +6270,6 @@
           },
           "sha256:7fad2357748ffc4215ec43c99d66b658a41e1e222eb8a42055e84dd454554ff8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
-          },
-          "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm"
-          },
-          "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm"
           },
           "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm"
@@ -6570,9 +6321,6 @@
           },
           "sha256:89197e09377e38f1706e687ba5e88c840bfd2107ca8cb700af96972cb36cfea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/sqlite-libs-3.38.1-1.fc37.x86_64.rpm"
-          },
-          "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm"
@@ -6784,9 +6532,6 @@
           "sha256:b60e3dcf86d85f433d1ce39bb9fe08402b18e30e080ca1976348a6a5a37ef016": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mokutil-0.5.0-2.fc36.x86_64.rpm"
           },
-          "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:b9ab52ac0447416503601a0834eb8aededbac7ec50cb2f49ae83b34a86d821fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
           },
@@ -6844,14 +6589,8 @@
           "sha256:c2f1617fdcc69ef3b9a76b2950854631c7259df3c68943982bac47d3b9dd2a1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/oniguruma-6.9.7.1-1.fc36.2.x86_64.rpm"
           },
-          "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm"
-          },
           "sha256:c354eb4c52dc900b8b6f5ca77b8f51e0468597e72f15619876498d15a4cf54b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iwl2030-firmware-18.168.6.1-130.fc37.noarch.rpm"
-          },
-          "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm"
           },
           "sha256:c5f06a61788f047447109570b5a4e3cd362cda81c17ae49889d6e5680fafec54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/elfutils-libs-0.186-1.fc36.x86_64.rpm"
@@ -6928,17 +6667,8 @@
           "sha256:d566b1edbe7f4ee9edad651f1a1747aa6eec0d3dcf99841618631447c991fd22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
           },
-          "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:d605af2be4ab8c161a00a1bdf11301ac9f91fb995cf8f917da30f5293472d835": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/crypto-policies-20220203-2.git112f859.fc36.noarch.rpm"
-          },
-          "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm"
-          },
-          "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
           },
           "sha256:d83fc9f5ec66db76ec07f6db9267d041d248895bc1fe2043ae01259512bd3e71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nftables-1.0.1-4.fc37.x86_64.rpm"
@@ -7149,9 +6879,6 @@
           },
           "sha256:fda15ee4d238c6ef258397d67128709986393bec9b2061dc4dbf620af8964682": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnsmasq-2.86-6.fc37.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:fee330aeb273fa504f1d3185dd574de6cc706f387025c9867c423da23214dc76": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nss-util-3.75.0-1.fc36.x86_64.rpm"
@@ -7442,26 +7169,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7492,36 +7199,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
-        "checksum": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -7529,26 +7206,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-056-1.fc37.x86_64.rpm",
         "checksum": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
         "check_gpg": true
       },
       {
@@ -7992,16 +7649,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -8119,16 +7766,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
         "checksum": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
         "check_gpg": true
       },
       {
@@ -8252,16 +7889,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -8279,16 +7906,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -8349,16 +7966,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfido2-1.10.0-3.fc37.x86_64.rpm",
         "checksum": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
         "check_gpg": true
       },
       {
@@ -8602,16 +8209,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8712,16 +8309,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -8779,16 +8366,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
         "check_gpg": true
       },
       {
@@ -9332,56 +8909,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -9389,36 +8916,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {
@@ -9449,16 +8946,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
         "check_gpg": true
       },
       {
@@ -9499,26 +8986,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -9689,16 +9156,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_commit_debug-boot.json
@@ -257,22 +257,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -297,47 +281,7 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -697,14 +641,6 @@
                     }
                   },
                   {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e69ef5e15c4355587435176b018d887e77e803fe8706090a1bc8258a1c99cf4",
                     "options": {
                       "metadata": {
@@ -794,14 +730,6 @@
                   },
                   {
                     "id": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -905,14 +833,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -922,14 +842,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -978,14 +890,6 @@
                   },
                   {
                     "id": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1185,14 +1089,6 @@
                     }
                   },
                   {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
                     "options": {
                       "metadata": {
@@ -1273,14 +1169,6 @@
                     }
                   },
                   {
-                    "id": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703",
                     "options": {
                       "metadata": {
@@ -1322,14 +1210,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1769,71 +1649,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1858,14 +1674,6 @@
                   },
                   {
                     "id": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1898,22 +1706,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2050,14 +1842,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6061,9 +5845,6 @@
           "sha256:310e0ea550a8eaf23bb33427988710162d7a9d0fb46b89cd1ae11da9bc18cdee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grubby-8.40-58.fc37.x86_64.rpm"
           },
-          "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
-          },
           "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
           },
@@ -6096,9 +5877,6 @@
           },
           "sha256:362aad209608a8f9509e1770d2d71971feca02f1f708eb83a35d0652c79ec36e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fedora-repos-rawhide-37-0.1.noarch.rpm"
-          },
-          "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:37383c40693c3d5ca5b82757fda27dd51734e576e88488c594eb36ad88900c0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
@@ -6184,9 +5962,6 @@
           "sha256:43747c25da3f74e4d7298a87295fd43fae1cd19f9c8306444ae41660a8435b15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/coreutils-9.0-5.fc37.x86_64.rpm"
           },
-          "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm"
           },
@@ -6232,9 +6007,6 @@
           "sha256:516db50ec0be7ed5712e5d4df4914f2e8516e00ffe3b7b37b0e943b17bc5aaeb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rsync-3.2.4-2pre3.fc37.x86_64.rpm"
           },
-          "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:51c00a1bd14a7cfd832bc9ccfdbcce209fa8a6fbb932f8f97ddee52b15491b48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
           },
@@ -6246,9 +6018,6 @@
           },
           "sha256:526749f925f29fb3232d6767d4838f7de189ea1d8c366eca1bc8e1a35a68840f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/a/aardvark-dns-1.0.1-2.fc37.x86_64.rpm"
-          },
-          "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm"
           },
           "sha256:52b0eb34a804165853a39ec93825f8865286f863766429bb2661180a90646ed4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tpm2-tools-5.2-2.fc36.x86_64.rpm"
@@ -6283,9 +6052,6 @@
           "sha256:56717547a895edbd62f4704a7f4a85c7406a196e6577aa550b3e1c87382bab24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/greenboot-0.14.0-2.fc36.x86_64.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:57674043c1fbed55f5e5343243237c130efa618e75507038be1b0d8cfc1bb46b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/clevis-luks-18-6.fc36.x86_64.rpm"
           },
@@ -6294,9 +6060,6 @@
           },
           "sha256:5800f6a5bd66f42930bb89facaccd67e10ef874298d0e5100b9bda9d1b77fea7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fwupd-1.7.6-1.fc37.x86_64.rpm"
-          },
-          "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm"
@@ -6333,9 +6096,6 @@
           },
           "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
-          },
-          "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
           },
           "sha256:6050180631c83e948c9df94d5cb0999254b0af09c5410ccecc8fbc20807497ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-config-generic-056-1.fc37.x86_64.rpm"
@@ -6472,9 +6232,6 @@
           "sha256:7890377928aafafcbda3ca47ae8b21f50fb085861cdc77602b636f844ea94f09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
           },
-          "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm"
-          },
           "sha256:795d865c4417ee6568d937c7584fa954daef08efed4c744306faa2cf89c16681": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
           },
@@ -6516,12 +6273,6 @@
           },
           "sha256:7fad2357748ffc4215ec43c99d66b658a41e1e222eb8a42055e84dd454554ff8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
-          },
-          "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm"
-          },
-          "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm"
           },
           "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm"
@@ -6573,9 +6324,6 @@
           },
           "sha256:89197e09377e38f1706e687ba5e88c840bfd2107ca8cb700af96972cb36cfea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/sqlite-libs-3.38.1-1.fc37.x86_64.rpm"
-          },
-          "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm"
@@ -6787,9 +6535,6 @@
           "sha256:b60e3dcf86d85f433d1ce39bb9fe08402b18e30e080ca1976348a6a5a37ef016": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mokutil-0.5.0-2.fc36.x86_64.rpm"
           },
-          "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:b9ab52ac0447416503601a0834eb8aededbac7ec50cb2f49ae83b34a86d821fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
           },
@@ -6847,14 +6592,8 @@
           "sha256:c2f1617fdcc69ef3b9a76b2950854631c7259df3c68943982bac47d3b9dd2a1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/oniguruma-6.9.7.1-1.fc36.2.x86_64.rpm"
           },
-          "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm"
-          },
           "sha256:c354eb4c52dc900b8b6f5ca77b8f51e0468597e72f15619876498d15a4cf54b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iwl2030-firmware-18.168.6.1-130.fc37.noarch.rpm"
-          },
-          "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm"
           },
           "sha256:c5f06a61788f047447109570b5a4e3cd362cda81c17ae49889d6e5680fafec54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/elfutils-libs-0.186-1.fc36.x86_64.rpm"
@@ -6931,17 +6670,8 @@
           "sha256:d566b1edbe7f4ee9edad651f1a1747aa6eec0d3dcf99841618631447c991fd22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
           },
-          "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:d605af2be4ab8c161a00a1bdf11301ac9f91fb995cf8f917da30f5293472d835": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/crypto-policies-20220203-2.git112f859.fc36.noarch.rpm"
-          },
-          "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm"
-          },
-          "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
           },
           "sha256:d83fc9f5ec66db76ec07f6db9267d041d248895bc1fe2043ae01259512bd3e71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nftables-1.0.1-4.fc37.x86_64.rpm"
@@ -7155,9 +6885,6 @@
           },
           "sha256:fda15ee4d238c6ef258397d67128709986393bec9b2061dc4dbf620af8964682": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnsmasq-2.86-6.fc37.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:fee330aeb273fa504f1d3185dd574de6cc706f387025c9867c423da23214dc76": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nss-util-3.75.0-1.fc36.x86_64.rpm"
@@ -7448,26 +7175,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7498,36 +7205,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
-        "checksum": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -7535,26 +7212,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-056-1.fc37.x86_64.rpm",
         "checksum": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
         "check_gpg": true
       },
       {
@@ -7998,16 +7655,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -8125,16 +7772,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
         "checksum": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
         "check_gpg": true
       },
       {
@@ -8258,16 +7895,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -8285,16 +7912,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -8355,16 +7972,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfido2-1.10.0-3.fc37.x86_64.rpm",
         "checksum": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
         "check_gpg": true
       },
       {
@@ -8608,16 +8215,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8718,16 +8315,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -8785,16 +8372,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
         "check_gpg": true
       },
       {
@@ -9338,56 +8915,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -9395,36 +8922,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {
@@ -9455,16 +8952,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
         "check_gpg": true
       },
       {
@@ -9505,26 +8992,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -9695,16 +9162,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_container-boot.json
@@ -251,22 +251,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -291,47 +275,7 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -691,14 +635,6 @@
                     }
                   },
                   {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6e69ef5e15c4355587435176b018d887e77e803fe8706090a1bc8258a1c99cf4",
                     "options": {
                       "metadata": {
@@ -788,14 +724,6 @@
                   },
                   {
                     "id": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -899,14 +827,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -916,14 +836,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -972,14 +884,6 @@
                   },
                   {
                     "id": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1179,14 +1083,6 @@
                     }
                   },
                   {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
                     "options": {
                       "metadata": {
@@ -1267,14 +1163,6 @@
                     }
                   },
                   {
-                    "id": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703",
                     "options": {
                       "metadata": {
@@ -1316,14 +1204,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1763,71 +1643,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1852,14 +1668,6 @@
                   },
                   {
                     "id": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1892,22 +1700,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2044,14 +1836,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7569,9 +7353,6 @@
           "sha256:310e0ea550a8eaf23bb33427988710162d7a9d0fb46b89cd1ae11da9bc18cdee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grubby-8.40-58.fc37.x86_64.rpm"
           },
-          "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
-          },
           "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
           },
@@ -7604,9 +7385,6 @@
           },
           "sha256:362aad209608a8f9509e1770d2d71971feca02f1f708eb83a35d0652c79ec36e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fedora-repos-rawhide-37-0.1.noarch.rpm"
-          },
-          "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:37383c40693c3d5ca5b82757fda27dd51734e576e88488c594eb36ad88900c0e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
@@ -7695,9 +7473,6 @@
           "sha256:43747c25da3f74e4d7298a87295fd43fae1cd19f9c8306444ae41660a8435b15": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/coreutils-9.0-5.fc37.x86_64.rpm"
           },
-          "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:45d7bed87c83512634879d2519527be7c5184c2d516d146654abeb7d4907c09c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/grub2-pc-2.06-28.fc37.x86_64.rpm"
           },
@@ -7746,9 +7521,6 @@
           "sha256:516db50ec0be7ed5712e5d4df4914f2e8516e00ffe3b7b37b0e943b17bc5aaeb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rsync-3.2.4-2pre3.fc37.x86_64.rpm"
           },
-          "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:51c00a1bd14a7cfd832bc9ccfdbcce209fa8a6fbb932f8f97ddee52b15491b48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
           },
@@ -7760,9 +7532,6 @@
           },
           "sha256:526749f925f29fb3232d6767d4838f7de189ea1d8c366eca1bc8e1a35a68840f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/a/aardvark-dns-1.0.1-2.fc37.x86_64.rpm"
-          },
-          "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm"
           },
           "sha256:52b0eb34a804165853a39ec93825f8865286f863766429bb2661180a90646ed4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tpm2-tools-5.2-2.fc36.x86_64.rpm"
@@ -7797,9 +7566,6 @@
           "sha256:56717547a895edbd62f4704a7f4a85c7406a196e6577aa550b3e1c87382bab24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/greenboot-0.14.0-2.fc36.x86_64.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:57674043c1fbed55f5e5343243237c130efa618e75507038be1b0d8cfc1bb46b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/clevis-luks-18-6.fc36.x86_64.rpm"
           },
@@ -7808,9 +7574,6 @@
           },
           "sha256:5800f6a5bd66f42930bb89facaccd67e10ef874298d0e5100b9bda9d1b77fea7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/f/fwupd-1.7.6-1.fc37.x86_64.rpm"
-          },
-          "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm"
@@ -7850,9 +7613,6 @@
           },
           "sha256:5faf8ab4b0a35f89b2d3de33e69b7ef6f89255095b3bc8e432287e6ce6daa703": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
-          },
-          "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
           },
           "sha256:6050180631c83e948c9df94d5cb0999254b0af09c5410ccecc8fbc20807497ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-config-generic-056-1.fc37.x86_64.rpm"
@@ -7992,9 +7752,6 @@
           "sha256:7890377928aafafcbda3ca47ae8b21f50fb085861cdc77602b636f844ea94f09": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
           },
-          "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm"
-          },
           "sha256:795d865c4417ee6568d937c7584fa954daef08efed4c744306faa2cf89c16681": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
           },
@@ -8036,12 +7793,6 @@
           },
           "sha256:7fad2357748ffc4215ec43c99d66b658a41e1e222eb8a42055e84dd454554ff8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
-          },
-          "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm"
-          },
-          "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm"
           },
           "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm"
@@ -8093,9 +7844,6 @@
           },
           "sha256:89197e09377e38f1706e687ba5e88c840bfd2107ca8cb700af96972cb36cfea6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/s/sqlite-libs-3.38.1-1.fc37.x86_64.rpm"
-          },
-          "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm"
           },
           "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm"
@@ -8313,9 +8061,6 @@
           "sha256:b60e3dcf86d85f433d1ce39bb9fe08402b18e30e080ca1976348a6a5a37ef016": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mokutil-0.5.0-2.fc36.x86_64.rpm"
           },
-          "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm"
-          },
           "sha256:b9ab52ac0447416503601a0834eb8aededbac7ec50cb2f49ae83b34a86d821fc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
           },
@@ -8373,14 +8118,8 @@
           "sha256:c2f1617fdcc69ef3b9a76b2950854631c7259df3c68943982bac47d3b9dd2a1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/oniguruma-6.9.7.1-1.fc36.2.x86_64.rpm"
           },
-          "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm"
-          },
           "sha256:c354eb4c52dc900b8b6f5ca77b8f51e0468597e72f15619876498d15a4cf54b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iwl2030-firmware-18.168.6.1-130.fc37.noarch.rpm"
-          },
-          "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm"
           },
           "sha256:c5f06a61788f047447109570b5a4e3cd362cda81c17ae49889d6e5680fafec54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/elfutils-libs-0.186-1.fc36.x86_64.rpm"
@@ -8457,17 +8196,8 @@
           "sha256:d566b1edbe7f4ee9edad651f1a1747aa6eec0d3dcf99841618631447c991fd22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
           },
-          "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm"
-          },
           "sha256:d605af2be4ab8c161a00a1bdf11301ac9f91fb995cf8f917da30f5293472d835": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/c/crypto-policies-20220203-2.git112f859.fc36.noarch.rpm"
-          },
-          "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm"
-          },
-          "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
           },
           "sha256:d83fc9f5ec66db76ec07f6db9267d041d248895bc1fe2043ae01259512bd3e71": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nftables-1.0.1-4.fc37.x86_64.rpm"
@@ -8684,9 +8414,6 @@
           },
           "sha256:fda15ee4d238c6ef258397d67128709986393bec9b2061dc4dbf620af8964682": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnsmasq-2.86-6.fc37.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:fee330aeb273fa504f1d3185dd574de6cc706f387025c9867c423da23214dc76": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nss-util-3.75.0-1.fc36.x86_64.rpm"
@@ -8977,26 +8704,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -9027,36 +8734,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
-        "check_gpg": true
-      },
-      {
-        "name": "dosfstools",
-        "epoch": 0,
-        "version": "4.2",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
-        "checksum": "sha256:381b19a26bb015f90280580e6a821505e976ae5f057bf85fed8cca88845cdb77",
-        "check_gpg": true
-      },
-      {
         "name": "dracut",
         "epoch": 0,
         "version": "056",
@@ -9064,26 +8741,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dracut-056-1.fc37.x86_64.rpm",
         "checksum": "sha256:82cdca13a5e2316a3a7531160681641cc656161b11cebcd9198a3adbef155280",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:f7aca592bd1b9c04b58b64967f3cb4c6212e567df30ee0ef0ac2ee169f9e2d0d",
-        "check_gpg": true
-      },
-      {
-        "name": "e2fsprogs-libs",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:1065beb6e4d990fc01d0ea5361020606fa24bc8fe29a1f2247afd6f521ab9ff5",
         "check_gpg": true
       },
       {
@@ -9527,16 +9184,6 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -9654,16 +9301,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
         "checksum": "sha256:b480e8f067e7d34ed07f614452c102d4c23d0d683b8a68535c0035d45294517a",
-        "check_gpg": true
-      },
-      {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
         "check_gpg": true
       },
       {
@@ -9787,16 +9424,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -9814,16 +9441,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -9884,16 +9501,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfido2-1.10.0-3.fc37.x86_64.rpm",
         "checksum": "sha256:cc50c7b024c6d45c9226c7402bedff5f7582b23e9406e410b60c3664eee5e692",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
         "check_gpg": true
       },
       {
@@ -10137,16 +9744,6 @@
         "check_gpg": true
       },
       {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -10247,16 +9844,6 @@
         "check_gpg": true
       },
       {
-        "name": "libss",
-        "epoch": 0,
-        "version": "1.46.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:fd01a9eeb1e7e937652aae79ef451c70f3d73f5fef17725592966d1fae9d3cb1",
-        "check_gpg": true
-      },
-      {
         "name": "libssh",
         "epoch": 0,
         "version": "0.9.6",
@@ -10314,16 +9901,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
         "check_gpg": true
       },
       {
@@ -10867,56 +10444,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -10924,36 +10451,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {
@@ -10984,16 +10481,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:34ee4caa32c08a7b0c3e8c42f38712765bbd0d008808d5ed1711946c76df1144",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
         "check_gpg": true
       },
       {
@@ -11034,26 +10521,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -11224,16 +10691,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_installer-boot.json
@@ -297,14 +297,6 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
@@ -905,14 +897,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca678e16c32fe14846114ba1c27d59b67c474b6b97f39c3f82c5392660d4b2e4",
                     "options": {
                       "metadata": {
@@ -1482,14 +1466,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2226,14 +2202,6 @@
                   },
                   {
                     "id": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -11966,9 +11934,6 @@
           "sha256:573078ea55cf0e1a58dc29c75b1f72d6ddebf14ff6539d7da6a96e1cbae2190d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/perl-File-Temp-0.231.100-479.fc36.noarch.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:5768d2860adfb7798fa048a10053d151b0ce3916f522b6358d11cbb5c86f2a65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iproute-5.17.0-1.fc37.x86_64.rpm"
           },
@@ -13891,9 +13856,6 @@
           },
           "sha256:fd03c888a957d6e2b4c8b8e2270ee57c282df70d621102810aad37fa79ec95c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:fee330aeb273fa504f1d3185dd574de6cc706f387025c9867c423da23214dc76": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nss-util-3.75.0-1.fc36.x86_64.rpm"
@@ -24233,16 +24195,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.11.1",
@@ -24993,16 +24945,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.0",
@@ -25720,16 +25662,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
         "check_gpg": true
       },
       {
@@ -26650,16 +26582,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-urllib3-1.26.8-2.fc36.noarch.rpm",
         "checksum": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_installer_with_users-boot.json
@@ -326,14 +326,6 @@
                     }
                   },
                   {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
@@ -934,14 +926,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:ca678e16c32fe14846114ba1c27d59b67c474b6b97f39c3f82c5392660d4b2e4",
                     "options": {
                       "metadata": {
@@ -1511,14 +1495,6 @@
                   },
                   {
                     "id": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -2255,14 +2231,6 @@
                   },
                   {
                     "id": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -12018,9 +11986,6 @@
           "sha256:573078ea55cf0e1a58dc29c75b1f72d6ddebf14ff6539d7da6a96e1cbae2190d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/perl-File-Temp-0.231.100-479.fc36.noarch.rpm"
           },
-          "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm"
-          },
           "sha256:5768d2860adfb7798fa048a10053d151b0ce3916f522b6358d11cbb5c86f2a65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/iproute-5.17.0-1.fc37.x86_64.rpm"
           },
@@ -13943,9 +13908,6 @@
           },
           "sha256:fd03c888a957d6e2b4c8b8e2270ee57c282df70d621102810aad37fa79ec95c6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
-          },
-          "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm"
           },
           "sha256:fee330aeb273fa504f1d3185dd574de6cc706f387025c9867c423da23214dc76": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/nss-util-3.75.0-1.fc36.x86_64.rpm"
@@ -24285,16 +24247,6 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
         "name": "dnf-data",
         "epoch": 0,
         "version": "4.11.1",
@@ -25045,16 +24997,6 @@
         "check_gpg": true
       },
       {
-        "name": "libaio",
-        "epoch": 0,
-        "version": "0.3.111",
-        "release": "13.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libaio-0.3.111-13.fc36.x86_64.rpm",
-        "checksum": "sha256:1193d714b5bc5f3212b2f4ec6a9cbeb85ea7f88ea2a38d817354543e35f122ef",
-        "check_gpg": true
-      },
-      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.6.0",
@@ -25772,16 +25714,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
         "checksum": "sha256:325d3cdf0db2867b4fe2c3789084f1b579cf8f0a2ccb99606286e06cb2016a96",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/liburing-2.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:fe124f5d7fe40dc14304ff5ab31e6593458d3dcf0278da0e080fee4438c06c6c",
         "check_gpg": true
       },
       {
@@ -26702,16 +26634,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-urllib3-1.26.8-2.fc36.noarch.rpm",
         "checksum": "sha256:d095a8e1f18bf89caebe49bd25a7d10cc28dfe6e2c475f0eb08d06d43f89a4d4",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-img",
-        "epoch": 2,
-        "version": "6.2.0",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/q/qemu-img-6.2.0-5.fc37.x86_64.rpm",
-        "checksum": "sha256:5739c39b512119917acdafd53fcfad106b8a939515618c8d5e9dcf8acfe06e17",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-oci-boot.json
@@ -195,22 +195,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -228,22 +212,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -507,31 +475,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -596,14 +540,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -707,14 +643,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -779,14 +707,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -796,14 +716,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -851,14 +763,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -891,14 +795,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -916,22 +812,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -979,31 +859,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1052,14 +908,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1131,14 +979,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1195,14 +1035,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1236,14 +1068,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1291,23 +1115,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1395,30 +1203,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1427,39 +1211,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1476,14 +1228,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1531,63 +1275,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1627,14 +1315,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1644,22 +1324,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1763,14 +1427,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1780,14 +1436,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1844,14 +1492,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6536,26 +6176,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6583,26 +6203,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -6926,26 +6526,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -6953,16 +6533,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -7043,16 +6613,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -7176,16 +6736,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7266,16 +6816,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7293,16 +6833,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7356,16 +6886,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7406,16 +6926,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7443,26 +6953,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7516,26 +7006,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7543,16 +7013,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7613,16 +7073,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7706,16 +7156,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7786,16 +7226,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -7843,16 +7273,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -7906,16 +7326,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -7923,16 +7333,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -8036,36 +7436,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8076,16 +7446,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8093,36 +7453,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8143,16 +7473,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8206,56 +7526,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8263,26 +7533,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8326,16 +7576,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8353,26 +7593,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8496,16 +7716,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8523,16 +7733,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8603,16 +7803,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-openstack-boot.json
@@ -212,22 +212,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -245,22 +229,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -524,31 +492,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -613,14 +557,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -724,14 +660,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -796,14 +724,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -813,14 +733,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -868,14 +780,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -908,14 +812,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -933,22 +829,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -996,31 +876,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1069,14 +925,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1148,14 +996,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1212,14 +1052,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1253,14 +1085,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1308,23 +1132,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1412,30 +1220,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1444,39 +1228,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1493,14 +1245,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1548,63 +1292,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1644,14 +1332,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1661,22 +1341,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1780,14 +1444,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1797,14 +1453,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1861,14 +1509,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6102,9 +5742,6 @@
           "sha256:979823a3ec28bd2c523f43140c5f7d863e0606395ba5d7316da6ce75ec83c4ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-charset-normalizer-2.0.12-1.fc37.noarch.rpm"
           },
-          "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm"
-          },
           "sha256:9801b2631f15ec5e8b86a8cc4d2142124723e73fb4c107a17a6841ecba381411": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/parted-3.4-12.fc37.x86_64.rpm"
           },
@@ -6765,26 +6402,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6812,26 +6429,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -7155,26 +6752,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -7182,16 +6759,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -7272,16 +6839,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -7405,16 +6962,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7495,16 +7042,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7522,16 +7059,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7585,16 +7112,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7635,16 +7152,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7672,26 +7179,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7745,26 +7232,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7772,16 +7239,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7842,16 +7299,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7935,16 +7382,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8015,16 +7452,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8072,16 +7499,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -8135,16 +7552,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -8152,16 +7559,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -8265,36 +7662,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8305,16 +7672,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8322,36 +7679,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8372,16 +7699,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8435,56 +7752,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8492,26 +7759,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8555,16 +7802,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8582,26 +7819,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8725,16 +7942,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8752,16 +7959,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8832,16 +8029,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -242,22 +226,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,31 +489,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -610,14 +554,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -793,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -810,14 +730,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -865,14 +777,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -905,14 +809,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -930,22 +826,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -993,31 +873,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1066,14 +922,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1145,14 +993,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1209,14 +1049,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1250,14 +1082,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1305,23 +1129,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1409,30 +1217,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1441,39 +1225,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1490,14 +1242,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1545,63 +1289,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1641,14 +1329,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1658,22 +1338,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1777,14 +1441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1794,14 +1450,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1858,14 +1506,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6560,26 +6200,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6607,26 +6227,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -6950,26 +6550,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -6977,16 +6557,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -7067,16 +6637,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -7200,16 +6760,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7290,16 +6840,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7317,16 +6857,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7380,16 +6910,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7430,16 +6950,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7467,26 +6977,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7540,26 +7030,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7567,16 +7037,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7637,16 +7097,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7730,16 +7180,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7810,16 +7250,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -7867,16 +7297,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -7930,16 +7350,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -7947,16 +7357,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -8060,36 +7460,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8100,16 +7470,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8117,36 +7477,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8167,16 +7497,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8230,56 +7550,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8287,26 +7557,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8350,16 +7600,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8377,26 +7617,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8520,16 +7740,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8547,16 +7757,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8627,16 +7827,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
@@ -273,23 +273,23 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a44e9df5bdf95cafe191a9601bb3920761bd7f1afb2e1d0c6e6a5ca54518417b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aaa63bbe96d683e4a307fdabc233d20c71f00331c58b614407ec933c8ba8649a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -305,23 +305,15 @@
                     }
                   },
                   {
+                    "id": "sha256:0667c0a226e9d310fb872faa9c0283a80cb70696b0b3d037bcce461b7f5845dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -585,31 +577,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -681,7 +649,7 @@
                     }
                   },
                   {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
+                    "id": "sha256:ed9ede93088ccb1c3e38c225446d6ba41e28ad6b2fc19736e82c1dc61b2814cb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -785,14 +753,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -857,14 +817,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -881,7 +833,7 @@
                     }
                   },
                   {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
+                    "id": "sha256:f13d283ae5ab9a77e6873d4ac271135852794d7936a6905e9b3604c52a6c1445",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -889,7 +841,7 @@
                     }
                   },
                   {
-                    "id": "sha256:f13d283ae5ab9a77e6873d4ac271135852794d7936a6905e9b3604c52a6c1445",
+                    "id": "sha256:52c21c4797fbcf82e14915d91d784956b8ccc5a9b10438f0b75f73f0d716e0f0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -929,14 +881,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -969,14 +913,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -994,22 +930,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1057,31 +977,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1130,14 +1026,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1209,14 +1097,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1273,14 +1153,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1290,6 +1162,22 @@
                   },
                   {
                     "id": "sha256:18ae3d633edc0433c9c3571a6c808ae32903817cbd8de5bf0018e442486a4a7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:548a1e144bcf7ee0990749749db17fcd1f111d22935389b7592ea4b06b4f5973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98a952ca4eca7d0fb7cfbc5999b01938a3a7cce9bf45829f27c9a74e39ec5d1",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1314,14 +1202,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1369,23 +1249,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1473,30 +1337,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1505,39 +1345,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1554,14 +1362,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1609,63 +1409,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1705,14 +1449,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1722,22 +1458,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1841,14 +1561,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1865,7 +1577,7 @@
                     }
                   },
                   {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
+                    "id": "sha256:2c36bc87d4658acc293fdedca348a4c11375a2ddaa2ccb903669e7d369ef3d92",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1905,6 +1617,14 @@
                     }
                   },
                   {
+                    "id": "sha256:03717a161a67bf3e52a54db8bb52ebc8d94c4d36b67883df667c74ded0c20c5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9d4abf661fa90e195280e6ee773d5bb1681250ce35c34ee6a47e6009c80b87d3",
                     "options": {
                       "metadata": {
@@ -1922,14 +1642,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7083,26 +6795,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -7110,6 +6802,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
         "checksum": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/device-mapper-event-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:a44e9df5bdf95cafe191a9601bb3920761bd7f1afb2e1d0c6e6a5ca54518417b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/device-mapper-event-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:aaa63bbe96d683e4a307fdabc233d20c71f00331c58b614407ec933c8ba8649a",
         "check_gpg": true
       },
       {
@@ -7123,6 +6835,16 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/device-mapper-persistent-data-0.9.0-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0667c0a226e9d310fb872faa9c0283a80cb70696b0b3d037bcce461b7f5845dc",
+        "check_gpg": true
+      },
+      {
         "name": "diffutils",
         "epoch": 0,
         "version": "3.8",
@@ -7130,26 +6852,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -7473,26 +7175,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -7500,16 +7182,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -7593,13 +7265,13 @@
         "check_gpg": true
       },
       {
-        "name": "ima-evm-utils",
+        "name": "inih",
         "epoch": 0,
-        "version": "1.4",
+        "version": "49",
         "release": "5.fc36",
         "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/inih-49-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ed9ede93088ccb1c3e38c225446d6ba41e28ad6b2fc19736e82c1dc61b2814cb",
         "check_gpg": true
       },
       {
@@ -7723,16 +7395,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7813,16 +7475,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7843,16 +7495,6 @@
         "check_gpg": true
       },
       {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
-        "check_gpg": true
-      },
-      {
         "name": "libeconf",
         "epoch": 0,
         "version": "0.4.0",
@@ -7860,6 +7502,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
         "checksum": "sha256:f13d283ae5ab9a77e6873d4ac271135852794d7936a6905e9b3604c52a6c1445",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm",
+        "checksum": "sha256:52c21c4797fbcf82e14915d91d784956b8ccc5a9b10438f0b75f73f0d716e0f0",
         "check_gpg": true
       },
       {
@@ -7903,16 +7555,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7953,16 +7595,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7990,26 +7622,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -8063,26 +7675,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -8090,16 +7682,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -8160,16 +7742,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -8253,16 +7825,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -8333,16 +7895,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -8360,6 +7912,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
         "checksum": "sha256:18ae3d633edc0433c9c3571a6c808ae32903817cbd8de5bf0018e442486a4a7e",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lvm2-2.03.11-7.fc36.x86_64.rpm",
+        "checksum": "sha256:548a1e144bcf7ee0990749749db17fcd1f111d22935389b7592ea4b06b4f5973",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/lvm2-libs-2.03.11-7.fc36.x86_64.rpm",
+        "checksum": "sha256:c98a952ca4eca7d0fb7cfbc5999b01938a3a7cce9bf45829f27c9a74e39ec5d1",
         "check_gpg": true
       },
       {
@@ -8390,16 +7962,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -8453,16 +8015,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -8470,16 +8022,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -8583,36 +8125,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8623,16 +8135,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8640,36 +8142,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8690,16 +8162,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8753,56 +8215,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8810,26 +8222,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8873,16 +8265,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8900,26 +8282,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -9043,16 +8405,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -9073,13 +8425,13 @@
         "check_gpg": true
       },
       {
-        "name": "unbound-libs",
+        "name": "userspace-rcu",
         "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
+        "version": "0.13.0",
+        "release": "4.fc36",
         "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:2c36bc87d4658acc293fdedca348a4c11375a2ddaa2ccb903669e7d369ef3d92",
         "check_gpg": true
       },
       {
@@ -9123,6 +8475,16 @@
         "check_gpg": true
       },
       {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:03717a161a67bf3e52a54db8bb52ebc8d94c4d36b67883df667c74ded0c20c5c",
+        "check_gpg": true
+      },
+      {
         "name": "xkeyboard-config",
         "epoch": 0,
         "version": "2.35.1",
@@ -9150,16 +8512,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vhd-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -242,22 +226,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,31 +489,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -610,14 +554,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -793,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -810,14 +730,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -865,14 +777,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -905,14 +809,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -930,22 +826,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -993,31 +873,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1066,14 +922,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1145,14 +993,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1209,14 +1049,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1250,14 +1082,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1305,23 +1129,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1409,30 +1217,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1441,39 +1225,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1490,14 +1242,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1545,63 +1289,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1641,14 +1329,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1658,22 +1338,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1777,14 +1441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1794,14 +1450,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1858,14 +1506,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5641,9 +5281,6 @@
           "sha256:96bc38943691e2da6237751cf67bee103abc94cd6c623edd1f2f1290ce59941a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm"
           },
-          "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm"
-          },
           "sha256:9801b2631f15ec5e8b86a8cc4d2142124723e73fb4c107a17a6841ecba381411": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/parted-3.4-12.fc37.x86_64.rpm"
           },
@@ -6250,26 +5887,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6297,26 +5914,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -6640,26 +6237,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -6667,16 +6244,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -6757,16 +6324,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -6890,16 +6447,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -6980,16 +6527,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7007,16 +6544,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7070,16 +6597,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7120,16 +6637,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7157,26 +6664,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7230,26 +6717,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7257,16 +6724,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7327,16 +6784,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7420,16 +6867,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7500,16 +6937,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -7557,16 +6984,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -7620,16 +7037,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -7637,16 +7044,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -7750,36 +7147,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -7790,16 +7157,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -7807,36 +7164,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -7857,16 +7184,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -7920,56 +7237,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -7977,26 +7244,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8040,16 +7287,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8067,26 +7304,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8210,16 +7427,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8237,16 +7444,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8317,16 +7514,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
@@ -209,22 +209,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:2d4c679bc38f6fa0a01091802f141c5bd8e4f5c16d7f15384c7c5e183c95884d",
                     "options": {
                       "metadata": {
@@ -242,22 +226,6 @@
                   },
                   {
                     "id": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -521,31 +489,7 @@
                     }
                   },
                   {
-                    "id": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -610,14 +554,6 @@
                   },
                   {
                     "id": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -721,14 +657,6 @@
                     }
                   },
                   {
-                    "id": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:efa8bf099623032179c01418799e3ec5f32ed2aa2471f0081bd662ee4795c4cf",
                     "options": {
                       "metadata": {
@@ -793,14 +721,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d1bdb4b65f716accfdab6b670692fc7b7bc4f597bae0086c284437ef64a3b5d3",
                     "options": {
                       "metadata": {
@@ -810,14 +730,6 @@
                   },
                   {
                     "id": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -865,14 +777,6 @@
                     }
                   },
                   {
-                    "id": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:006c76d12baf00c8fc0d7454be3df1e27c5f26b54a366ec98d7140a87efc1dc6",
                     "options": {
                       "metadata": {
@@ -905,14 +809,6 @@
                     }
                   },
                   {
-                    "id": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:70175b9fff0b73fff2faab91486d43dd7d3730a9f7a98d972e136edcc4cc6d6a",
                     "options": {
                       "metadata": {
@@ -930,22 +826,6 @@
                   },
                   {
                     "id": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -993,31 +873,7 @@
                     }
                   },
                   {
-                    "id": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1066,14 +922,6 @@
                   },
                   {
                     "id": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1145,14 +993,6 @@
                     }
                   },
                   {
-                    "id": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:1cd991445efde2b5459f3857d0bc0263526ef26d6c9e83942443c9fe290f0635",
                     "options": {
                       "metadata": {
@@ -1209,14 +1049,6 @@
                     }
                   },
                   {
-                    "id": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d11832397ce1768d171d129ee7e1ccbb85ab0d0a3f3fe1578095cdb84c48c12c",
                     "options": {
                       "metadata": {
@@ -1250,14 +1082,6 @@
                   },
                   {
                     "id": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1305,23 +1129,7 @@
                     }
                   },
                   {
-                    "id": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1409,30 +1217,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:6efefecae57089d22767ea376d901b17acec04c1bba0ce50a406a29417c3c5ef",
                     "options": {
                       "metadata": {
@@ -1441,39 +1225,7 @@
                     }
                   },
                   {
-                    "id": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1490,14 +1242,6 @@
                   },
                   {
                     "id": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1545,63 +1289,7 @@
                     }
                   },
                   {
-                    "id": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1641,14 +1329,6 @@
                     }
                   },
                   {
-                    "id": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:df3d71a3e62f08d14901aa206a4f66e7642722c7b389bd14e822b1e14a50d0fd",
                     "options": {
                       "metadata": {
@@ -1658,22 +1338,6 @@
                   },
                   {
                     "id": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1777,14 +1441,6 @@
                     }
                   },
                   {
-                    "id": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:15c74e72594df409d68a2bbdd7c7b5f1d6cf61cbb277d5f8bbf09a7948973aa9",
                     "options": {
                       "metadata": {
@@ -1794,14 +1450,6 @@
                   },
                   {
                     "id": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1858,14 +1506,6 @@
                   },
                   {
                     "id": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6559,26 +6199,6 @@
         "check_gpg": true
       },
       {
-        "name": "dbus-libs",
-        "epoch": 1,
-        "version": "1.14.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dbus-libs-1.14.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:1760430559238320396181897845a2f525be8a05528fd89d0442ee3a93427746",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.3",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/deltarpm-3.6.3-2.fc37.x86_64.rpm",
-        "checksum": "sha256:78a58d0d65ced1c196b408cf5864f594eed58eb56e41593da4ccd49fbe28e074",
-        "check_gpg": true
-      },
-      {
         "name": "device-mapper",
         "epoch": 0,
         "version": "1.02.175",
@@ -6606,26 +6226,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
         "checksum": "sha256:25df629a25f0aed219dabe88dc84bc4d65acf5eff0e1188a08a72ddde380f331",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:44b8073e409d9b3d681fb39183db23496a0825503987de3db78a57be4b551e16",
-        "check_gpg": true
-      },
-      {
-        "name": "dnf-data",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/d/dnf-data-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:d584746b939fac19b467c3067d15ee911b249a1da91a7e531b5ef0177bf0cf18",
         "check_gpg": true
       },
       {
@@ -6949,26 +6549,6 @@
         "check_gpg": true
       },
       {
-        "name": "gnupg2",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:b5003b7c4eee52f83ba0567ad7716fb8deabfbdc2b6a6edc113d4a7ab0843386",
-        "check_gpg": true
-      },
-      {
-        "name": "gnupg2-smime",
-        "epoch": 0,
-        "version": "2.3.4",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnupg2-smime-2.3.4-2.fc36.x86_64.rpm",
-        "checksum": "sha256:a645c569781e16b330f2285d87afa3a7eeb5b08b0e8ed882cc69a2a9f1ae6859",
-        "check_gpg": true
-      },
-      {
         "name": "gnutls",
         "epoch": 0,
         "version": "3.7.3",
@@ -6976,16 +6556,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gnutls-3.7.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:0f67c3b41a18d4886c760e5a79737e195fdf8dd3a24db3fa145b3aed51130e88",
-        "check_gpg": true
-      },
-      {
-        "name": "gpgme",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gpgme-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:1fa5a61f16bd1550932ec112af36f385c2a8a0fbd20d68576349b1bcb641b5df",
         "check_gpg": true
       },
       {
@@ -7066,16 +6636,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/g/gzip-1.11-2.fc36.x86_64.rpm",
         "checksum": "sha256:6cf0c3b4176c031050847190e65adcdb3d6b30531a7a805371efea11b9d11438",
-        "check_gpg": true
-      },
-      {
-        "name": "ima-evm-utils",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
-        "checksum": "sha256:859fb1f641b1352c92b72ff6e4fa2ca25f57fa05bffd6eaec7be3f62c909abfa",
         "check_gpg": true
       },
       {
@@ -7199,16 +6759,6 @@
         "check_gpg": true
       },
       {
-        "name": "libassuan",
-        "epoch": 0,
-        "version": "2.5.5",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
-        "checksum": "sha256:06048c4ad30e3a54846b2d456613b90d25c42072b3a2978869fbab825776ed2e",
-        "check_gpg": true
-      },
-      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -7289,16 +6839,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:d7074115e34263bc1422a488a750b1524c0cca02a18a10021b898c9388af039d",
-        "check_gpg": true
-      },
-      {
         "name": "libcurl",
         "epoch": 0,
         "version": "7.82.0",
@@ -7316,16 +6856,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdb-5.3.28-52.fc37.x86_64.rpm",
         "checksum": "sha256:c1a8136c4d5d1bc6f15c2bfbfc3bfdd8c62c9b0bf207e5eeeccc1dc05a1ab536",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:51a39b867c136d9177d271d2799e0b99b5150913da694423da8615705b99dafd",
         "check_gpg": true
       },
       {
@@ -7379,16 +6909,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
-        "checksum": "sha256:5fb420f95713f952fb0833089411ec4e45da5e6fc24543ccaaa64320876793b8",
-        "check_gpg": true
-      },
-      {
         "name": "libgcc",
         "epoch": 0,
         "version": "12.0.1",
@@ -7429,16 +6949,6 @@
         "check_gpg": true
       },
       {
-        "name": "libicu",
-        "epoch": 0,
-        "version": "69.1",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libicu-69.1-5.fc36.x86_64.rpm",
-        "checksum": "sha256:e96feedbab81e6d615be063093435a1a1d1acad3c63ed4f7a373f2d8c91c326e",
-        "check_gpg": true
-      },
-      {
         "name": "libidn2",
         "epoch": 0,
         "version": "2.3.2",
@@ -7466,26 +6976,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
         "checksum": "sha256:1ae7641fc5de998c642adb81f843db06883c974d7455ba0e2e90a96364f565d2",
-        "check_gpg": true
-      },
-      {
-        "name": "libksba",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
-        "checksum": "sha256:f88aacf346349e25aceb69a8832be2a85940f84898ba78e60eee648c50725856",
-        "check_gpg": true
-      },
-      {
-        "name": "libmodulemd",
-        "epoch": 0,
-        "version": "2.14.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8532edf8c1478792b0b693736acbb5d64adc2a843310ecaee8d3dbb7d52e79bd",
         "check_gpg": true
       },
       {
@@ -7539,26 +7029,6 @@
         "check_gpg": true
       },
       {
-        "name": "librepo",
-        "epoch": 0,
-        "version": "1.14.2",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/librepo-1.14.2-2.fc36.x86_64.rpm",
-        "checksum": "sha256:8d7412eeb19f101df800fa13d5500558c675ffb522c832dd7204ea7ff0167a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libreport-filesystem",
-        "epoch": 0,
-        "version": "2.17.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libreport-filesystem-2.17.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:28c7b25d9b6176cb745e6dc2a050ae767cf72f38c15bcbc05d3c0726079acb0a",
-        "check_gpg": true
-      },
-      {
         "name": "libseccomp",
         "epoch": 0,
         "version": "2.5.3",
@@ -7566,16 +7036,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
         "checksum": "sha256:93d72d498206619aec5ba6fb96074b292201b4d467649f9fd5485bc9b56ea5ad",
-        "check_gpg": true
-      },
-      {
-        "name": "libsecret",
-        "epoch": 0,
-        "version": "0.20.5",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsecret-0.20.5-1.fc37.x86_64.rpm",
-        "checksum": "sha256:83742174a4c9eb2bb80ee0568f7a55814330886b0fa244c0a75fd5ee90c2210e",
         "check_gpg": true
       },
       {
@@ -7636,16 +7096,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsmartcols-2.38-0.4.fc37.x86_64.rpm",
         "checksum": "sha256:a053d1555f6c310a89762c3ce3e6c1b8f1c401523502ef7e19d46230d9d8089e",
-        "check_gpg": true
-      },
-      {
-        "name": "libsolv",
-        "epoch": 0,
-        "version": "0.7.21",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libsolv-0.7.21-1.fc37.x86_64.rpm",
-        "checksum": "sha256:d5590e623e4095872a5db1268081694ebd897d32e8f142ec3075477b82837a74",
         "check_gpg": true
       },
       {
@@ -7729,16 +7179,6 @@
         "check_gpg": true
       },
       {
-        "name": "libusb1",
-        "epoch": 0,
-        "version": "1.0.25",
-        "release": "8.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libusb1-1.0.25-8.fc37.x86_64.rpm",
-        "checksum": "sha256:58c29b3546d2145749e42436c80c146ff1e09697e9a7c394afeec593a7a2be56",
-        "check_gpg": true
-      },
-      {
         "name": "libutempter",
         "epoch": 0,
         "version": "1.2.1",
@@ -7809,16 +7249,6 @@
         "check_gpg": true
       },
       {
-        "name": "libyaml",
-        "epoch": 0,
-        "version": "0.2.5",
-        "release": "7.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
-        "checksum": "sha256:bd2b034ece1c43aab1029583807146c30e897cbbdf10e3981d86ed7f0bab9239",
-        "check_gpg": true
-      },
-      {
         "name": "libzstd",
         "epoch": 0,
         "version": "1.5.2",
@@ -7866,16 +7296,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mkpasswd-5.5.12-1.fc37.x86_64.rpm",
         "checksum": "sha256:116d770ce30146ad926b9febdff4022e9bcb7ad5d275d7082164f0dc30fe18f7",
-        "check_gpg": true
-      },
-      {
-        "name": "mozjs91",
-        "epoch": 0,
-        "version": "91.7.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/m/mozjs91-91.7.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:aa35f55ce0d99e66f9acd4fae242646eff7b6adb7b15490dd0d40e8a376dc87a",
         "check_gpg": true
       },
       {
@@ -7929,16 +7349,6 @@
         "check_gpg": true
       },
       {
-        "name": "npth",
-        "epoch": 0,
-        "version": "1.6",
-        "release": "8.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
-        "checksum": "sha256:5bdb733b153b510effb457ba0cfdb21d4be540347d6f555b3e17e585bf9fb8d7",
-        "check_gpg": true
-      },
-      {
         "name": "openldap",
         "epoch": 0,
         "version": "2.6.1",
@@ -7946,16 +7356,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-2.6.1-2.fc36.x86_64.rpm",
         "checksum": "sha256:8bae03847d39eadf8789b3db31e567e0b5312510f6b2c03674edd158b8b2e2d5",
-        "check_gpg": true
-      },
-      {
-        "name": "openldap-compat",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/o/openldap-compat-2.6.1-2.fc36.x86_64.rpm",
-        "checksum": "sha256:92d06acf974cd8d8446643382da4b62128b0323e7d65e011aad962d0e1a7a879",
         "check_gpg": true
       },
       {
@@ -8059,36 +7459,6 @@
         "check_gpg": true
       },
       {
-        "name": "pcsc-lite",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:6bd214ae332adf85c1b88dbd0447bcd966dc339f8b952511964d2d440053e9bf",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-ccid",
-        "epoch": 0,
-        "version": "1.5.0",
-        "release": "1.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
-        "checksum": "sha256:a040292289d7713e9324fb8b138a8eeb062bda8505a30f463ad3c9c396f88428",
-        "check_gpg": true
-      },
-      {
-        "name": "pcsc-lite-libs",
-        "epoch": 0,
-        "version": "1.9.5",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pcsc-lite-libs-1.9.5-2.fc36.x86_64.rpm",
-        "checksum": "sha256:40026b55d88df78601d4d7d257c14d4a75b35e144c27b9c3f303241e6d4af3be",
-        "check_gpg": true
-      },
-      {
         "name": "pigz",
         "epoch": 0,
         "version": "2.7",
@@ -8099,16 +7469,6 @@
         "check_gpg": true
       },
       {
-        "name": "pinentry",
-        "epoch": 0,
-        "version": "1.2.0",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
-        "checksum": "sha256:112f6d1ed29a1e5dcdb329187ed9c9516ef9051f8233809f9291e7d4220765f1",
-        "check_gpg": true
-      },
-      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -8116,36 +7476,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/policycoreutils-3.3-4.fc37.x86_64.rpm",
         "checksum": "sha256:0d8484e8d83f3c13a2aed47efac9f3f4543fe7541499995ccfd6cc43ac6cc65b",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:7bb10ad8f95fea674cd74eaa11a03c512d5e54888d085c217f93d98e121b8678",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-libs",
-        "epoch": 0,
-        "version": "0.120",
-        "release": "5.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-libs-0.120-5.fc37.x86_64.rpm",
-        "checksum": "sha256:9437efb8138aebf65e87341169489fe980aacf97dcc7fad82b3205abd90a81db",
-        "check_gpg": true
-      },
-      {
-        "name": "polkit-pkla-compat",
-        "epoch": 0,
-        "version": "0.1",
-        "release": "21.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
-        "checksum": "sha256:cb90df57c45186e7ecaf2a1fde48329fe79b39184118baa1f70907fb87c9065e",
         "check_gpg": true
       },
       {
@@ -8166,16 +7496,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
         "checksum": "sha256:344e74aa9efacf440fe985f9abefb2ac06e924a6a140dbaa1c4b90150a6a177b",
-        "check_gpg": true
-      },
-      {
-        "name": "protobuf-c",
-        "epoch": 0,
-        "version": "1.4.0",
-        "release": "4.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
-        "checksum": "sha256:b02791e6357653670d13a96d764af9798389014d1b723111483ee0fdf572d86e",
         "check_gpg": true
       },
       {
@@ -8229,56 +7549,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.11.1",
-        "release": "1.fc37",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-dnf-4.11.1-1.fc37.noarch.rpm",
-        "checksum": "sha256:7ff190b49695051db2a3babc5ad406273ebddfc5b038dff9f5da18bf095421b8",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.17.0",
-        "release": "2.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-gpg-1.17.0-2.fc37.x86_64.rpm",
-        "checksum": "sha256:8075a2a2380064ec6df81d7ad1fea75de03412280e7738e3264c2f838ef370e1",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-hawkey-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:c5098dae492bbb9acb55852fe3faa1f7d96e9f90cf3a89134342c0e1111748c7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "2.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
-        "checksum": "sha256:325103bef2a9a2776d8e198fc23b60fa0090c17284a0ec4a7600fceeaba8b80a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.66.0",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libdnf-0.66.0-1.fc37.x86_64.rpm",
-        "checksum": "sha256:b6129b87cfb0986461b5512f38d31b52e452d18947332865ca4b48815336f08f",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.3",
@@ -8286,26 +7556,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-libs-3.10.3-1.fc37.x86_64.rpm",
         "checksum": "sha256:e01ac3cb3d5f79efbd96e9e4d2c143e10be135502a3c4f10a8167f04168a7570",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-rpm-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:894c25a219728c6d2ff2199f5dea162896ad5e05d108b8ad096cd8a58174a19d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/p/python3-unbound-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:d62bd3c28d2f2e883885a4e334f95f465ac7ba6c956a1ad22c002715a6c173ca",
         "check_gpg": true
       },
       {
@@ -8349,16 +7599,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-build-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:587f785cdf0aaade828a34dae8854facb2fab5015a3fbeca32be728331d1885b",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -8376,26 +7616,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-selinux-4.17.0-10.fc37.x86_64.rpm",
         "checksum": "sha256:80cb31fb3f9e50f8754985a43e560e09dd228beaec8e94d7a52401824b715139",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-plugin-systemd-inhibit",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:364af30302ab32abb3646bf6aadbfcd273c29891dc7ef77a259dbf9a5eadfd02",
-        "check_gpg": true
-      },
-      {
-        "name": "rpm-sign-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "10.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/r/rpm-sign-libs-4.17.0-10.fc37.x86_64.rpm",
-        "checksum": "sha256:c3001bbd7cef5527bebaa1c2137d75e1b5321205b846ddaeaadafc86e23a5239",
         "check_gpg": true
       },
       {
@@ -8519,16 +7739,6 @@
         "check_gpg": true
       },
       {
-        "name": "tar",
-        "epoch": 2,
-        "version": "1.34",
-        "release": "3.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tar-1.34-3.fc36.x86_64.rpm",
-        "checksum": "sha256:9798da3a74c080a972f72ccbc93b733e588efc5563d5318b7521af394d524f74",
-        "check_gpg": true
-      },
-      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.2.0",
@@ -8546,16 +7756,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/t/tzdata-2021e-4.fc36.noarch.rpm",
         "checksum": "sha256:0fba8ec1be39838d629bb83193116db688eb92a2fcd9c470870617f713dbe227",
-        "check_gpg": true
-      },
-      {
-        "name": "unbound-libs",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "5.fc36",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/u/unbound-libs-1.13.2-5.fc36.x86_64.rpm",
-        "checksum": "sha256:52a06c8faa8f10c38a677b2f23ea21aefb91cbd800e73fe2ed7ba65816023abb",
         "check_gpg": true
       },
       {
@@ -8626,16 +7826,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/x/xz-libs-5.2.5-8.fc36.x86_64.rpm",
         "checksum": "sha256:e60ed800e1e2010dd86dff18953d55e8b0f769b70b4771d6df9f5b99068ef796",
-        "check_gpg": true
-      },
-      {
-        "name": "zchunk-libs",
-        "epoch": 0,
-        "version": "1.2.1",
-        "release": "1.fc37",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-rawhide-20220324/Packages/z/zchunk-libs-1.2.1-1.fc37.x86_64.rpm",
-        "checksum": "sha256:65a4bc25aa08eeffeb93f177eb4c7526fd7e28e9f0b60cf1c2fbfb89b7bad2fb",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
This simplifies and refines the pipeline definitions and makes it
easier to work with the playground.

The build pipelines are trimmed down a bit by only include required
packages.