### PR TITLE
metrics: add `arch` label to prometheus metrics

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -576,7 +576,7 @@ func (h *apiHandlers) getComposeStatusImpl(ctx echo.Context, id string) error {
 
 	if jobType == worker.JobTypeOSBuild {
 		var result worker.OSBuildJobResult
-		jobInfo, err := h.server.workers.OSBuildJobStatus(jobId, &result)
+		jobInfo, err := h.server.workers.OSBuildJobInfo(jobId, &result)
 		if err != nil {
 			return HTTPError(ErrorMalformedOSBuildJobResult)
 		}
@@ -616,7 +616,7 @@ func (h *apiHandlers) getComposeStatusImpl(ctx echo.Context, id string) error {
 		})
 	} else if jobType == worker.JobTypeKojiFinalize {
 		var result worker.KojiFinalizeJobResult
-		finalizeInfo, err := h.server.workers.KojiFinalizeJobStatus(jobId, &result)
+		finalizeInfo, err := h.server.workers.KojiFinalizeJobInfo(jobId, &result)
 		if err != nil {
 			return HTTPError(ErrorMalformedOSBuildJobResult)
 		}
@@ -624,7 +624,7 @@ func (h *apiHandlers) getComposeStatusImpl(ctx echo.Context, id string) error {
 			return HTTPError(ErrorUnexpectedNumberOfImageBuilds)
 		}
 		var initResult worker.KojiInitJobResult
-		_, err = h.server.workers.KojiInitJobStatus(finalizeInfo.Deps[0], &initResult)
+		_, err = h.server.workers.KojiInitJobInfo(finalizeInfo.Deps[0], &initResult)
 		if err != nil {
 			return HTTPError(ErrorMalformedOSBuildJobResult)
 		}
@@ -632,7 +632,7 @@ func (h *apiHandlers) getComposeStatusImpl(ctx echo.Context, id string) error {
 		var buildJobStatuses []ImageStatus
 		for i := 1; i < len(finalizeInfo.Deps); i++ {
 			var buildJobResult worker.OSBuildJobResult
-			buildInfo, err := h.server.workers.OSBuildJobStatus(finalizeInfo.Deps[i], &buildJobResult)
+			buildInfo, err := h.server.workers.OSBuildJobInfo(finalizeInfo.Deps[i], &buildJobResult)
 			if err != nil {
 				return HTTPError(ErrorMalformedOSBuildJobResult)
 			}
@@ -816,7 +816,7 @@ func (h *apiHandlers) getComposeMetadataImpl(ctx echo.Context, id string) error 
 	}
 
 	var result worker.OSBuildJobResult
-	buildInfo, err := h.server.workers.OSBuildJobStatus(jobId, &result)
+	buildInfo, err := h.server.workers.OSBuildJobInfo(jobId, &result)
 	if err != nil {
 		return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 	}
@@ -939,13 +939,13 @@ func (h *apiHandlers) getComposeLogsImpl(ctx echo.Context, id string) error {
 	switch jobType {
 	case worker.JobTypeKojiFinalize:
 		var finalizeResult worker.KojiFinalizeJobResult
-		finalizeInfo, err := h.server.workers.KojiFinalizeJobStatus(jobId, &finalizeResult)
+		finalizeInfo, err := h.server.workers.KojiFinalizeJobInfo(jobId, &finalizeResult)
 		if err != nil {
 			return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 		}
 
 		var initResult worker.KojiInitJobResult
-		_, err = h.server.workers.KojiInitJobStatus(finalizeInfo.Deps[0], &initResult)
+		_, err = h.server.workers.KojiInitJobInfo(finalizeInfo.Deps[0], &initResult)
 		if err != nil {
 			return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 		}
@@ -959,7 +959,7 @@ func (h *apiHandlers) getComposeLogsImpl(ctx echo.Context, id string) error {
 			switch buildJobType {
 			case worker.JobTypeOSBuild:
 				var buildResult worker.OSBuildJobResult
-				_, err = h.server.workers.OSBuildJobStatus(finalizeInfo.Deps[i], &buildResult)
+				_, err = h.server.workers.OSBuildJobInfo(finalizeInfo.Deps[i], &buildResult)
 				if err != nil {
 					return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 				}
@@ -978,7 +978,7 @@ func (h *apiHandlers) getComposeLogsImpl(ctx echo.Context, id string) error {
 
 	case worker.JobTypeOSBuild:
 		var buildResult worker.OSBuildJobResult
-		_, err = h.server.workers.OSBuildJobStatus(jobId, &buildResult)
+		_, err = h.server.workers.OSBuildJobInfo(jobId, &buildResult)
 		if err != nil {
 			return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 		}
@@ -1004,7 +1004,7 @@ func manifestJobResultsFromJobDeps(w *worker.Server, deps []uuid.UUID) (*worker.
 			return nil, err
 		}
 		if depType == worker.JobTypeManifestIDOnly {
-			_, err = w.ManifestJobStatus(deps[i], &manifestResult)
+			_, err = w.ManifestJobInfo(deps[i], &manifestResult)
 			if err != nil {
 				return nil, err
 			}
@@ -1036,7 +1036,7 @@ func (h *apiHandlers) getComposeManifestsImpl(ctx echo.Context, id string) error
 	switch jobType {
 	case worker.JobTypeKojiFinalize:
 		var finalizeResult worker.KojiFinalizeJobResult
-		finalizeInfo, err := h.server.workers.KojiFinalizeJobStatus(jobId, &finalizeResult)
+		finalizeInfo, err := h.server.workers.KojiFinalizeJobInfo(jobId, &finalizeResult)
 		if err != nil {
 			return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 		}
@@ -1060,7 +1060,7 @@ func (h *apiHandlers) getComposeManifestsImpl(ctx echo.Context, id string) error
 				if len(buildJob.Manifest) != 0 {
 					manifest = buildJob.Manifest
 				} else {
-					buildInfo, err := h.server.workers.OSBuildJobStatus(finalizeInfo.Deps[i], &worker.OSBuildJobResult{})
+					buildInfo, err := h.server.workers.OSBuildJobInfo(finalizeInfo.Deps[i], &worker.OSBuildJobResult{})
 					if err != nil {
 						return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 					}
@@ -1089,7 +1089,7 @@ func (h *apiHandlers) getComposeManifestsImpl(ctx echo.Context, id string) error
 		if len(buildJob.Manifest) != 0 {
 			manifest = buildJob.Manifest
 		} else {
-			buildInfo, err := h.server.workers.OSBuildJobStatus(jobId, &worker.OSBuildJobResult{})
+			buildInfo, err := h.server.workers.OSBuildJobInfo(jobId, &worker.OSBuildJobResult{})
 			if err != nil {
 				return HTTPErrorWithInternal(ErrorComposeNotFound, err)
 			}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -292,7 +292,7 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 		return
 	}
 
-	_, _, err = workers.DepsolveJobStatus(depsolveJobID, &depsolveResults)
+	_, err = workers.DepsolveJobStatus(depsolveJobID, &depsolveResults)
 	if err != nil {
 		reason := "Error reading depsolve status"
 		jobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorReadingJobStatus, reason)

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -292,7 +292,7 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 		return
 	}
 
-	_, err = workers.DepsolveJobStatus(depsolveJobID, &depsolveResults)
+	_, err = workers.DepsolveJobInfo(depsolveJobID, &depsolveResults)
 	if err != nil {
 		reason := "Error reading depsolve status"
 		jobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorReadingJobStatus, reason)

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -458,7 +458,7 @@ func TestKojiCompose(t *testing.T) {
 			// Finishing of the goroutine handling the manifest job is not deterministic and as a result, we may get
 			// the second osbuild job first.
 			// The build jobs ID is determined from the dependencies of the koji-finalize job dependencies.
-			finalizeInfo, err := workerServer.KojiFinalizeJobStatus(composeId, &worker.KojiFinalizeJobResult{})
+			finalizeInfo, err := workerServer.KojiFinalizeJobInfo(composeId, &worker.KojiFinalizeJobResult{})
 			require.NoError(t, err)
 			buildJobIDs := finalizeInfo.Deps[1:]
 			require.Len(t, buildJobIDs, 2)

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -458,9 +458,9 @@ func TestKojiCompose(t *testing.T) {
 			// Finishing of the goroutine handling the manifest job is not deterministic and as a result, we may get
 			// the second osbuild job first.
 			// The build jobs ID is determined from the dependencies of the koji-finalize job dependencies.
-			_, finalizeJobDeps, err := workerServer.KojiFinalizeJobStatus(composeId, &worker.KojiFinalizeJobResult{})
+			finalizeInfo, err := workerServer.KojiFinalizeJobStatus(composeId, &worker.KojiFinalizeJobResult{})
 			require.NoError(t, err)
-			buildJobIDs := finalizeJobDeps[1:]
+			buildJobIDs := finalizeInfo.Deps[1:]
 			require.Len(t, buildJobIDs, 2)
 
 			// handle build jobs

--- a/internal/prometheus/job_metrics.go
+++ b/internal/prometheus/job_metrics.go
@@ -16,7 +16,7 @@ var (
 		Namespace: namespace,
 		Subsystem: workerSubsystem,
 		Help:      "Total jobs",
-	}, []string{"type", "status", "tenant"})
+	}, []string{"type", "status", "tenant", "arch"})
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 		Subsystem: workerSubsystem,
 		Help:      "Duration spent by workers on a job.",
 		Buckets:   []float64{.1, .2, .5, 1, 2, 4, 8, 16, 32, 40, 48, 64, 96, 128, 160, 192, 224, 256, 320, 382, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2049},
-	}, []string{"type", "status", "tenant"})
+	}, []string{"type", "status", "tenant", "arch"})
 )
 
 var (
@@ -70,7 +70,7 @@ func DequeueJobMetrics(pending time.Time, started time.Time, jobType, tenant str
 	}
 }
 
-func CancelJobMetrics(started time.Time, jobType string, tenant string) {
+func CancelJobMetrics(started time.Time, jobType, tenant string) {
 	if !started.IsZero() {
 		RunningJobs.WithLabelValues(jobType, tenant).Dec()
 	} else {
@@ -78,11 +78,11 @@ func CancelJobMetrics(started time.Time, jobType string, tenant string) {
 	}
 }
 
-func FinishJobMetrics(started time.Time, finished time.Time, canceled bool, jobType, tenant string, status clienterrors.StatusCode) {
+func FinishJobMetrics(started time.Time, finished time.Time, canceled bool, jobType, tenant, arch string, status clienterrors.StatusCode) {
 	if !finished.IsZero() && !canceled {
 		diff := finished.Sub(started).Seconds()
-		JobDuration.WithLabelValues(jobType, status.ToString(), tenant).Observe(diff)
-		TotalJobs.WithLabelValues(jobType, status.ToString(), tenant).Inc()
+		JobDuration.WithLabelValues(jobType, status.ToString(), tenant, arch).Observe(diff)
+		TotalJobs.WithLabelValues(jobType, status.ToString(), tenant, arch).Inc()
 		RunningJobs.WithLabelValues(jobType, tenant).Dec()
 	}
 }

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -359,16 +359,16 @@ func (api *API) getComposeStatus(compose store.Compose) *composeStatus {
 
 	// All jobs are "osbuild" jobs.
 	var result worker.OSBuildJobResult
-	jobStatus, _, err := api.workers.OSBuildJobStatus(jobId, &result)
+	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &result)
 	if err != nil {
 		panic(err)
 	}
 
 	return &composeStatus{
-		State:    composeStateFromJobStatus(jobStatus, &result),
-		Queued:   jobStatus.Queued,
-		Started:  jobStatus.Started,
-		Finished: jobStatus.Finished,
+		State:    composeStateFromJobStatus(jobInfo.JobStatus, &result),
+		Queued:   jobInfo.JobStatus.Queued,
+		Started:  jobInfo.JobStatus.Started,
+		Finished: jobInfo.JobStatus.Finished,
 		Result:   result.OSBuildOutput,
 	}
 }
@@ -2196,7 +2196,7 @@ func (api *API) resolveContainersForImageType(bp blueprint.Blueprint, imageType 
 	var result worker.ContainerResolveJobResult
 
 	for {
-		status, _, err := api.workers.ContainerResolveJobStatus(jobId, &result)
+		jobInfo, err := api.workers.ContainerResolveJobStatus(jobId, &result)
 
 		if err != nil {
 			return specs, err
@@ -2204,9 +2204,9 @@ func (api *API) resolveContainersForImageType(bp blueprint.Blueprint, imageType 
 
 		if result.JobError != nil {
 			return specs, errors.New(result.JobError.Reason)
-		} else if status.Canceled {
+		} else if jobInfo.JobStatus.Canceled {
 			return specs, fmt.Errorf("Failed to resolve containers: job cancelled")
-		} else if !status.Finished.IsZero() {
+		} else if !jobInfo.JobStatus.Finished.IsZero() {
 			break
 		}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -359,7 +359,7 @@ func (api *API) getComposeStatus(compose store.Compose) *composeStatus {
 
 	// All jobs are "osbuild" jobs.
 	var result worker.OSBuildJobResult
-	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &result)
+	jobInfo, err := api.workers.OSBuildJobInfo(jobId, &result)
 	if err != nil {
 		panic(err)
 	}
@@ -2196,7 +2196,7 @@ func (api *API) resolveContainersForImageType(bp blueprint.Blueprint, imageType 
 	var result worker.ContainerResolveJobResult
 
 	for {
-		jobInfo, err := api.workers.ContainerResolveJobStatus(jobId, &result)
+		jobInfo, err := api.workers.ContainerResolveJobInfo(jobId, &result)
 
 		if err != nil {
 			return specs, err

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -57,7 +57,7 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 	err = api.workers.FinishJob(token, rawResult)
 	require.NoError(t, err)
 
-	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
+	jobInfo, err := api.workers.OSBuildJobInfo(jobId, &jobResult)
 	require.NoError(t, err)
 
 	state := composeStateFromJobStatus(jobInfo.JobStatus, &jobResult)
@@ -100,7 +100,7 @@ func TestComposeStatusFromJobError(t *testing.T) {
 	err = api.workers.FinishJob(token, rawResult)
 	require.NoError(t, err)
 
-	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
+	jobInfo, err := api.workers.OSBuildJobInfo(jobId, &jobResult)
 	require.NoError(t, err)
 
 	state := composeStateFromJobStatus(jobInfo.JobStatus, &jobResult)

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -57,10 +57,10 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 	err = api.workers.FinishJob(token, rawResult)
 	require.NoError(t, err)
 
-	jobStatus, _, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
+	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
 	require.NoError(t, err)
 
-	state := composeStateFromJobStatus(jobStatus, &jobResult)
+	state := composeStateFromJobStatus(jobInfo.JobStatus, &jobResult)
 	require.Equal(t, "FAILED", state.ToString())
 }
 
@@ -100,9 +100,9 @@ func TestComposeStatusFromJobError(t *testing.T) {
 	err = api.workers.FinishJob(token, rawResult)
 	require.NoError(t, err)
 
-	jobStatus, _, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
+	jobInfo, err := api.workers.OSBuildJobStatus(jobId, &jobResult)
 	require.NoError(t, err)
 
-	state := composeStateFromJobStatus(jobStatus, &jobResult)
+	state := composeStateFromJobStatus(jobInfo.JobStatus, &jobResult)
 	require.Equal(t, "FAILED", state.ToString())
 }

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -50,6 +50,13 @@ type JobStatus struct {
 	Canceled bool
 }
 
+type JobInfo struct {
+	JobType   string
+	Channel   string
+	JobStatus *JobStatus
+	Deps      []uuid.UUID
+}
+
 var ErrInvalidToken = errors.New("token does not exist")
 var ErrJobNotRunning = errors.New("job isn't running")
 var ErrInvalidJobType = errors.New("job has invalid type")
@@ -161,11 +168,11 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 	}
 
 	var jobResult *JobResult
-	var jobDeps []uuid.UUID
+	var jobInfo *JobInfo
 	switch jobType {
 	case JobTypeOSBuild:
 		var osbuildJR OSBuildJobResult
-		_, jobDeps, err = s.OSBuildJobStatus(id, &osbuildJR)
+		jobInfo, err = s.OSBuildJobStatus(id, &osbuildJR)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +180,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeDepsolve:
 		var depsolveJR DepsolveJobResult
-		_, jobDeps, err = s.DepsolveJobStatus(id, &depsolveJR)
+		jobInfo, err = s.DepsolveJobStatus(id, &depsolveJR)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +188,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeManifestIDOnly:
 		var manifestJR ManifestJobByIDResult
-		_, jobDeps, err = s.ManifestJobStatus(id, &manifestJR)
+		jobInfo, err = s.ManifestJobStatus(id, &manifestJR)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +196,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeKojiInit:
 		var kojiInitJR KojiInitJobResult
-		_, jobDeps, err = s.KojiInitJobStatus(id, &kojiInitJR)
+		jobInfo, err = s.KojiInitJobStatus(id, &kojiInitJR)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +204,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeKojiFinalize:
 		var kojiFinalizeJR KojiFinalizeJobResult
-		_, jobDeps, err = s.KojiFinalizeJobStatus(id, &kojiFinalizeJR)
+		jobInfo, err = s.KojiFinalizeJobStatus(id, &kojiFinalizeJR)
 		if err != nil {
 			return nil, err
 		}
@@ -205,7 +212,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeContainerResolve:
 		var containerResolveJR ContainerResolveJobResult
-		_, jobDeps, err = s.ContainerResolveJobStatus(id, &containerResolveJR)
+		jobInfo, err = s.ContainerResolveJobStatus(id, &containerResolveJR)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +226,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 		depErrors := []*clienterrors.Error{}
 		if jobError.IsDependencyError() {
 			// check job's dependencies
-			for _, dep := range jobDeps {
+			for _, dep := range jobInfo.Deps {
 				depError, err := s.JobDependencyChainErrors(dep)
 				if err != nil {
 					return nil, err
@@ -240,17 +247,17 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 	return nil, nil
 }
 
-func (s *Server) OSBuildJobStatus(id uuid.UUID, result *OSBuildJobResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) OSBuildJobStatus(id uuid.UUID, result *OSBuildJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if !strings.HasPrefix(jobType, JobTypeOSBuild+":") { // Build jobs get automatic arch suffix: Check prefix
-		return nil, nil, fmt.Errorf("expected \"%s:*\", found %q job instead", JobTypeOSBuild, jobType)
+	if !strings.HasPrefix(jobInfo.JobType, JobTypeOSBuild+":") { // Build jobs get automatic arch suffix: Check prefix
+		return nil, fmt.Errorf("expected \"%s:*\", found %q job instead", JobTypeOSBuild, jobInfo.JobType)
 	}
 
-	if result.JobError == nil && !status.Finished.IsZero() {
+	if result.JobError == nil && !jobInfo.JobStatus.Finished.IsZero() {
 		if result.OSBuildOutput == nil {
 			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed")
 		} else if len(result.OSBuildOutput.Error) > 0 {
@@ -265,51 +272,51 @@ func (s *Server) OSBuildJobStatus(id uuid.UUID, result *OSBuildJobResult) (*JobS
 		result.Success = result.OSBuildOutput.Success && result.JobError == nil
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) KojiInitJobStatus(id uuid.UUID, result *KojiInitJobResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) KojiInitJobStatus(id uuid.UUID, result *KojiInitJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if jobType != JobTypeKojiInit {
-		return nil, nil, fmt.Errorf("expected %q, found %q job instead", JobTypeKojiInit, jobType)
+	if jobInfo.JobType != JobTypeKojiInit {
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeKojiInit, jobInfo.JobType)
 	}
 
 	if result.JobError == nil && result.KojiError != "" {
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorOldResultCompatible, result.KojiError)
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) KojiFinalizeJobStatus(id uuid.UUID, result *KojiFinalizeJobResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) KojiFinalizeJobStatus(id uuid.UUID, result *KojiFinalizeJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if jobType != JobTypeKojiFinalize {
-		return nil, nil, fmt.Errorf("expected %q, found %q job instead", JobTypeKojiFinalize, jobType)
+	if jobInfo.JobType != JobTypeKojiFinalize {
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeKojiFinalize, jobInfo.JobType)
 	}
 
 	if result.JobError == nil && result.KojiError != "" {
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorOldResultCompatible, result.KojiError)
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if jobType != JobTypeDepsolve {
-		return nil, nil, fmt.Errorf("expected %q, found %q job instead", JobTypeDepsolve, jobType)
+	if jobInfo.JobType != JobTypeDepsolve {
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeDepsolve, jobInfo.JobType)
 	}
 
 	if result.JobError == nil && result.Error != "" {
@@ -320,55 +327,60 @@ func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*Jo
 		}
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if jobType != JobTypeManifestIDOnly {
-		return nil, nil, fmt.Errorf("expected %q, found %q job instead", JobTypeManifestIDOnly, jobType)
+	if jobInfo.JobType != JobTypeManifestIDOnly {
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeManifestIDOnly, jobInfo.JobType)
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) ContainerResolveJobStatus(id uuid.UUID, result *ContainerResolveJobResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, _, status, deps, err := s.jobStatus(id, result)
+func (s *Server) ContainerResolveJobStatus(id uuid.UUID, result *ContainerResolveJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobStatus(id, result)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if jobType != JobTypeContainerResolve {
-		return nil, nil, fmt.Errorf("expected %q, found %q job instead", JobTypeDepsolve, jobType)
+	if jobInfo.JobType != JobTypeContainerResolve {
+		return nil, fmt.Errorf("expected %q, found %q job instead", JobTypeDepsolve, jobInfo.JobType)
 	}
 
-	return status, deps, nil
+	return jobInfo, nil
 }
 
-func (s *Server) jobStatus(id uuid.UUID, result interface{}) (string, string, *JobStatus, []uuid.UUID, error) {
+func (s *Server) jobStatus(id uuid.UUID, result interface{}) (*JobInfo, error) {
 	jobType, channel, rawResult, queued, started, finished, canceled, deps, err := s.jobs.JobStatus(id)
 	if err != nil {
-		return "", "", nil, nil, err
+		return nil, err
 	}
 
 	if result != nil && !finished.IsZero() && !canceled {
 		err = json.Unmarshal(rawResult, result)
 		if err != nil {
-			return "", "", nil, nil, fmt.Errorf("error unmarshaling result for job '%s': %v", id, err)
+			return nil, fmt.Errorf("error unmarshaling result for job '%s': %v", id, err)
 		}
 	}
 
-	return jobType, channel, &JobStatus{
-		Queued:   queued,
-		Started:  started,
-		Finished: finished,
-		Canceled: canceled,
-	}, deps, nil
+	return &JobInfo{
+		JobType: strings.Split(jobType, ":")[0],
+		Channel: channel,
+		JobStatus: &JobStatus{
+			Queued:   queued,
+			Started:  started,
+			Finished: finished,
+			Canceled: canceled,
+		},
+		Deps: deps,
+	}, nil
 }
 
 // OSBuildJob returns the parameters of an OSBuildJob
@@ -403,11 +415,11 @@ func (s *Server) JobType(id uuid.UUID) (string, error) {
 }
 
 func (s *Server) Cancel(id uuid.UUID) error {
-	jobType, channel, status, _, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobStatus(id, nil)
 	if err != nil {
 		logrus.Errorf("error getting job status: %v", err)
 	} else {
-		prometheus.CancelJobMetrics(status.Started, jobType, channel)
+		prometheus.CancelJobMetrics(jobInfo.JobStatus.Started, jobInfo.JobType, jobInfo.Channel)
 	}
 	return s.jobs.CancelJob(id)
 }
@@ -419,12 +431,12 @@ func (s *Server) JobArtifact(id uuid.UUID, name string) (io.Reader, int64, error
 		return nil, 0, errors.New("Artifacts not enabled")
 	}
 
-	_, _, status, _, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobStatus(id, nil)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	if status.Finished.IsZero() {
+	if jobInfo.JobStatus.Finished.IsZero() {
 		return nil, 0, fmt.Errorf("Cannot access artifacts before job is finished: %s", id)
 	}
 
@@ -448,12 +460,12 @@ func (s *Server) DeleteArtifacts(id uuid.UUID) error {
 		return errors.New("Artifacts not enabled")
 	}
 
-	_, _, status, _, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobStatus(id, nil)
 	if err != nil {
 		return err
 	}
 
-	if status.Finished.IsZero() {
+	if jobInfo.JobStatus.Finished.IsZero() {
 		return fmt.Errorf("Cannot delete artifacts before job is finished: %s", id)
 	}
 
@@ -502,7 +514,7 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 		return
 	}
 
-	jobType, channel, status, _, err := s.jobStatus(jobId, nil)
+	jobInfo, err := s.jobStatus(jobId, nil)
 	if err != nil {
 		logrus.Errorf("error retrieving job status: %v", err)
 	}
@@ -511,7 +523,8 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 	// long it has been queued for, in case it has no dependencies, or
 	// how long it has been since all its dependencies finished, if it
 	// has any.
-	pending := status.Queued
+	pending := jobInfo.JobStatus.Queued
+	jobType = jobInfo.JobType
 
 	for _, depID := range depIDs {
 		// TODO: include type of arguments
@@ -536,7 +549,7 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 
 	// TODO: Drop the ':$architecture' for metrics too, first prometheus queries for alerts and
 	// dashboards need to be adjusted.
-	prometheus.DequeueJobMetrics(pending, status.Started, jobType, channel)
+	prometheus.DequeueJobMetrics(pending, jobInfo.JobStatus.Started, jobType, jobInfo.Channel)
 	if jobType == JobTypeOSBuild+":"+arch {
 		jobType = JobTypeOSBuild
 	}
@@ -566,13 +579,13 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 	}
 
 	var jobResult JobResult
-	jobType, channel, status, _, err := s.jobStatus(jobId, &jobResult)
+	jobInfo, err := s.jobStatus(jobId, &jobResult)
 	if err != nil {
 		logrus.Errorf("error finding job status: %v", err)
 	} else {
 		statusCode := clienterrors.GetStatusCode(jobResult.JobError)
-		arch := getBuildJobArch(jobType, result)
-		prometheus.FinishJobMetrics(status.Started, status.Finished, status.Canceled, jobType, channel, arch, statusCode)
+		arch := getBuildJobArch(jobInfo.JobType, result)
+		prometheus.FinishJobMetrics(jobInfo.JobStatus.Started, jobInfo.JobStatus.Finished, jobInfo.JobStatus.Canceled, jobInfo.JobType, jobInfo.Channel, arch, statusCode)
 	}
 
 	// Move artifacts from the temporary location to the final job
@@ -723,7 +736,7 @@ func (h *apiHandlers) GetJob(ctx echo.Context, tokenstr string) error {
 
 	h.server.jobs.RefreshHeartbeat(token)
 
-	_, _, status, _, err := h.server.jobStatus(jobId, nil)
+	jobInfo, err := h.server.jobStatus(jobId, nil)
 	if err != nil {
 		return api.HTTPErrorWithInternal(api.ErrorRetrievingJobStatus, err)
 	}
@@ -734,7 +747,7 @@ func (h *apiHandlers) GetJob(ctx echo.Context, tokenstr string) error {
 			Id:   token.String(),
 			Kind: "JobStatus",
 		},
-		Canceled: status.Canceled,
+		Canceled: jobInfo.JobStatus.Canceled,
 	})
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -571,7 +571,8 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 		logrus.Errorf("error finding job status: %v", err)
 	} else {
 		statusCode := clienterrors.GetStatusCode(jobResult.JobError)
-		prometheus.FinishJobMetrics(status.Started, status.Finished, status.Canceled, jobType, channel, statusCode)
+		arch := getBuildJobArch(jobType, result)
+		prometheus.FinishJobMetrics(status.Started, status.Finished, status.Canceled, jobType, channel, arch, statusCode)
 	}
 
 	// Move artifacts from the temporary location to the final job
@@ -585,6 +586,14 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 	}
 
 	return nil
+}
+
+func getBuildJobArch(jobType string, jobResult json.RawMessage) string {
+	if !strings.HasPrefix(jobType, "osbuild:") {
+		return ""
+	}
+	arch := strings.Split(jobType, ":")[1]
+	return arch
 }
 
 // apiHandlers implements api.ServerInterface - the http api route handlers

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -172,7 +172,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 	switch jobType {
 	case JobTypeOSBuild:
 		var osbuildJR OSBuildJobResult
-		jobInfo, err = s.OSBuildJobStatus(id, &osbuildJR)
+		jobInfo, err = s.OSBuildJobInfo(id, &osbuildJR)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +180,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeDepsolve:
 		var depsolveJR DepsolveJobResult
-		jobInfo, err = s.DepsolveJobStatus(id, &depsolveJR)
+		jobInfo, err = s.DepsolveJobInfo(id, &depsolveJR)
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +188,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeManifestIDOnly:
 		var manifestJR ManifestJobByIDResult
-		jobInfo, err = s.ManifestJobStatus(id, &manifestJR)
+		jobInfo, err = s.ManifestJobInfo(id, &manifestJR)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeKojiInit:
 		var kojiInitJR KojiInitJobResult
-		jobInfo, err = s.KojiInitJobStatus(id, &kojiInitJR)
+		jobInfo, err = s.KojiInitJobInfo(id, &kojiInitJR)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeKojiFinalize:
 		var kojiFinalizeJR KojiFinalizeJobResult
-		jobInfo, err = s.KojiFinalizeJobStatus(id, &kojiFinalizeJR)
+		jobInfo, err = s.KojiFinalizeJobInfo(id, &kojiFinalizeJR)
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +212,7 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 
 	case JobTypeContainerResolve:
 		var containerResolveJR ContainerResolveJobResult
-		jobInfo, err = s.ContainerResolveJobStatus(id, &containerResolveJR)
+		jobInfo, err = s.ContainerResolveJobInfo(id, &containerResolveJR)
 		if err != nil {
 			return nil, err
 		}
@@ -247,8 +247,8 @@ func (s *Server) JobDependencyChainErrors(id uuid.UUID) (*clienterrors.Error, er
 	return nil, nil
 }
 
-func (s *Server) OSBuildJobStatus(id uuid.UUID, result *OSBuildJobResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) OSBuildJobInfo(id uuid.UUID, result *OSBuildJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 	if err != nil {
 		return nil, err
 	}
@@ -275,8 +275,8 @@ func (s *Server) OSBuildJobStatus(id uuid.UUID, result *OSBuildJobResult) (*JobI
 	return jobInfo, nil
 }
 
-func (s *Server) KojiInitJobStatus(id uuid.UUID, result *KojiInitJobResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) KojiInitJobInfo(id uuid.UUID, result *KojiInitJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 	if err != nil {
 		return nil, err
 	}
@@ -292,8 +292,8 @@ func (s *Server) KojiInitJobStatus(id uuid.UUID, result *KojiInitJobResult) (*Jo
 	return jobInfo, nil
 }
 
-func (s *Server) KojiFinalizeJobStatus(id uuid.UUID, result *KojiFinalizeJobResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) KojiFinalizeJobInfo(id uuid.UUID, result *KojiFinalizeJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 	if err != nil {
 		return nil, err
 	}
@@ -309,8 +309,8 @@ func (s *Server) KojiFinalizeJobStatus(id uuid.UUID, result *KojiFinalizeJobResu
 	return jobInfo, nil
 }
 
-func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) DepsolveJobInfo(id uuid.UUID, result *DepsolveJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 	if err != nil {
 		return nil, err
 	}
@@ -330,8 +330,8 @@ func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*Jo
 	return jobInfo, nil
 }
 
-func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) ManifestJobInfo(id uuid.UUID, result *ManifestJobByIDResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 	if err != nil {
 		return nil, err
 	}
@@ -343,8 +343,8 @@ func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) 
 	return jobInfo, nil
 }
 
-func (s *Server) ContainerResolveJobStatus(id uuid.UUID, result *ContainerResolveJobResult) (*JobInfo, error) {
-	jobInfo, err := s.jobStatus(id, result)
+func (s *Server) ContainerResolveJobInfo(id uuid.UUID, result *ContainerResolveJobResult) (*JobInfo, error) {
+	jobInfo, err := s.jobInfo(id, result)
 
 	if err != nil {
 		return nil, err
@@ -357,7 +357,7 @@ func (s *Server) ContainerResolveJobStatus(id uuid.UUID, result *ContainerResolv
 	return jobInfo, nil
 }
 
-func (s *Server) jobStatus(id uuid.UUID, result interface{}) (*JobInfo, error) {
+func (s *Server) jobInfo(id uuid.UUID, result interface{}) (*JobInfo, error) {
 	jobType, channel, rawResult, queued, started, finished, canceled, deps, err := s.jobs.JobStatus(id)
 	if err != nil {
 		return nil, err
@@ -415,7 +415,7 @@ func (s *Server) JobType(id uuid.UUID) (string, error) {
 }
 
 func (s *Server) Cancel(id uuid.UUID) error {
-	jobInfo, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobInfo(id, nil)
 	if err != nil {
 		logrus.Errorf("error getting job status: %v", err)
 	} else {
@@ -431,7 +431,7 @@ func (s *Server) JobArtifact(id uuid.UUID, name string) (io.Reader, int64, error
 		return nil, 0, errors.New("Artifacts not enabled")
 	}
 
-	jobInfo, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobInfo(id, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -460,7 +460,7 @@ func (s *Server) DeleteArtifacts(id uuid.UUID) error {
 		return errors.New("Artifacts not enabled")
 	}
 
-	jobInfo, err := s.jobStatus(id, nil)
+	jobInfo, err := s.jobInfo(id, nil)
 	if err != nil {
 		return err
 	}
@@ -514,7 +514,7 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 		return
 	}
 
-	jobInfo, err := s.jobStatus(jobId, nil)
+	jobInfo, err := s.jobInfo(jobId, nil)
 	if err != nil {
 		logrus.Errorf("error retrieving job status: %v", err)
 	}
@@ -584,7 +584,7 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 	switch jobType {
 	case JobTypeOSBuild:
 		var osbuildJR OSBuildJobResult
-		jobInfo, err = s.OSBuildJobStatus(jobId, &osbuildJR)
+		jobInfo, err = s.OSBuildJobInfo(jobId, &osbuildJR)
 		if err != nil {
 			return err
 		}
@@ -593,7 +593,7 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 
 	case JobTypeDepsolve:
 		var depsolveJR DepsolveJobResult
-		jobInfo, err = s.DepsolveJobStatus(jobId, &depsolveJR)
+		jobInfo, err = s.DepsolveJobInfo(jobId, &depsolveJR)
 		if err != nil {
 			return err
 		}
@@ -601,7 +601,7 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 
 	case JobTypeManifestIDOnly:
 		var manifestJR ManifestJobByIDResult
-		jobInfo, err = s.ManifestJobStatus(jobId, &manifestJR)
+		jobInfo, err = s.ManifestJobInfo(jobId, &manifestJR)
 		if err != nil {
 			return err
 		}
@@ -609,7 +609,7 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 
 	case JobTypeKojiInit:
 		var kojiInitJR KojiInitJobResult
-		jobInfo, err = s.KojiInitJobStatus(jobId, &kojiInitJR)
+		jobInfo, err = s.KojiInitJobInfo(jobId, &kojiInitJR)
 		if err != nil {
 			return err
 		}
@@ -617,7 +617,7 @@ func (s *Server) FinishJob(token uuid.UUID, result json.RawMessage) error {
 
 	case JobTypeKojiFinalize:
 		var kojiFinalizeJR KojiFinalizeJobResult
-		jobInfo, err = s.KojiFinalizeJobStatus(jobId, &kojiFinalizeJR)
+		jobInfo, err = s.KojiFinalizeJobInfo(jobId, &kojiFinalizeJR)
 		if err != nil {
 			return err
 		}
@@ -770,7 +770,7 @@ func (h *apiHandlers) GetJob(ctx echo.Context, tokenstr string) error {
 
 	h.server.jobs.RefreshHeartbeat(token)
 
-	jobInfo, err := h.server.jobStatus(jobId, nil)
+	jobInfo, err := h.server.jobInfo(jobId, nil)
 	if err != nil {
 		return api.HTTPErrorWithInternal(api.ErrorRetrievingJobStatus, err)
 	}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -505,8 +505,6 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 	jobType, channel, status, _, err := s.jobStatus(jobId, nil)
 	if err != nil {
 		logrus.Errorf("error retrieving job status: %v", err)
-	} else {
-		prometheus.DequeueJobMetrics(status.Queued, status.Started, jobType, channel)
 	}
 
 	// Record how long the job has been pending for, that is either how

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -516,7 +516,7 @@ func TestMixedOSBuildJob(t *testing.T) {
 	require.NoError(err)
 
 	oldJobResultRead := new(worker.OSBuildJobResult)
-	_, err = server.OSBuildJobStatus(oldJobID, oldJobResultRead)
+	_, err = server.OSBuildJobInfo(oldJobID, oldJobResultRead)
 	require.NoError(err)
 
 	// oldJobResultRead should have PipelineNames now
@@ -554,7 +554,7 @@ func TestMixedOSBuildJob(t *testing.T) {
 	require.NoError(err)
 
 	newJobResultRead := new(worker.OSBuildJobResult)
-	_, err = server.OSBuildJobStatus(newJobID, newJobResultRead)
+	_, err = server.OSBuildJobInfo(newJobID, newJobResultRead)
 	require.NoError(err)
 	require.Equal(newJobResult, newJobResultRead)
 }
@@ -589,7 +589,7 @@ func TestDepsolveLegacyErrorConversion(t *testing.T) {
 		ErrorType: errType,
 	}
 
-	_, err = server.DepsolveJobStatus(depsolveJobId, &depsolveJobResult)
+	_, err = server.DepsolveJobInfo(depsolveJobId, &depsolveJobResult)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, depsolveJobResult)
 }

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -516,7 +516,7 @@ func TestMixedOSBuildJob(t *testing.T) {
 	require.NoError(err)
 
 	oldJobResultRead := new(worker.OSBuildJobResult)
-	_, _, err = server.OSBuildJobStatus(oldJobID, oldJobResultRead)
+	_, err = server.OSBuildJobStatus(oldJobID, oldJobResultRead)
 	require.NoError(err)
 
 	// oldJobResultRead should have PipelineNames now
@@ -554,7 +554,7 @@ func TestMixedOSBuildJob(t *testing.T) {
 	require.NoError(err)
 
 	newJobResultRead := new(worker.OSBuildJobResult)
-	_, _, err = server.OSBuildJobStatus(newJobID, newJobResultRead)
+	_, err = server.OSBuildJobStatus(newJobID, newJobResultRead)
 	require.NoError(err)
 	require.Equal(newJobResult, newJobResultRead)
 }
@@ -589,7 +589,7 @@ func TestDepsolveLegacyErrorConversion(t *testing.T) {
 		ErrorType: errType,
 	}
 
-	_, _, err = server.DepsolveJobStatus(depsolveJobId, &depsolveJobResult)
+	_, err = server.DepsolveJobStatus(depsolveJobId, &depsolveJobResult)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, depsolveJobResult)
 }


### PR DESCRIPTION
This pull request includes:
- updating the prometheus metrics to accept the `arch` label


- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
