### PR TITLE
Container embedding: support accessing protected resources

### DIFF
--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -55,7 +55,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	store := path.Join(state_dir, "osbuild-store")
 
-	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), false, os.Stdout)
+	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not run osbuild: %s", err.Error())
 	}

--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -50,6 +50,10 @@ type authenticationConfig struct {
 	ClientSecretPath string `toml:"client_secret"`
 }
 
+type containersConfig struct {
+	AuthFilePath string `toml:"auth_file_path"`
+}
+
 type workerConfig struct {
 	Composer       *composerConfig             `toml:"composer"`
 	Koji           map[string]kojiServerConfig `toml:"koji"`
@@ -58,6 +62,7 @@ type workerConfig struct {
 	AWS            *awsConfig                  `toml:"aws"`
 	GenericS3      *genericS3Config            `toml:"generic_s3"`
 	Authentication *authenticationConfig       `toml:"authentication"`
+	Containers     *containersConfig           `toml:"containers"`
 	// default value: /api/worker/v1
 	BasePath string `toml:"base_path"`
 	DNFJson  string `toml:"dnf-json"`

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/osbuild-composer/internal/container"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+type ContainerResolveJobImpl struct {
+	AuthFilePath string
+}
+
+func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
+	logWithId := logrus.WithField("jobId", job.Id())
+	var args worker.ContainerResolveJob
+	err := job.Args(&args)
+	if err != nil {
+		return err
+	}
+
+	result := worker.ContainerResolveJobResult{
+		Specs: make([]worker.ContainerSpec, len(args.Specs)),
+	}
+
+	logWithId.Infof("Resolving containers (%d)", len(args.Specs))
+
+	resolver := container.NewResolver(args.Arch)
+
+	for _, s := range args.Specs {
+		resolver.Add(s.Source, s.Name, s.TLSVerify)
+	}
+
+	specs, err := resolver.Finish()
+
+	if err != nil {
+		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorContainerResolution, err.Error())
+	} else {
+		for i, spec := range specs {
+			result.Specs[i] = worker.ContainerSpec{
+				Source:    spec.Source,
+				Name:      spec.LocalName,
+				TLSVerify: spec.TLSVerify,
+				ImageID:   spec.ImageID,
+				Digest:    spec.Digest,
+			}
+		}
+	}
+
+	err = job.Update(&result)
+	if err != nil {
+		return fmt.Errorf("Error reporting job result: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -29,6 +29,7 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	logWithId.Infof("Resolving containers (%d)", len(args.Specs))
 
 	resolver := container.NewResolver(args.Arch)
+	resolver.AuthFilePath = impl.AuthFilePath
 
 	for _, s := range args.Specs {
 		resolver.Add(s.Source, s.Name, s.TLSVerify)

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -307,7 +307,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	}
 
 	// Run osbuild and handle two kinds of errors
-	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, true, os.Stderr)
+	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, nil, true, os.Stderr)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed")

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -377,6 +377,11 @@ func main() {
 		genericS3SkipSSLVerification = config.GenericS3.SkipSSLVerification
 	}
 
+	var containersAuthFilePath string
+	if config.Containers != nil {
+		containersAuthFilePath = config.Containers.AuthFilePath
+	}
+
 	// depsolve jobs can be done during other jobs
 	depsolveCtx, depsolveCtxCancel := context.WithCancel(context.Background())
 	solver := dnfjson.NewBaseSolver(rpmmd_cache)
@@ -430,11 +435,17 @@ func main() {
 				CABundle:            genericS3CABundle,
 				SkipSSLVerification: genericS3SkipSSLVerification,
 			},
+			ContainerAuthFile: containersAuthFilePath,
 		},
 		worker.JobTypeKojiInit: &KojiInitJobImpl{
 			KojiServers: kojiServers,
 		},
-		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{},
+		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{
+			KojiServers: kojiServers,
+		},
+		worker.JobTypeContainerResolve: &ContainerResolveJobImpl{
+			AuthFilePath: containersAuthFilePath,
+		},
 	}
 
 	acceptedJobTypes := []string{}

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -434,9 +434,7 @@ func main() {
 		worker.JobTypeKojiInit: &KojiInitJobImpl{
 			KojiServers: kojiServers,
 		},
-		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{
-			KojiServers: kojiServers,
-		},
+		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{},
 	}
 
 	acceptedJobTypes := []string{}

--- a/internal/container/resolver.go
+++ b/internal/container/resolver.go
@@ -17,7 +17,8 @@ type Resolver struct {
 
 	ctx context.Context
 
-	Arch string
+	Arch         string
+	AuthFilePath string
 }
 
 func NewResolver(arch string) Resolver {
@@ -39,6 +40,9 @@ func (r *Resolver) Add(source, name string, TLSVerify *bool) {
 
 	client.SetTLSVerify(TLSVerify)
 	client.SetArchitectureChoice(r.Arch)
+	if r.AuthFilePath != "" {
+		client.SetAuthFilePath(r.AuthFilePath)
+	}
 
 	go func() {
 		spec, err := client.Resolve(r.ctx, name)

--- a/internal/osbuild/osbuild-exec.go
+++ b/internal/osbuild/osbuild-exec.go
@@ -14,7 +14,7 @@ import (
 // Note that osbuild returns non-zero when the pipeline fails. This function
 // does not return an error in this case. Instead, the failure is communicated
 // with its corresponding logs through osbuild.Result.
-func RunOSBuild(manifest []byte, store, outputDirectory string, exports, checkpoints []string, result bool, errorWriter io.Writer) (*Result, error) {
+func RunOSBuild(manifest []byte, store, outputDirectory string, exports, checkpoints, extraEnv []string, result bool, errorWriter io.Writer) (*Result, error) {
 	var stdoutBuffer bytes.Buffer
 	var res Result
 
@@ -39,6 +39,11 @@ func RunOSBuild(manifest []byte, store, outputDirectory string, exports, checkpo
 	} else {
 		cmd.Stdout = os.Stdout
 	}
+
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+
 	cmd.Stderr = errorWriter
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -30,6 +30,7 @@ const (
 	ErrorJobMissingHeartbeat  ClientErrorCode = 27
 	ErrorTargetError          ClientErrorCode = 28
 	ErrorParsingJobArgs       ClientErrorCode = 29
+	ErrorContainerResolution  ClientErrorCode = 30
 )
 
 type ClientErrorCode int
@@ -82,6 +83,8 @@ func GetStatusCode(err *Error) StatusCode {
 	case ErrorEmptyPackageSpecs:
 		return JobStatusUserInputError
 	case ErrorEmptyManifest:
+		return JobStatusUserInputError
+	case ErrorContainerResolution:
 		return JobStatusUserInputError
 	default:
 		return JobStatusInternalError

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -236,6 +236,26 @@ type ManifestJobByIDResult struct {
 	JobResult
 }
 
+type ContainerSpec struct {
+	Source    string `json:"source"`
+	Name      string `json:"name"`
+	TLSVerify *bool  `json:"tls-verify,omitempty"`
+
+	ImageID string `json:"image_id"`
+	Digest  string `json:"digest"`
+}
+
+type ContainerResolveJob struct {
+	Arch  string          `json:"arch"`
+	Specs []ContainerSpec `json:"specs"`
+}
+
+type ContainerResolveJobResult struct {
+	Specs []ContainerSpec `json:"specs"`
+
+	JobResult
+}
+
 //
 // JSON-serializable types for the client
 //


### PR DESCRIPTION
The osbuild worker gained a new configuration section `containers` with a new key `auth_file_path` to be able to specify a `containers-auth.conf(5)` file to be used for request. All container resolution is moved to a new worker job type so that there is only one central place that does container resolution. The containers auth file, if specified, is also forwarded to `osbuild` via the `REGISTRY_AUTH_FILE` file that is then used by `skopeo` in the `org.osbuild.skopeo` source.