### PR TITLE
Fix Go 1.19 issues (stable `fstab` ordering and wrong `errors.As` usages)

### DIFF
--- a/internal/osbuild/fstab_stage.go
+++ b/internal/osbuild/fstab_stage.go
@@ -1,6 +1,7 @@
 package osbuild
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/osbuild/osbuild-composer/internal/disk"
@@ -64,10 +65,14 @@ func NewFSTabStageOptions(pt *disk.PartitionTable) *FSTabStageOptions {
 		return nil
 	}
 
+	key := func(fs *FSTabEntry) string {
+		return fmt.Sprintf("%d%s", fs.PassNo, fs.Path)
+	}
+
 	_ = pt.ForEachMountable(genOption) // genOption always returns nil
 	// sort the entries by PassNo to maintain backward compatibility
 	sort.Slice(options.FileSystems, func(i, j int) bool {
-		return options.FileSystems[i].PassNo < options.FileSystems[j].PassNo
+		return key(options.FileSystems[i]) < key(options.FileSystems[j])
 	})
 	return &options
 }

--- a/pkg/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/pkg/jobqueue/dbjobqueue/dbjobqueue.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
 
 	logrus "github.com/sirupsen/logrus"
@@ -229,7 +230,7 @@ func (q *DBJobQueue) Enqueue(jobType string, args interface{}, dependencies []uu
 	}
 	defer func() {
 		err := tx.Rollback(context.Background())
-		if err != nil && !errors.As(err, &pgx.ErrTxClosed) {
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
 			logrus.Error("error rolling back enqueue transaction: ", err)
 		}
 	}()
@@ -283,7 +284,7 @@ func (q *DBJobQueue) Dequeue(ctx context.Context, jobTypes []string, channels []
 		if err == nil {
 			break
 		}
-		if err != nil && !errors.As(err, &pgx.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return uuid.Nil, uuid.Nil, nil, "", nil, fmt.Errorf("error dequeuing job: %v", err)
 		}
 
@@ -384,7 +385,7 @@ func (q *DBJobQueue) FinishJob(id uuid.UUID, result interface{}) error {
 	}
 	defer func() {
 		err = tx.Rollback(context.Background())
-		if err != nil && !errors.As(err, &pgx.ErrTxClosed) {
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
 			logrus.Errorf("error rolling back finish job transaction for job %s: %v", id, err)
 		}
 

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -5394,15 +5394,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -5919,15 +5919,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -6327,15 +6327,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -6015,15 +6015,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_9-aarch64-ami-boot.json
@@ -5106,15 +5106,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_9-aarch64-openstack-boot.json
@@ -5077,15 +5077,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2-boot.json
@@ -5123,15 +5123,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -5368,15 +5368,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
@@ -5611,15 +5611,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -5856,15 +5856,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-s390x-qcow2-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2-boot.json
@@ -6307,15 +6307,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -6552,15 +6552,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_9-x86_64-ami-boot.json
@@ -4958,15 +4958,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_9-x86_64-gce-boot.json
@@ -5150,15 +5150,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-oci-boot.json
+++ b/test/data/manifests/centos_9-x86_64-oci-boot.json
@@ -5262,15 +5262,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_9-x86_64-openstack-boot.json
@@ -5341,15 +5341,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2-boot.json
@@ -5283,15 +5283,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -5624,15 +5624,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vhd-boot.json
@@ -5287,15 +5287,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/centos_9-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vmdk-boot.json
@@ -5341,15 +5341,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -4475,15 +4475,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-oci-boot.json
@@ -4478,15 +4478,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-openstack-boot.json
@@ -4690,15 +4690,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
@@ -4499,15 +4499,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
@@ -4746,15 +4746,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-ami-boot.json
@@ -4467,15 +4467,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-oci-boot.json
@@ -4590,15 +4590,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-openstack-boot.json
@@ -4730,15 +4730,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
@@ -4611,15 +4611,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
@@ -4858,15 +4858,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vhd-boot.json
@@ -4349,15 +4349,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
@@ -4610,15 +4610,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-ami-boot.json
@@ -4843,15 +4843,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-oci-boot.json
@@ -4830,15 +4830,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-openstack-boot.json
@@ -5074,15 +5074,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2-boot.json
@@ -4851,15 +4851,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-qcow2_customize-boot.json
@@ -5272,15 +5272,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-ami-boot.json
@@ -4883,15 +4883,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-oci-boot.json
@@ -4974,15 +4974,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-openstack-boot.json
@@ -5154,15 +5154,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2-boot.json
@@ -4995,15 +4995,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-qcow2_customize-boot.json
@@ -5416,15 +5416,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vhd-boot.json
@@ -4797,15 +4797,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-vmdk-boot.json
@@ -4994,15 +4994,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "ext4",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "ext4",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
@@ -2501,9 +2501,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2519,12 +2519,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -2534,6 +2528,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
@@ -1693,15 +1693,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -1810,15 +1810,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -2242,15 +2242,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_8-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ec2-boot.json
@@ -2258,15 +2258,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_8-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-azure_rhui-boot.json
@@ -2974,9 +2974,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2992,12 +2992,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -3007,6 +3001,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -2275,15 +2275,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_84-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ec2-boot.json
@@ -2291,15 +2291,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_84-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-azure_rhui-boot.json
@@ -3004,9 +3004,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -3022,12 +3022,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -3037,6 +3031,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -2239,15 +2239,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -2255,15 +2255,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -2457,6 +2457,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/usr",
@@ -2466,12 +2472,6 @@
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/var",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -2619,6 +2619,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/usr",
@@ -2628,12 +2634,6 @@
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/var",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -2725,6 +2725,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/usr",
@@ -2734,12 +2740,6 @@
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/var",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
@@ -2977,9 +2977,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2995,12 +2995,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -3010,6 +3004,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -2496,6 +2496,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/usr",
@@ -2505,12 +2511,6 @@
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/var",
-                  "options": "defaults"
-                },
-                {
-                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -2242,15 +2242,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -2258,15 +2258,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -2458,15 +2458,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -2611,15 +2611,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -2708,15 +2708,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
@@ -2974,9 +2974,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2992,12 +2992,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -3007,6 +3001,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -2497,15 +2497,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_87-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ami-boot.json
@@ -2239,15 +2239,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_87-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ec2-boot.json
@@ -2255,15 +2255,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
@@ -2458,15 +2458,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
@@ -2611,15 +2611,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
@@ -2708,15 +2708,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
@@ -2974,9 +2974,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2992,12 +2992,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -3007,6 +3001,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
@@ -2497,15 +2497,15 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-                  "vfs_type": "xfs",
-                  "path": "/opt",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
                   "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -2127,15 +2127,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -2146,15 +2146,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-openstack-boot.json
@@ -2029,15 +2029,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -2078,15 +2078,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -2243,15 +2243,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -2267,15 +2267,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -2432,15 +2432,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -2525,15 +2525,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -2690,15 +2690,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -2085,15 +2085,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2827,9 +2827,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -2845,12 +2845,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -2860,6 +2854,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -2106,15 +2106,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -2678,15 +2678,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -3661,15 +3661,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce-boot.json
@@ -2177,15 +2177,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
@@ -2183,15 +2183,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-oci-boot.json
@@ -2117,15 +2117,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-openstack-boot.json
@@ -2131,15 +2131,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -2138,15 +2138,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -2339,15 +2339,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vhd-boot.json
@@ -2117,15 +2117,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -2131,15 +2131,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -5228,15 +5228,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -5258,15 +5258,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-openstack-boot.json
@@ -5165,15 +5165,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
@@ -5296,15 +5296,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -5549,15 +5549,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
@@ -5800,15 +5800,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -6053,15 +6053,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2-boot.json
@@ -6488,15 +6488,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 }
               ]

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -6741,15 +6741,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -5096,15 +5096,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -7013,9 +7013,9 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
                   "vfs_type": "xfs",
-                  "path": "/var",
+                  "path": "/",
                   "options": "defaults"
                 },
                 {
@@ -7031,12 +7031,6 @@
                   "options": "defaults"
                 },
                 {
-                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
-                  "vfs_type": "xfs",
-                  "path": "/",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "a178892e-e285-4ce1-9114-55780875d64e",
                   "vfs_type": "xfs",
                   "path": "/tmp",
@@ -7046,6 +7040,12 @@
                   "uuid": "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
                   "vfs_type": "xfs",
                   "path": "/usr",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "f83b8e88-3bbf-457a-ab99-c5b252c7429c",
+                  "vfs_type": "xfs",
+                  "path": "/var",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -5128,15 +5128,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -6636,15 +6636,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -9071,15 +9071,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce-boot.json
@@ -5344,15 +5344,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
@@ -5350,15 +5350,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-oci-boot.json
@@ -5435,15 +5435,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-openstack-boot.json
@@ -5437,15 +5437,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
@@ -5456,15 +5456,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -5805,15 +5805,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vhd-boot.json
@@ -5383,15 +5383,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {

--- a/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
@@ -5437,15 +5437,15 @@
             "options": {
               "filesystems": [
                 {
-                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-                  "vfs_type": "xfs",
-                  "path": "/boot",
-                  "options": "defaults"
-                },
-                {
                   "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
                   "vfs_type": "xfs",
                   "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
                   "options": "defaults"
                 },
                 {


### PR DESCRIPTION
Two fixes for Go 1.19

##  osbuild: use path as secondary sort key for fstab 

Most filesystems entries in `fstab` don't have a `PassNo`, which makes the order of those entries dependent on the sorting algorithm.  Changes in the algorithm can introduce changes in the sort order, which we don't like. This has happened with `go 1.19`, breaking our copr builds.

Add a secondary sorting key, the Path, which is guaranteed unique, to guarantee stable ordering.

## dbjobqueue: fix bad errors.As usages

`errors.As` is meant to check whether err (or other error in its chain) can be assigned to the value that target is pointing at.

Let's consider this example:

```
errors.As(err, &pgx.ErrNoRows)
```

`pgx.ErrNoRows` (and `pgx.ErrTxClosed`) is typed as `error`, thus in all `errors.As` calls, the target is typed as `*error`. `err` is always an `error`. So this call is basically asking whether `error` can be assigned to `error`. If `err != nil`, this is always `true`, thus this check doesn't make any sense over a plain `err != nil`.

Go 1.19 now checks this issue and if it's found, it refuses to compile the code, see:

https://go-review.googlesource.com/c/tools/+/339889

This commit changes usages of `errors.As()` to `errors.Is()`. The `Is()` method doesn't check assignability but equality (the only different between `Is()` and a plain old `==` operator is that `Is()` also inspects the whole error chain).

This fixes the check because now, we are basically checking if `err` (or any other error in its chain) `== pgx.ErrTxClosed` which is exactly what we want.