### PR TITLE
tag created vmare VMs

### DIFF
--- a/test/cases/api/common/s3.sh
+++ b/test/cases/api/common/s3.sh
@@ -383,6 +383,13 @@ function verifyInVSphere() {
         -on=false \
         "${VSPHERE_VM_NAME}"
 
+    # tagging vm as testing object
+    $GOVC_CMD tags.attach \
+    	-u "${GOVMOMI_USERNAME}":"${GOVMOMI_PASSWORD}"@"${GOVMOMI_URL}" \
+    	-k=true \
+    	-c "osbuild-composer testing" gitlab-ci-test \
+    	"/${GOVMOMI_DATACENTER}/vm/${GOVMOMI_FOLDER}/${VSPHERE_VM_NAME}"    
+
     # upload ISO, create CDROM device and insert the ISO in it
     greenprint "💿 ⬆️ Uploading the cloud-init user-data ISO to VSphere"
     VSPHERE_CIDATA_ISO_PATH="${VSPHERE_VM_NAME}/cidata.iso"


### PR DESCRIPTION
tag VMs with 'gitlba-ci-test' images so they can get removed with
cloud cleaner


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/