### PR TITLE
worker/osbuild: use `os-release` to determine host OS

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -246,10 +246,10 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		Arch:         common.CurrentArch(),
 	}
 
-	hostOS, err := common.GetRedHatRelease()
+	hostOS, _, _, err := common.GetHostDistroName()
 	if err != nil {
-		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, err.Error(), nil)
-		return nil
+		logWithId.Warnf("Failed to get host distro name: %v", err)
+		hostOS = "linux"
 	}
 	osbuildJobResult.HostOS = hostOS
 

--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -3,9 +3,7 @@ package common
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -29,20 +27,6 @@ func GetHostDistroName() (string, bool, bool, error) {
 	// TODO: We should probably index these things by the full CPE
 	beta := strings.Contains(osrelease["CPE_NAME"], "beta")
 	return name, beta, isStream, nil
-}
-
-// GetRedHatRelease returns the content of /etc/redhat-release
-// without the trailing new-line.
-func GetRedHatRelease() (string, error) {
-	raw, err := ioutil.ReadFile("/etc/redhat-release")
-	if err != nil {
-		return "", fmt.Errorf("cannot read /etc/redhat-release: %v", err)
-	}
-
-	//Remove the trailing new-line.
-	redHatRelease := strings.TrimSpace(string(raw))
-
-	return redHatRelease, nil
 }
 
 func readOSRelease(r io.Reader) (map[string]string, error) {

--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -60,14 +60,8 @@ func readOSRelease(r io.Reader) (map[string]string, error) {
 		}
 
 		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if value[0] == '"' {
-			if len(value) < 2 || value[len(value)-1] != '"' {
-				return nil, errors.New("readOSRelease: invalid input")
-			}
-			value = value[1 : len(value)-1]
-		}
-
+		// drop all surrounding whitespace and double-quotes
+		value := strings.Trim(strings.TrimSpace(parts[1]), "\"")
 		osrelease[key] = value
 	}
 

--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -23,12 +23,8 @@ func GetHostDistroName() (string, bool, bool, error) {
 
 	isStream := osrelease["NAME"] == "CentOS Stream"
 
-	// NOTE: We only consider major releases up until rhel 8.4
 	version := strings.Split(osrelease["VERSION_ID"], ".")
-	name := osrelease["ID"] + "-" + version[0]
-	if osrelease["ID"] == "rhel" && ((version[0] == "8" && version[1] >= "4") || version[0] == "9") {
-		name = name + version[1]
-	}
+	name := osrelease["ID"] + "-" + strings.Join(version, "")
 
 	// TODO: We should probably index these things by the full CPE
 	beta := strings.Contains(osrelease["CPE_NAME"], "beta")


### PR DESCRIPTION
When running an osbuild job, we read `/etc/redhat-release` to get the host OS name to attach as metadata to the job result.

Only Fedora and RHEL ship this file, which makes the osbuild job always fail on other distributions.

The main reason to report host OS back to the worker server is due to Koji composes and the koji-finalize job, which pushes it to Koji. The motivation is to have enough information to potentially re-instantiate / identify the original builder host OS. There are no specific requirements on the string.

Modify the code to use `/etc/os-release` to determine the host OS. Fall back to using `linux` as the host OS, in case reading `os-release` fails, log the error and continue with the job. The `linux` fallback is suggested by the `os-release` spec [1]

[1] https://www.freedesktop.org/software/systemd/man/os-release.html#ID=

Had issues running on Arch and wasn't sure what was happening. :)

Note that with the current behaviour (on `main`), the job doesn't fail immediately because after the error is caught we `return nil`.  The job stops and then times out (essentially failing) but the error message is lost (or hard to find).

## Miscellaneous changes

-  Drop special handling for RHEL < 8.4 in `GetHostDistroName()` and always include the minor version in the host distro string.
- Simplify trimming of quotes in `readOSRelease()`