### PR TITLE
packit: Enable Bodhi update feature

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,10 @@ actions:
   post-upstream-clone: "./tools/rpm_spec_add_provides_bundle.sh"
 
 jobs:
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable # rawhide updates are created automatically
 - job: koji_build
   trigger: commit
   metadata:


### PR DESCRIPTION
While this feature is 'not mature yet' according to Packit developers, we can enable it because there's no harm done. If Packit fails to publish the Bodhi update then fedora-bot will take care of it.

For reference see https://packit.dev/docs/configuration/#bodhi_update