### PR TITLE
CI: drop /tmp/artifacts upload to Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -666,7 +666,7 @@ Manifest-diff:
     GIT_DEPTH: 500
   artifacts:
     paths:
-      - "/tmp/artifacts"
+      - manifests.diff
 
 SCHEDULED_CLOUD_CLEANER:
   stage: cleanup

--- a/schutzbot/upload_artifacts.sh
+++ b/schutzbot/upload_artifacts.sh
@@ -10,7 +10,7 @@ ARTIFACTS=${ARTIFACTS:-/tmp/artifacts}
 function greenprint {
   echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
-
+source /etc/os-release
 # s3cmd is in epel, add if it's not present
 if [[ $ID == rhel || $ID == centos ]] && ! rpm -q epel-release; then
     curl -Ls --retry 5 --output /tmp/epel.rpm \

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-artifacts="/tmp/artifacts"
-mkdir -p "${artifacts}"
-
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
@@ -90,10 +87,10 @@ if (( err == 0 )); then
 fi
 
 greenprint "Manifests differ"
-echo "${diff}" > "${artifacts}/manifests.diff"
+echo "${diff}" > "manifests.diff"
 greenprint "Saved diff in job artifacts"
 
-artifacts_url="${CI_JOB_URL}/artifacts/browse/ci-artifacts"
+artifacts_url="${CI_JOB_URL}/artifacts/browse"
 
 cat > "${review_data_file}" << EOF
 {"body":"⚠️ This PR introduces changes in at least one manifest (when comparing PR HEAD ${head} with the ${basebranch} merge-base ${mergebase}).  Please review the changes.  The changes can be found in the [artifacts of the \`Manifest-diff\` job [0]](${artifacts_url}) as \`manifests.diff\`.\n\n${merge_base_fail}[0] ${artifacts_url}","event":"COMMENT"}

--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -9,6 +9,9 @@ function greenprint {
 function redprint {
     echo -e "\033[1;31m[$(date -Isecond)] ${1}\033[0m"
 }
+function revert_to_head {
+   git checkout "$head"
+}
 
 if [[ "${CI_COMMIT_BRANCH}" != PR-* ]]; then
     greenprint "${CI_COMMIT_BRANCH} is not a Pull Request"
@@ -60,6 +63,8 @@ if (( err != 0 )); then
     exit 1
 fi
 
+# revert to $head on exit
+trap revert_to_head EXIT
 greenprint "Checking out merge-base ${mergebase}"
 git checkout "${mergebase}"
 


### PR DESCRIPTION
Contents of this folder are uploaded to S3 with shutzbot/upload_artifacts.sh
Also fixing epel installation in the mentioned script.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
