### PR TITLE
Embedding container in OSTree commits

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-35": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "527be5081c21a313afb0c0cdeb4c3edadcf2225c"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [
@@ -156,21 +156,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [
@@ -216,14 +216,14 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [
@@ -269,21 +269,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [
@@ -329,7 +329,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "51315a985aa3c26179acead9459db9c249a8b4f6"
+        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
       }
     },
     "repos": [

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -144,6 +144,11 @@ func (cl *Client) SetAuthFilePath(path string) {
 	cl.sysCtx.AuthFilePath = path
 }
 
+// GetAuthFilePath gets the location of the `containers-auth.json(5)` file.
+func (cl *Client) GetAuthFilePath() string {
+	return cl.sysCtx.AuthFilePath
+}
+
 func (cl *Client) SetArchitectureChoice(arch string) {
 	// Translate some well-known Composer architecture strings
 	// into the corresponding container ones

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -2,7 +2,6 @@ package container_test
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -95,7 +94,6 @@ func TestClientAuthFilePath(t *testing.T) {
 		os.Unsetenv("XDG_RUNTIME_DIR")
 
 		authFilePath := container.GetDefaultAuthFile()
-		fmt.Printf("auth file path: %s", authFilePath)
 		assert.NotEmpty(t, authFilePath)
 		_, err = ioutil.ReadFile(authFilePath)
 		assert.True(t, err == nil || os.IsNotExist(err))

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -419,7 +419,16 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 
 	// if we are embedding containers we need to have `skopeo` in the build root
 	if len(bp.Containers) > 0 {
-		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(rpmmd.PackageSet{Include: []string{"skopeo"}})
+
+		extraPkgs := rpmmd.PackageSet{Include: []string{"skopeo"}}
+
+		if t.rpmOstree {
+			// for OSTree based images we need to configure the containers-storage.conf(5)
+			// via the org.osbuild.containers.storage.conf stage, which needs python3-pytoml
+			extraPkgs = extraPkgs.Append(rpmmd.PackageSet{Include: []string{"python3-pytoml"}})
+		}
+
+		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(extraPkgs)
 	}
 
 	// depsolve bp packages separately
@@ -567,10 +576,8 @@ func (t *imageType) Manifest(customizations *blueprint.Customizations,
 // checkOptions checks the validity and compatibility of options and customizations for the image type.
 func (t *imageType) checkOptions(customizations *blueprint.Customizations, options distro.ImageOptions, containers []container.Spec) error {
 
-	// we support embedding containers on all image types that are not ostree based
-	// since we need to store them outside `/var` since that is not preserved in
-	// commits and then point the container `storage.conf` to that extra location
-	if t.rpmOstree && len(containers) > 0 {
+	// we do not support embedding containers on ostree-derived images, only on commits themselves
+	if len(containers) > 0 && t.rpmOstree && (t.name != "edge-commit" && t.name != "edge-container") {
 		return fmt.Errorf("embedding containers is not supported for %s on %s", t.name, t.arch.distro.name)
 	}
 

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -439,7 +439,22 @@ func osPipeline(t *imageType,
 
 	if len(containers) > 0 {
 		images := osbuild.NewContainersInputForSources(containers)
-		skopeo := osbuild.NewSkopeoStage(images, "")
+
+		var storagePath string
+
+		// OSTree commits do not include data in `/var` since that is tied to the
+		// deployment, rather than the commit. Therefore the containers need to be
+		// stored in a different location, like `/usr/share`, and the container
+		// storage engine configured accordingly.
+		if t.rpmOstree {
+			storagePath = "/usr/share/containers/storage"
+			storageConf := "/etc/containers/storage.conf"
+
+			containerStoreOpts := osbuild.NewContainerStorageOptions(storageConf, storagePath)
+			p.AddStage(osbuild.NewContainersStorageConfStage(containerStoreOpts))
+		}
+
+		skopeo := osbuild.NewSkopeoStage(images, storagePath)
 		p.AddStage(skopeo)
 	}
 

--- a/internal/osbuild/containers_storage_conf_stage.go
+++ b/internal/osbuild/containers_storage_conf_stage.go
@@ -1,0 +1,58 @@
+package osbuild
+
+import "fmt"
+
+type CSCStorageOptions struct {
+	AdditionalImageStores []string `json:"additionalimagestores,omitempty"`
+}
+
+// CSCStorage is short for ContainersStorageConfigStorage
+type CSCStorage struct {
+	Options *CSCStorageOptions `json:"options,omitempty"`
+}
+
+type ContainersStorageConfig struct {
+	Storage CSCStorage `json:"storage,omitempty"`
+}
+
+type ContainersStorageConfStageOptions struct {
+	Filename string                  `json:"filename,omitempty"`
+	Config   ContainersStorageConfig `json:"config"`
+	Comment  []string                `json:"comment,omitempty"`
+}
+
+func (ContainersStorageConfStageOptions) isStageOptions() {}
+
+func NewContainerStorageOptions(filename string, additionalImageStores ...string) *ContainersStorageConfStageOptions {
+	options := ContainersStorageConfStageOptions{
+		Filename: filename,
+	}
+
+	if len(additionalImageStores) > 0 {
+		options.Config.Storage.Options = &CSCStorageOptions{
+			AdditionalImageStores: additionalImageStores,
+		}
+	}
+
+	return &options
+}
+
+func (o *ContainersStorageConfStageOptions) validate() error {
+	if o.Filename == "" {
+		return fmt.Errorf("`Filename` must be set")
+	}
+
+	return nil
+}
+
+func NewContainersStorageConfStage(options *ContainersStorageConfStageOptions) *Stage {
+
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.containers.storage.conf",
+		Options: options,
+	}
+}

--- a/internal/osbuild/containers_storage_conf_stage_test.go
+++ b/internal/osbuild/containers_storage_conf_stage_test.go
@@ -1,0 +1,31 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainersStorageConfStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type: "org.osbuild.containers.storage.conf",
+		Options: &ContainersStorageConfStageOptions{
+			Filename: "/usr/share/containers/storage.conf",
+			Config: ContainersStorageConfig{
+				Storage: CSCStorage{
+					Options: &CSCStorageOptions{
+						AdditionalImageStores: []string{
+							"/usr/share/containers/storage/",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actualStage := NewContainersStorageConfStage(
+		NewContainerStorageOptions("/usr/share/containers/storage.conf",
+			"/usr/share/containers/storage/"),
+	)
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -308,10 +308,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 55
-Requires:   osbuild-ostree >= 55
-Requires:   osbuild-lvm2 >= 55
-Requires:   osbuild-luks2 >= 55
+Requires:   osbuild >= 62
+Requires:   osbuild-ostree >= 62
+Requires:   osbuild-lvm2 >= 62
+Requires:   osbuild-luks2 >= 62
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -5,6 +5,7 @@
     workspace: "{{ lookup('env', 'WORKSPACE') }}"
     skip_rollback_test: "false"
     fdo_credential: "false"
+    embeded_container: "false"
     total_counter: "0"
     failed_counter: "0"
 
@@ -150,7 +151,7 @@
     - name: check if it is simplified-installer or raw-image
       command: findmnt -r -o SOURCE -n /sysroot
       register: result_encrypted
-    
+
     - set_fact:
         device_name: "{{ result_encrypted.stdout }}"
       when: "'/dev/mapper/luks-' in result_encrypted.stdout"
@@ -341,6 +342,36 @@
     - name: check dmesg error and fail log
       shell: dmesg --notime | grep -i "error\|fail" || true
       register: result_dmesg_error
+
+    - name: check embeded container image with podman
+      command: podman images
+      become: yes
+      register: result_podman_images
+      when:
+        - embeded_container == "true"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.0', '>')) or
+          (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('8.6', '>') and ansible_facts ['distribution_version'] is version('9.0', '!=')) or
+          (ansible_facts['distribution'] == 'CentOS')
+
+    - name: embded container should be listed by podman images
+      block:
+        - assert:
+            that:
+              - "'quay.io/fedora/fedora' in result_podman_images.stdout"
+            fail_msg: "fedora image is not built in image"
+            success_msg: "fedora image is built in image"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - embeded_container == "true"
+        - (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('9.0', '>')) or
+          (ansible_facts['distribution'] == 'RedHat' and ansible_facts ['distribution_version'] is version('8.6', '>') and ansible_facts ['distribution_version'] is version('9.0', '!=')) or
+          (ansible_facts['distribution'] == 'CentOS')
 
     # case: check running container with podman
     - name: run ubi8 image


### PR DESCRIPTION
Add support for embedding containers in OSTree commits by storing them in `/usr/share/containers/storage`. The storage engine is configured accordingly so that this extra location is automatically taken into account by e.g. `podman`.

