### PR TITLE
blueprint: Hash all user passwords

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -144,9 +144,16 @@ func (b *Blueprint) CryptPasswords() error {
 	// Any passwords for users?
 	for i := range b.Customizations.User {
 		// Missing or empty password
-		if b.Customizations.User[i].Password == nil || len(*b.Customizations.User[i].Password) == 0 {
+		if b.Customizations.User[i].Password == nil {
 			continue
 		}
+
+		// Prevent empty password from being hashed
+		if len(*b.Customizations.User[i].Password) == 0 {
+			b.Customizations.User[i].Password = nil
+			continue
+		}
+
 		if !crypt.PasswordIsCrypted(*b.Customizations.User[i].Password) {
 			pw, err := crypt.CryptSHA512(*b.Customizations.User[i].Password)
 			if err != nil {

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/osbuild/osbuild-composer/internal/crypt"
+
 	"github.com/coreos/go-semver/semver"
 )
 
@@ -74,6 +76,12 @@ func (b *Blueprint) Initialize() error {
 	if err != nil {
 		return fmt.Errorf("Invalid 'version', must use Semantic Versioning: %s", err.Error())
 	}
+
+	err = b.CryptPasswords()
+	if err != nil {
+		return fmt.Errorf("Error hashing passwords: %s", err.Error())
+	}
+
 	return nil
 }
 
@@ -125,4 +133,30 @@ func (p Package) ToNameVersion() string {
 	}
 
 	return p.Name + "-" + p.Version
+}
+
+// CryptPasswords ensures that all blueprint passwords are hashed
+func (b *Blueprint) CryptPasswords() error {
+	if b.Customizations == nil {
+		return nil
+	}
+
+	// Any passwords for users?
+	for i := range b.Customizations.User {
+		// Missing or empty password
+		if b.Customizations.User[i].Password == nil || len(*b.Customizations.User[i].Password) == 0 {
+			continue
+		}
+		if !crypt.PasswordIsCrypted(*b.Customizations.User[i].Password) {
+			pw, err := crypt.CryptSHA512(*b.Customizations.User[i].Password)
+			if err != nil {
+				return err
+			}
+
+			// Replace the password with the
+			b.Customizations.User[i].Password = &pw
+		}
+	}
+
+	return nil
 }

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -2,6 +2,7 @@ package blueprint
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -212,4 +213,39 @@ func TestKernelNameCustomization(t *testing.T) {
 			assert.ElementsMatch(t, []string{"tmux-1.2", bk, "openssh-server", "@anaconda-tools", ck}, Received_packages)
 		}
 	}
+}
+
+// TestBlueprintPasswords check to make sure all passwords are hashed
+func TestBlueprintPasswords(t *testing.T) {
+	blueprint := `
+name = "test"
+description = "Test"
+version = "0.0.0"
+
+[[customizations.user]]
+name = "bart"
+password = "nobodysawmedoit"
+
+[[customizations.user]]
+name = "lisa"
+password = "$6$RWdHzrPfoM6BMuIP$gKYlBXQuJgP.G2j2twbOyxYjFDPUQw8Jp.gWe1WD/obX0RMyfgw5vt.Mn/tLLX4mQjaklSiIzoAW3HrVQRg4Q."
+
+[[customizations.user]]
+name = "maggie"
+password = ""
+`
+
+	var bp Blueprint
+	err := toml.Unmarshal([]byte(blueprint), &bp)
+	require.Nil(t, err)
+	require.Nil(t, bp.Initialize())
+
+	// Note: User entries are in the same order as the toml
+	users := bp.Customizations.GetUsers()
+	assert.Equal(t, "bart", users[0].Name)
+	assert.True(t, strings.HasPrefix(*users[0].Password, "$6$"))
+	assert.Equal(t, "lisa", users[1].Name)
+	assert.Equal(t, "$6$RWdHzrPfoM6BMuIP$gKYlBXQuJgP.G2j2twbOyxYjFDPUQw8Jp.gWe1WD/obX0RMyfgw5vt.Mn/tLLX4mQjaklSiIzoAW3HrVQRg4Q.", *users[1].Password)
+	assert.Equal(t, "maggie", users[2].Name)
+	assert.Equal(t, "", *users[2].Password)
 }

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -247,5 +247,5 @@ password = ""
 	assert.Equal(t, "lisa", users[1].Name)
 	assert.Equal(t, "$6$RWdHzrPfoM6BMuIP$gKYlBXQuJgP.G2j2twbOyxYjFDPUQw8Jp.gWe1WD/obX0RMyfgw5vt.Mn/tLLX4mQjaklSiIzoAW3HrVQRg4Q.", *users[1].Password)
 	assert.Equal(t, "maggie", users[2].Name)
-	assert.Equal(t, "", *users[2].Password)
+	assert.Nil(t, users[2].Password)
 }

--- a/internal/osbuild/users_stage.go
+++ b/internal/osbuild/users_stage.go
@@ -36,6 +36,12 @@ func NewUsersStageOptions(userCustomizations []blueprint.UserCustomization, omit
 
 	users := make(map[string]UsersStageOptionsUser, len(userCustomizations))
 	for _, uc := range userCustomizations {
+		// Don't hash empty passwords, set to nil to lock account
+		if uc.Password != nil && len(*uc.Password) == 0 {
+			uc.Password = nil
+		}
+
+		// Hash non-empty un-hashed passwords
 		if uc.Password != nil && !crypt.PasswordIsCrypted(*uc.Password) {
 			cryptedPassword, err := crypt.CryptSHA512(*uc.Password)
 			if err != nil {

--- a/internal/osbuild/users_stage_test.go
+++ b/internal/osbuild/users_stage_test.go
@@ -1,9 +1,13 @@
 package osbuild
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUsersStage(t *testing.T) {
@@ -13,4 +17,44 @@ func TestNewUsersStage(t *testing.T) {
 	}
 	actualStage := NewUsersStage(&UsersStageOptions{})
 	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestNewUsersStageOptionsPassword(t *testing.T) {
+	Pass := "testpass"
+	EmptyPass := ""
+	CryptPass := "$6$RWdHzrPfoM6BMuIP$gKYlBXQuJgP.G2j2twbOyxYjFDPUQw8Jp.gWe1WD/obX0RMyfgw5vt.Mn/tLLX4mQjaklSiIzoAW3HrVQRg4Q." // #nosec G101
+
+	users := []blueprint.UserCustomization{
+		blueprint.UserCustomization{
+			Name:     "bart",
+			Password: &Pass,
+		},
+		blueprint.UserCustomization{
+			Name:     "lisa",
+			Password: &CryptPass,
+		},
+		blueprint.UserCustomization{
+			Name:     "maggie",
+			Password: &EmptyPass,
+		},
+		blueprint.UserCustomization{
+			Name: "homer",
+		},
+	}
+
+	options, err := NewUsersStageOptions(users, false)
+	require.Nil(t, err)
+	require.NotNil(t, options)
+
+	// bart's password should now be a hash
+	assert.True(t, strings.HasPrefix(*options.Users["bart"].Password, "$6$"))
+
+	// lisa's password should be left alone (already hashed)
+	assert.Equal(t, CryptPass, *options.Users["lisa"].Password)
+
+	// maggie's password should now be nil (locked account)
+	assert.Nil(t, options.Users["maggie"].Password)
+
+	// homer's password should still be nil (locked account)
+	assert.Nil(t, options.Users["homer"].Password)
 }


### PR DESCRIPTION
This commit changes blueprint behavior to always store the hash of the
password for the 'customizations.user' accounts. Note that missing or
blank passwords are not hashed and should be dealt with at a lower
layer.

Resolves: rhbz#2107358


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
