### PR TITLE
dnf-json: explicitly set priority

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -52,12 +52,14 @@ class Solver():
         self.base.conf.substitutions['arch'] = arch
         self.base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
 
-        for repo in repos:
-            self.base.repos.add(self._dnfrepo(repo, self.base.conf))
+        # The order repositories are passed indicate their priority, with
+        # each repository overriding the previous ones in the list.
+        for priority, repo in enumerate(list.reverse(repos), start=1):
+            self.base.repos.add(self._dnfrepo(repo, self.base.conf, priority))
         self.base.fill_sack(load_system_repo=False)
 
     @staticmethod
-    def _dnfrepo(desc, parent_conf=None):
+    def _dnfrepo(desc, parent_conf=None, priority=99):
         """Makes a dnf.repo.Repo out of a JSON repository description"""
 
         repo = dnf.repo.Repo(desc["id"], parent_conf)
@@ -81,6 +83,10 @@ class Solver():
             repo.sslclientkey = desc["sslclientkey"]
         if "sslclientcert" in desc:
             repo.sslclientcert = desc["sslclientcert"]
+
+        # The default priority is 99, and a repository with lower priority
+        # takes precedence over one with higher priority.
+        repo.priority = priority
 
         # In dnf, the default metadata expiration time is 48 hours. However,
         # some repositories never expire the metadata, and others expire it much


### PR DESCRIPTION
Prioritise the repositories in the order they are passed. Currently their priorities are all
the same, which gives (to me) unexpected results.

The logic is now that appending a repo to the list of repositories, means that it overrides
the previously passed ones. This is relevant in case the same packages exist in the
base repositories as in the payload repositories. In this case we should prefer the
payload ones.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
