### PR TITLE
distro/rhel7: blacklist skx_edac,intel_cstate kernel modules on azure

### DIFF
--- a/internal/distro/rhel7/azure.go
+++ b/internal/distro/rhel7/azure.go
@@ -257,6 +257,24 @@ var azureRhuiImgType = imageType{
 		},
 		Modprobe: []*osbuild.ModprobeStageOptions{
 			{
+				Filename: "blacklist-amdgpu.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+				},
+			},
+			{
+				Filename: "blacklist-intel-cstate.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+				},
+			},
+			{
+				Filename: "blacklist-floppy.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+				},
+			},
+			{
 				Filename: "blacklist-nouveau.conf",
 				Commands: osbuild.ModprobeConfigCmdList{
 					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
@@ -264,9 +282,9 @@ var azureRhuiImgType = imageType{
 				},
 			},
 			{
-				Filename: "blacklist-floppy.conf",
+				Filename: "blacklist-skylake-edac.conf",
 				Commands: osbuild.ModprobeConfigCmdList{
-					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+					osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
 				},
 			},
 		},

--- a/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
@@ -2382,6 +2382,42 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-intel-cstate.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "intel_cstate"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-floppy.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "floppy"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.modprobe",
+            "options": {
               "filename": "blacklist-nouveau.conf",
               "commands": [
                 {
@@ -2398,11 +2434,11 @@
           {
             "type": "org.osbuild.modprobe",
             "options": {
-              "filename": "blacklist-floppy.conf",
+              "filename": "blacklist-skylake-edac.conf",
               "commands": [
                 {
                   "command": "blacklist",
-                  "modulename": "floppy"
+                  "modulename": "skx_edac"
                 }
               ]
             }


### PR DESCRIPTION
This was done in RHEL 8, 9 but RHEL 7 was not yet merged so this was missed there. See e.g. 5c1530ee53fec2649eda24bd635e4a75275b12e2

See also  #2706 and #2717