### PR TITLE
Improvements for gen-manifests tool and Manifest-diff test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -664,6 +664,9 @@ Manifest-diff:
     GIT_STRATEGY: "clone"
     GIT_CHECKOUT: "true"
     GIT_DEPTH: 500
+  artifacts:
+    paths:
+      - "/tmp/artifacts"
 
 SCHEDULED_CLOUD_CLEANER:
   stage: cleanup

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -400,9 +400,9 @@ func main() {
 	errs := wq.wait()
 	exit := 0
 	if len(errs) > 0 {
-		fmt.Printf("Encountered %d errors:\n", len(errs))
+		fmt.Fprintf(os.Stderr, "Encountered %d errors:\n", len(errs))
 		for idx, err := range errs {
-			fmt.Printf("%3d: %s\n", idx, err.Error())
+			fmt.Fprintf(os.Stderr, "%3d: %s\n", idx, err.Error())
 		}
 		exit = 1
 	}

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -323,14 +323,12 @@ func mergeOverrides(base, overrides composeRequest) composeRequest {
 }
 
 func main() {
-	outputDirFlag := flag.String("output", "test/data/manifests.plain/", "manifest store directory")
-	nWorkersFlag := flag.Int("workers", 16, "number of workers to run concurrently")
-	cacheRootFlag := flag.String("cache", "/tmp/rpmmd", "rpm metadata cache directory")
+	var outputDir, cacheRoot string
+	var nWorkers int
+	flag.StringVar(&outputDir, "output", "test/data/manifests.plain/", "manifest store directory")
+	flag.IntVar(&nWorkers, "workers", 16, "number of workers to run concurrently")
+	flag.StringVar(&cacheRoot, "cache", "/tmp/rpmmd", "rpm metadata cache directory")
 	flag.Parse()
-
-	outputDir := *outputDirFlag
-	nWorkers := *nWorkersFlag
-	cacheRoot := *cacheRootFlag
 
 	seedArg := int64(0)
 	darm := readRepos()

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -441,6 +441,7 @@ func main() {
 	for _, j := range jobs {
 		wq.submitJob(j)
 	}
+	fmt.Println("done")
 	errs := wq.wait()
 	exit := 0
 	if len(errs) > 0 {

--- a/cmd/gen-manifests/workerqueue.go
+++ b/cmd/gen-manifests/workerqueue.go
@@ -85,7 +85,6 @@ func (wq *workerQueue) startWorker(idx uint32) {
 			}
 		}
 	}()
-	wq.msgQueue <- fmt.Sprintf("Worker %d started", idx)
 }
 
 func (wq *workerQueue) startMessagePrinter() {

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -65,8 +65,8 @@ greenprint "Generating all manifests for merge-base (${mergebase})"
 go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50
 
 greenprint "Diff: ${manifestdir}/${mergebase} ${manifestdir}/PR"
-err=0
-diff=$(diff -Naur "${manifestdir}"/{"${mergebase}",PR}) || err=$?
+diff=$(diff -Naur "${manifestdir}"/"${mergebase}" "${manifestdir}/PR")
+err=$?
 
 review_data_file="review.json"
 

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -57,11 +57,19 @@ manifestdir=$(mktemp -d)
 
 greenprint "Generating all manifests for HEAD (PR #${prnum})"
 go run ./cmd/gen-manifests --output "${manifestdir}/PR" --workers 50
+err=$?
+if (( err != 0 )); then
+    greenprint "Manifest generation on PR HEAD failed"
+    exit 1
+fi
 
 greenprint "Checking out merge-base ${mergebase}"
 git checkout "${mergebase}"
 
 greenprint "Generating all manifests for merge-base (${mergebase})"
+# NOTE: it's not an error if this task fails; manifest generation on main can
+# be broken in a PR that fixes it.
+# As long as the generation on the PR HEAD succeeds, the job should succeed.
 go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50
 
 greenprint "Diff: ${manifestdir}/${mergebase} ${manifestdir}/PR"

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-artifacts="ci-artifacts"
+artifacts="/tmp/artifacts"
 mkdir -p "${artifacts}"
 
 # Colorful output.

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -56,13 +56,13 @@ sudo dnf build-dep -y osbuild-composer.spec
 manifestdir=$(mktemp -d)
 
 greenprint "Generating all manifests for HEAD (PR #${prnum})"
-go run ./cmd/gen-manifests --output "${manifestdir}/PR" --workers 50 > /dev/null
+go run ./cmd/gen-manifests --output "${manifestdir}/PR" --workers 50
 
 greenprint "Checking out merge-base ${mergebase}"
 git checkout "${mergebase}"
 
 greenprint "Generating all manifests for merge-base (${mergebase})"
-go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50 > /dev/null
+go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50
 
 greenprint "Diff: ${manifestdir}/${mergebase} ${manifestdir}/PR"
 err=0

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -87,8 +87,10 @@ greenprint "Manifests differ"
 echo "${diff}" > "${artifacts}/manifests.diff"
 greenprint "Saved diff in job artifacts"
 
+artifacts_url="${CI_JOB_URL}/artifacts/browse/ci-artifacts"
+
 cat > "${review_data_file}" << EOF
-{"body":"⚠️ This PR introduces changes in at least one manifest (when comparing PR HEAD ${head} with the main merge-base ${mergebase}).  Please review the changes.  The changes can be found in the job artifacts of the \`Manifest-diff\` job as \`manifests.diff\`","event":"COMMENT"}
+{"body":"⚠️ This PR introduces changes in at least one manifest (when comparing PR HEAD ${head} with the main merge-base ${mergebase}).  Please review the changes.  The changes can be found in the [artifacts of the \`Manifest-diff\` job [0]](${artifacts_url}) as \`manifests.diff\`.\n\n[0] ${artifacts_url}","event":"COMMENT"}
 EOF
 
 greenprint "Posting review comment"


### PR DESCRIPTION
Partially addresses issue #2767.

Changes for `gen-manifests`:
- Prints the final error summary on stderr.
- Only print progress update after receiving a message on the message queue.  This makes the command less noisy in CI where the carriage return `\r` produces a new line and constant progress updates were producing new lines.  The logic relies on the fact that each job reports when its finished with a line on the message queue, which could change, but for now is adequate.
- Support `-arches`, `-distros`, and `-images` flags.  Each supports is a comma-separated list of strings for manifest generation filtering.
- Appends the text `[failed]` to the `Finished` message for failed jobs.

Changes for `diff-manifests` test:
- Print all the output from `gen-manifests`.
- The test now fails if manifest generation fails on the PR `HEAD`.
- The test does not fail if manifest generation fails on the `merge-base`, but a note is added to the review comment.
- The comment links directly to the artifacts directory for the CI job if there are differences in the manifests.
