### PR TITLE
Dockerfile: update worker builder

### DIFF
--- a/distribution/Dockerfile-worker
+++ b/distribution/Dockerfile-worker
@@ -1,5 +1,13 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
-COPY . .
+FROM fedora:35 AS builder
+ENV GOBIN=/opt/app-root/src/go/bin
+# extra packages are needed
+# to compile osbuild
+RUN dnf install -y golang \
+  krb5-devel \
+  gpgme-devel \
+  libassuan-devel
+WORKDIR /osbuild-composer
+COPY . /osbuild-composer
 ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-worker
 


### PR DESCRIPTION
Additional packages are required to build the docker worker. This fix updates the builder
container to install the required libraries and then create the worker binary.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
