### PR TITLE
Fix UEFI HTTP boot for RHEL 9 ISOs

### DIFF
--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -1223,6 +1223,7 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			"nmap-ncat",
 			"nm-connection-editor",
 			"nss-tools",
+			"nvme-cli", // for nvmf dracut module
 			"openssh-clients",
 			"openssh-server",
 			"oscap-anaconda-addon",

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -1058,6 +1058,9 @@ func anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec
 		"rdma",
 		"rngd",
 	})
+	// drivers / kernel modules to add explicitly for parity with the official
+	// RHEL 9.0 ISO
+	dso.AddDrivers = []string{"cuse", "ipmi_devintf", "ipmi_msghandler"}
 	p.AddStage(osbuild.NewDracutStage(dso))
 	p.AddStage(osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
 

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -1045,17 +1045,20 @@ func anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec
 	p.AddStage(osbuild.NewUsersStage(usersStageOptions))
 	p.AddStage(osbuild.NewAnacondaStage(osbuild.NewAnacondaStageOptions(users)))
 	p.AddStage(osbuild.NewLoraxScriptStage(loraxScriptStageOptions(arch)))
-	p.AddStage(osbuild.NewDracutStage(dracutStageOptions(kernelVer, arch, []string{
+	dso := dracutStageOptions(kernelVer, arch, []string{
 		"anaconda",
-		"rdma",
-		"rngd",
-		"multipath",
 		"fcoe",
 		"fcoe-uefi",
 		"iscsi",
 		"lunmask",
+		"multipath",
 		"nfs",
-	})))
+		"nvdimm", // non-volatile DIMM firmware (provides nfit, cuse, and nd_e820)
+		"nvmf",
+		"rdma",
+		"rngd",
+	})
+	p.AddStage(osbuild.NewDracutStage(dso))
 	p.AddStage(osbuild.NewSELinuxConfigStage(&osbuild.SELinuxConfigStageOptions{State: osbuild.SELinuxStatePermissive}))
 
 	return p

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -56,10 +56,8 @@ sudo dnf build-dep -y osbuild-composer.spec
 manifestdir=$(mktemp -d)
 
 greenprint "Generating all manifests for HEAD (PR #${prnum})"
-go run ./cmd/gen-manifests --output "${manifestdir}/PR" --workers 50
-err=$?
-if (( err != 0 )); then
-    greenprint "Manifest generation on PR HEAD failed"
+if ! go run ./cmd/gen-manifests --output "${manifestdir}/PR" --workers 50; then
+    redprint "Manifest generation on PR HEAD failed"
     exit 1
 fi
 
@@ -72,21 +70,14 @@ greenprint "Generating all manifests for merge-base (${mergebase})"
 # NOTE: it's not an error if this task fails; manifest generation on base
 # branch can be broken in a PR that fixes it.
 # As long as the generation on the PR HEAD succeeds, the job should succeed.
-go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50
-err=$?
 merge_base_fail=""
-if (( err != 0 )); then
-    greenprint "Manifest generation on merge-base failed"
+if ! go run ./cmd/gen-manifests --output "${manifestdir}/${mergebase}" --workers 50; then
+    redprint "Manifest generation on merge-base failed"
     merge_base_fail="**NOTE:** Manifest generation on merge-base with \`${basebranch}\` (${mergebase}) failed.\n\n"
 fi
 
 greenprint "Diff: ${manifestdir}/${mergebase} ${manifestdir}/PR"
-diff=$(diff -Naur "${manifestdir}"/"${mergebase}" "${manifestdir}/PR")
-err=$?
-
-review_data_file="review.json"
-
-if (( err == 0 )); then
+if diff=$(diff -Naur "${manifestdir}"/"${mergebase}" "${manifestdir}/PR"); then
     greenprint "No changes in manifests"
     exit 0
 fi
@@ -97,6 +88,7 @@ greenprint "Saved diff in job artifacts"
 
 artifacts_url="${CI_JOB_URL}/artifacts/browse"
 
+review_data_file="review.json"
 cat > "${review_data_file}" << EOF
 {"body":"⚠️ This PR introduces changes in at least one manifest (when comparing PR HEAD ${head} with the ${basebranch} merge-base ${mergebase}).  Please review the changes.  The changes can be found in the [artifacts of the \`Manifest-diff\` job [0]](${artifacts_url}) as \`manifests.diff\`.\n\n${merge_base_fail}[0] ${artifacts_url}","event":"COMMENT"}
 EOF

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -9115,6 +9115,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -8129,6 +8129,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -9096,14 +9104,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -10761,6 +10771,9 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
+          },
+          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -22083,6 +22096,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -8158,6 +8158,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -9126,14 +9134,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -10813,6 +10823,9 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
+          },
+          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -22135,6 +22148,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -9145,6 +9145,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -11822,6 +11822,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -12790,14 +12798,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -14444,6 +14454,9 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
+          },
+          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -25727,6 +25740,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -12809,6 +12809,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -11851,6 +11851,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -12819,14 +12827,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -14495,6 +14505,9 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
+          },
+          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -25778,6 +25791,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -12838,6 +12838,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -9276,6 +9276,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -8272,6 +8272,14 @@
                     }
                   },
                   {
+                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -9257,14 +9265,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -10892,6 +10902,9 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
+          },
+          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -22453,6 +22466,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -9306,6 +9306,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -8301,6 +8301,14 @@
                     }
                   },
                   {
+                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -9287,14 +9295,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -10944,6 +10954,9 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
+          },
+          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -22505,6 +22518,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -13035,6 +13035,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -12030,6 +12030,14 @@
                     }
                   },
                   {
+                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -13016,14 +13024,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -14642,6 +14652,9 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
+          },
+          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -26167,6 +26180,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
@@ -13064,6 +13064,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
@@ -12059,6 +12059,14 @@
                     }
                   },
                   {
+                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -13045,14 +13053,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -14693,6 +14703,9 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
+          },
+          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -26218,6 +26231,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -3580,6 +3580,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -1724,6 +1724,9 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
+                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -3566,14 +3569,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -4571,6 +4576,9 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
+          },
+          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -11473,6 +11481,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
+        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -1753,6 +1753,9 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
+                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -3596,14 +3599,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -4623,6 +4628,9 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
+          },
+          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -11525,6 +11533,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
+        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -3610,6 +3610,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -5035,6 +5035,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -3178,6 +3178,9 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
+                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -5021,14 +5024,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -6036,6 +6041,9 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
+          },
+          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -12887,6 +12895,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
+        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -5064,6 +5064,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -3207,6 +3207,9 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
+                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -5050,14 +5053,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -6087,6 +6092,9 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
+          },
+          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -12938,6 +12946,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
+        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -3644,6 +3644,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -1763,6 +1763,9 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
+                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -3630,14 +3633,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -5586,6 +5591,9 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
+          },
+          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -11699,6 +11707,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
+        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -1792,6 +1792,9 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
+                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -3660,14 +3663,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -5638,6 +5643,9 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
+          },
+          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -11751,6 +11759,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
+        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -3674,6 +3674,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -5126,6 +5126,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -3244,6 +3244,9 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
+                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -5112,14 +5115,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -7083,6 +7088,9 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
+          },
+          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -13142,6 +13150,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
+        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
@@ -3273,6 +3273,9 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
+                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -5141,14 +5144,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -7134,6 +7139,9 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
+          },
+          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -13193,6 +13201,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "2.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
+        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
@@ -5155,6 +5155,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -9275,6 +9275,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -4489,6 +4489,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -9256,14 +9264,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -11368,6 +11378,9 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
+          },
+          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -17747,6 +17760,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
+        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -9305,6 +9305,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -4518,6 +4518,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -9286,14 +9294,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -11420,6 +11430,9 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
+          },
+          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -17799,6 +17812,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
+        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -8302,6 +8302,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -13070,14 +13078,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -15192,6 +15202,9 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
+          },
+          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -21511,6 +21524,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
+        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -13089,6 +13089,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -13118,6 +13118,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -8331,6 +8331,14 @@
                     }
                   },
                   {
+                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -13099,14 +13107,16 @@
                 "shutdown",
                 "uefi-lib",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -15243,6 +15253,9 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
+          },
+          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -21562,6 +21575,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
+        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -4593,6 +4593,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -9433,14 +9441,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -11902,6 +11912,9 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
+          },
+          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -18102,6 +18115,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
+        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -9452,6 +9452,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -4622,6 +4622,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -9463,14 +9471,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -11954,6 +11964,9 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
+          },
+          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -18154,6 +18167,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
+        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -9482,6 +9482,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
@@ -8478,6 +8478,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -13319,14 +13327,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -15812,6 +15822,9 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
+          },
+          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -21940,6 +21953,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
+        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
@@ -13338,6 +13338,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
@@ -13367,6 +13367,11 @@
                 "rdma",
                 "rngd"
               ],
+              "add_drivers": [
+                "cuse",
+                "ipmi_devintf",
+                "ipmi_msghandler"
+              ],
               "install": [
                 "/.buildstamp"
               ]

--- a/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
@@ -8507,6 +8507,14 @@
                     }
                   },
                   {
+                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -13348,14 +13356,16 @@
                 "uefi-lib",
                 "biosdevname",
                 "anaconda",
-                "rdma",
-                "rngd",
-                "multipath",
                 "fcoe",
                 "fcoe-uefi",
                 "iscsi",
                 "lunmask",
-                "nfs"
+                "multipath",
+                "nfs",
+                "nvdimm",
+                "nvmf",
+                "rdma",
+                "rngd"
               ],
               "install": [
                 "/.buildstamp"
@@ -15863,6 +15873,9 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
+          },
+          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -21991,6 +22004,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "nvme-cli",
+        "epoch": 0,
+        "version": "1.16",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
+        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
The RHEL 9 and CS9 ISOs would fail to boot over UEFI HTTP.  Added the necessary dracut and kernel modules to support this.

The second commit adds all kernel modules that are in the official RHEL 9 ISO's initramfs and were not on ours.

See rhbz#2030730

Manifests regenerated for each commit.  Image info dropped for all updated manifests that had any.