### PR TITLE
Exclude dracut-config-rescue in ec2 and qemu-guest-agent in ec2 and gce images

### DIFF
--- a/internal/distro/rhel8/package_sets.go
+++ b/internal/distro/rhel8/package_sets.go
@@ -538,7 +538,6 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"langpacks-en",
 			"NetworkManager",
 			"NetworkManager-cloud-setup",
-			"qemu-guest-agent",
 			"redhat-release",
 			"redhat-release-eula",
 			"rsync",
@@ -573,6 +572,8 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"libertas-sd8787-firmware",
 			"libertas-usb8388-firmware",
 			"plymouth",
+			// RHBZ#2075815
+			"qemu-guest-agent",
 		},
 	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
 }
@@ -681,8 +682,6 @@ func gceCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			// for time synchronization
 			"chrony",
 			"timedatex",
-			// Detected Platform requirements by Anaconda
-			"qemu-guest-agent",
 			// EFI
 			"grub2-tools-efi",
 		},
@@ -722,6 +721,8 @@ func gceCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"rt73usb-firmware",
 			"xorg-x11-drv-ati-firmware",
 			"zd1211-firmware",
+			// RHBZ#2075815
+			"qemu-guest-agent",
 		},
 	}.Append(bootPackageSet(t)).Append(distroSpecificPackageSet(t))
 }

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -698,7 +698,6 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"redhat-release-eula",
 			"rsync",
 			"tar",
-			"qemu-guest-agent",
 		},
 		Exclude: []string{
 			"aic94xx-firmware",
@@ -711,6 +710,8 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"plymouth",
 			// RHBZ#2064087
 			"dracut-config-rescue",
+			// RHBZ#2075815
+			"qemu-guest-agent",
 		},
 	}.Append(bootPackageSet(t)).Append(coreOsCommonPackageSet(t)).Append(distroSpecificPackageSet(t))
 }
@@ -817,8 +818,6 @@ func gceCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			// for time synchronization
 			"chrony",
 			"timedatex",
-			// Detected Platform requirements by Anaconda
-			"qemu-guest-agent",
 			// EFI
 			"grub2-tools-efi",
 			"firewalld", // not pulled in any more as on RHEL-8
@@ -859,6 +858,8 @@ func gceCommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"rt73usb-firmware",
 			"xorg-x11-drv-ati-firmware",
 			"zd1211-firmware",
+			// RHBZ#2075815
+			"qemu-guest-agent",
 		},
 	}.Append(bootPackageSet(t)).Append(coreOsCommonPackageSet(t)).Append(distroSpecificPackageSet(t))
 

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -688,7 +688,6 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"cloud-init",
 			"cloud-utils-growpart",
 			"dhcp-client",
-			"dracut-config-rescue",
 			"yum-utils",
 			"dracut-config-generic",
 			"gdisk",
@@ -710,6 +709,8 @@ func ec2CommonPackageSet(t *imageType) rpmmd.PackageSet {
 			"ivtv-firmware",
 			"libertas-sd8787-firmware",
 			"plymouth",
+			// RHBZ#2064087
+			"dracut-config-rescue",
 		},
 	}.Append(bootPackageSet(t)).Append(coreOsCommonPackageSet(t)).Append(distroSpecificPackageSet(t))
 }

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -5172,14 +5172,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b590e504fdbdf084fc31afad64e5619932fe324b71b0f2591068d08d30717d23",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:08b3506e03f120f39bd5e7f81c04898229c6682d90d55bc703ae71c5d6cf9958",
                     "options": {
                       "metadata": {
@@ -6532,9 +6524,6 @@
           },
           "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libzstd-1.4.4-1.el8.aarch64.rpm"
-          },
-          "sha256:b590e504fdbdf084fc31afad64e5619932fe324b71b0f2591068d08d30717d23": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.aarch64.rpm"
           },
           "sha256:b62589101a60a365ef34447cae78f62e6dba560d403dc56c87036709ea00ad88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libidn2-2.2.0-1.el8.aarch64.rpm"
@@ -13273,16 +13262,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:867c11abf3105a23b5bf1aa25d2d530fa3322d5f4c70a0757ea92b62b0d7649f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.1.0",
-        "release": "5.module_el8.6.0+1040+0ae94936",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.aarch64.rpm",
-        "checksum": "sha256:b590e504fdbdf084fc31afad64e5619932fe324b71b0f2591068d08d30717d23",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -4996,14 +4996,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c7bfe545f212a230e12bb9ef202c6dbc57a1d380dfdaaa667ecb762bd0ee7a63",
                     "options": {
                       "metadata": {
@@ -5575,9 +5567,6 @@
           },
           "sha256:2c63399bee449fb6e921671a9bbf3356fda73f890b578820f7d926202e98a479": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
-          },
-          "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.x86_64.rpm"
           },
           "sha256:2e8d4ee76fa8678b0e4d6c0297b16f96e0116201bf96b36e8924b1b080abcddd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libnl3-cli-3.5.0-1.el8.x86_64.rpm"
@@ -12723,16 +12712,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:861c24f03117c7597167c5e8e3a9a920a3fffd5de346deec2a1bd6172a187120",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.1.0",
-        "release": "5.module_el8.6.0+1040+0ae94936",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.x86_64.rpm",
-        "checksum": "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_8-x86_64-gce-boot.json
@@ -5288,14 +5288,6 @@
                     }
                   },
                   {
-                    "id": "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c7bfe545f212a230e12bb9ef202c6dbc57a1d380dfdaaa667ecb762bd0ee7a63",
                     "options": {
                       "metadata": {
@@ -6023,9 +6015,6 @@
           },
           "sha256:2c63399bee449fb6e921671a9bbf3356fda73f890b578820f7d926202e98a479": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libaio-0.3.112-1.el8.x86_64.rpm"
-          },
-          "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.x86_64.rpm"
           },
           "sha256:2e8d4ee76fa8678b0e4d6c0297b16f96e0116201bf96b36e8924b1b080abcddd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libnl3-cli-3.5.0-1.el8.x86_64.rpm"
@@ -13637,16 +13626,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64.rpm",
         "checksum": "sha256:002b3672de2744c3f97ad8776d012952c058f9213a0cf8e01f7f9b8651b3e6af",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.1.0",
-        "release": "5.module_el8.6.0+1040+0ae94936",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.1.0-5.module_el8.6.0+1040+0ae94936.x86_64.rpm",
-        "checksum": "sha256:2df1f7f66bc8f95049f9d90793ac1c831954657db96fe387139a06415bd888b9",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_9-aarch64-ami-boot.json
@@ -2235,14 +2235,6 @@
                     }
                   },
                   {
-                    "id": "sha256:a817b1bae982a875ba3e03a020bbaaf43eac086dd533a9b9e524ae842a236949",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:61424b5c6da1f5ff2c1b4fc4da18a501822f60797826a0dde2e1f1bba6e793ef",
                     "options": {
                       "metadata": {
@@ -6146,9 +6138,6 @@
           "sha256:a7e79d52b4c5c7b17478e7c30869a80353be2bf3efc3054bd550affdce2ae5ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/nspr-4.32.0-8.el9.aarch64.rpm"
           },
-          "sha256:a817b1bae982a875ba3e03a020bbaaf43eac086dd533a9b9e524ae842a236949": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm"
-          },
           "sha256:a8425192f250e294ddff960c1925e6b6250ba8327540eac6947edaef71f1cc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/procps-ng-3.3.17-4.el9.aarch64.rpm"
           },
@@ -9263,16 +9252,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:e29e50c96c36586e2adb3e2d7a2ac5bbd66a376d48fbf899638ae76357057b7d",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm",
-        "checksum": "sha256:a817b1bae982a875ba3e03a020bbaaf43eac086dd533a9b9e524ae842a236949",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_9-aarch64-ami-boot.json
@@ -2691,14 +2691,6 @@
                     }
                   },
                   {
-                    "id": "sha256:1e1cfb72b1111ad7b16b35966dc624c659e2b5521d3041fa1e063f6365bfc538",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:c17542cdd49f973058d76682b3af022646d642159b6a39c4fe43962dc29a3892",
                     "options": {
                       "metadata": {
@@ -5469,9 +5461,6 @@
           },
           "sha256:1d4815615490cc6c8c0e5352860970859fcf6f52c9f772c38d696f42f7d51948": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/libisofs-1.5.4-3.el9.aarch64.rpm"
-          },
-          "sha256:1e1cfb72b1111ad7b16b35966dc624c659e2b5521d3041fa1e063f6365bfc538": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm"
           },
           "sha256:1e58565c513e5251cd9ee9cf75e0a8e02e961f8285f355418493f689e28a985b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/shared-mime-info-2.1-4.el9.aarch64.rpm"
@@ -9844,16 +9833,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.aarch64.rpm",
         "checksum": "sha256:a3523e85eb0aab24c3302c7a583ebf0c780b232545e0ab1f56a9a70e8995c103",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm",
-        "checksum": "sha256:1e1cfb72b1111ad7b16b35966dc624c659e2b5521d3041fa1e063f6365bfc538",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_9-x86_64-ami-boot.json
@@ -2210,14 +2210,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7ae244bf549eaa426975ef377b1346cca8fc756bfb12170789c854c83e8fa7a7",
                     "options": {
                       "metadata": {
@@ -6255,9 +6247,6 @@
           "sha256:edab8459488d631c21b4a1f06260f2b0d08a0fd3f1a2c578043a34ac6a353cbc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/openssh-server-8.7p1-6.el9.x86_64.rpm"
           },
-          "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
-          },
           "sha256:f006c0e7cb58cb74f8cdc7abc3455a6d27b735e6a4540dff856b9c6a7af62d5a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/parted-3.4-6.el9.x86_64.rpm"
           },
@@ -9005,16 +8994,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:e29e50c96c36586e2adb3e2d7a2ac5bbd66a376d48fbf899638ae76357057b7d",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_9-x86_64-ami-boot.json
@@ -2634,14 +2634,6 @@
                     }
                   },
                   {
-                    "id": "sha256:3b918f21bcdd47100ab8076354f250888db6d665c8876c3ea3e12a0239bf02dd",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f9be6cefbff3a37832fc436922f1fb0c58ed3da6c8dbd3ec63aa7fcf2560887c",
                     "options": {
                       "metadata": {
@@ -5479,9 +5471,6 @@
           },
           "sha256:3b5ce98a03a3336a3f32ac7a0867fbc23da702e8618bfd20d49d882d42a460f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/gzip-1.10-8.el9.x86_64.rpm"
-          },
-          "sha256:3b918f21bcdd47100ab8076354f250888db6d665c8876c3ea3e12a0239bf02dd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:3bb064ceb18523e043c75d9d90ff3c2fccf6dbd93377c2557d7d2ae30e528fc1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/pbzip2-1.1.13-6.el9.x86_64.rpm"
@@ -9546,16 +9535,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.x86_64.rpm",
         "checksum": "sha256:defa47f5799acbf95283507deaf3d7cefdec0980268dafb926b30beddcfd594d",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm",
-        "checksum": "sha256:3b918f21bcdd47100ab8076354f250888db6d665c8876c3ea3e12a0239bf02dd",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_9-x86_64-gce-boot.json
@@ -2224,14 +2224,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:7ae244bf549eaa426975ef377b1346cca8fc756bfb12170789c854c83e8fa7a7",
                     "options": {
                       "metadata": {
@@ -6605,9 +6597,6 @@
           "sha256:edab8459488d631c21b4a1f06260f2b0d08a0fd3f1a2c578043a34ac6a353cbc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/openssh-server-8.7p1-6.el9.x86_64.rpm"
           },
-          "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
-          },
           "sha256:ef6a101e3c85cf9c5bc8e72dd2e1775c8a4c1fecbd24a99853d74bd984088d9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/libbytesize-2.5-3.el9.x86_64.rpm"
           },
@@ -9355,16 +9344,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:2bc4e5468961e9f8c4abed928ab036da9eed2cfaea725930ff9277e337984580",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:ef2261275c64411ac198bd10da76eb5bedc4fbe2f52cae1f01b212968d0ae39a",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -2037,9 +2037,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
-                  },
-                  {
                     "id": "sha256:5f8a723a2d2eed7a553d9efa794e362811bf04b413c30054887bd2d56cef24e8"
                   },
                   {
@@ -3308,9 +3305,6 @@
           },
           "sha256:a93b90699f26009debf0ac7b6759daf23afa9f3c851ccd7c98e35d9a89824dcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sg3_utils-libs-1.44-5.el8.aarch64.rpm"
-          },
-          "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
           "sha256:aa4b8463be8bceddb296424e76ddecc80b72ffc8543b6746eadfc4972131b6e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/setup-2.12.2-6.el8.noarch.rpm"
@@ -9706,15 +9700,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm",
-        "checksum": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ec2-boot.json
@@ -2046,9 +2046,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
-                  },
-                  {
                     "id": "sha256:5f8a723a2d2eed7a553d9efa794e362811bf04b413c30054887bd2d56cef24e8"
                   },
                   {
@@ -3350,9 +3347,6 @@
           },
           "sha256:a93b90699f26009debf0ac7b6759daf23afa9f3c851ccd7c98e35d9a89824dcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sg3_utils-libs-1.44-5.el8.aarch64.rpm"
-          },
-          "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
           "sha256:aa4b8463be8bceddb296424e76ddecc80b72ffc8543b6746eadfc4972131b6e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/setup-2.12.2-6.el8.noarch.rpm"
@@ -9748,15 +9742,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm",
-        "checksum": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -1980,9 +1980,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3113,9 +3110,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -9343,15 +9337,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2-boot.json
@@ -1991,9 +1991,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3157,9 +3154,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -9387,15 +9381,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
@@ -2424,9 +2424,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3999,9 +3996,6 @@
           },
           "sha256:9d44aa71f33960ce96e66ee5b42dc12a00edbdb9450e9c7787550a7facb96552": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-lxml-4.2.3-4.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
@@ -11684,15 +11678,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
@@ -3129,9 +3129,6 @@
                     "id": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:65f09851bd80394b34b388d3df5bc6955bfa7e5a9a525bebe915e5adf9052780"
                   },
                   {
@@ -5262,9 +5259,6 @@
           },
           "sha256:9d44aa71f33960ce96e66ee5b42dc12a00edbdb9450e9c7787550a7facb96552": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-lxml-4.2.3-4.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
@@ -15284,15 +15278,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python38-six-1.12.0-10.module+el8.4.0+8888+89bc7e79.noarch.rpm",
         "checksum": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rest",

--- a/test/data/manifests/rhel_8-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3461,9 +3458,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -10090,15 +10084,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3475,9 +3472,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -10104,15 +10098,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -2070,9 +2070,6 @@
                     "id": "sha256:eeabe7958b5c845f5985d4d42e7ce3dbe731e96ee012252866acd1e3be7974ed"
                   },
                   {
-                    "id": "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9"
-                  },
-                  {
                     "id": "sha256:92b6987ccd613f645d24008e10c2b59537502396f0a5f98727ceae640782a6ea"
                   },
                   {
@@ -3083,9 +3080,6 @@
           },
           "sha256:6c3ee8b53c0af9bd4958b4e48d4d55fa7c574f444fb42eead1508ad740f97088": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/prefixdevname-0.1.0-6.el8.aarch64.rpm"
-          },
-          "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.aarch64.rpm"
           },
           "sha256:6d6990ea51c417dc752c98d34f3a19f9c6fce966f1931bc2cfdddcdbe27931dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/ima-evm-utils-1.3.2-12.el8.aarch64.rpm"
@@ -9847,15 +9841,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.aarch64.rpm",
         "checksum": "sha256:eeabe7958b5c845f5985d4d42e7ce3dbe731e96ee012252866acd1e3be7974ed"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.aarch64.rpm",
-        "checksum": "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ec2-boot.json
@@ -2079,9 +2079,6 @@
                     "id": "sha256:eeabe7958b5c845f5985d4d42e7ce3dbe731e96ee012252866acd1e3be7974ed"
                   },
                   {
-                    "id": "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9"
-                  },
-                  {
                     "id": "sha256:92b6987ccd613f645d24008e10c2b59537502396f0a5f98727ceae640782a6ea"
                   },
                   {
@@ -3125,9 +3122,6 @@
           },
           "sha256:6c3ee8b53c0af9bd4958b4e48d4d55fa7c574f444fb42eead1508ad740f97088": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/prefixdevname-0.1.0-6.el8.aarch64.rpm"
-          },
-          "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.aarch64.rpm"
           },
           "sha256:6d6990ea51c417dc752c98d34f3a19f9c6fce966f1931bc2cfdddcdbe27931dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.4-20210921/Packages/ima-evm-utils-1.3.2-12.el8.aarch64.rpm"
@@ -9889,15 +9883,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.aarch64.rpm",
         "checksum": "sha256:eeabe7958b5c845f5985d4d42e7ce3dbe731e96ee012252866acd1e3be7974ed"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.aarch64.rpm",
-        "checksum": "sha256:6cf6cae43dd6c169b625e301c663893be741753d8a3c65fe762f467fcf4b21c9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -2010,9 +2010,6 @@
                     "id": "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:560f49382557eb971a482da7026e56a44149a8440ac887fd4fd4d778bb1ab196"
                   },
                   {
@@ -2390,9 +2387,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:0627b4b710fdc3708c23f142e79e2e83101ca30bb7e57870c2aa02364a784a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/tuned-2.15.0-2.el8.noarch.rpm"
@@ -9469,15 +9463,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.x86_64.rpm",
         "checksum": "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2-boot.json
@@ -2021,9 +2021,6 @@
                     "id": "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:560f49382557eb971a482da7026e56a44149a8440ac887fd4fd4d778bb1ab196"
                   },
                   {
@@ -2431,9 +2428,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:0627b4b710fdc3708c23f142e79e2e83101ca30bb7e57870c2aa02364a784a96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/tuned-2.15.0-2.el8.noarch.rpm"
@@ -9513,15 +9507,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-unbound-1.7.3-15.el8.x86_64.rpm",
         "checksum": "sha256:8c4b5140b61fa1e491d76462c2137e81d19c5fbc7e0a91329d91c8d8427ea696"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
@@ -2457,9 +2457,6 @@
                     "id": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:560f49382557eb971a482da7026e56a44149a8440ac887fd4fd4d778bb1ab196"
                   },
                   {
@@ -2970,9 +2967,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:05c3638dd983e5ab4c29768ce33e74a1ec065e846b28bc67035ec3e6c7fa8ee5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/net-snmp-utils-5.8-20.el8.x86_64.rpm"
@@ -11825,15 +11819,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64.rpm",
         "checksum": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
@@ -3072,9 +3072,6 @@
                     "id": "sha256:e4fa05ad0f62dabe98a764837433504576febb454109cacc066f165412a7dcce"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:65f09851bd80394b34b388d3df5bc6955bfa7e5a9a525bebe915e5adf9052780"
                   },
                   {
@@ -3750,9 +3747,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:0448fffcd2d9f2770c9b4a4eec60e117753353c5b2c1258a23a6ec0b478be00d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/tcsh-6.20.00-13.el8.x86_64.rpm"
@@ -14981,15 +14975,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python3-webencodings-0.5.1-6.el8.noarch.rpm",
         "checksum": "sha256:e4fa05ad0f62dabe98a764837433504576febb454109cacc066f165412a7dcce"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rest",

--- a/test/data/manifests/rhel_84-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce-boot.json
@@ -2146,9 +2146,6 @@
                     "id": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:560f49382557eb971a482da7026e56a44149a8440ac887fd4fd4d778bb1ab196"
                   },
                   {
@@ -2635,9 +2632,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:052251a8350237da90314221e6edad8de076c59165a563c141613214a9d73f23": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20220227/Packages/052251a8350237da90314221e6edad8de076c59165a563c141613214a9d73f23-gce-disk-expand-20200716.00-g1.el8.x86_64.rpm"
@@ -10209,15 +10203,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64.rpm",
         "checksum": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
@@ -2146,9 +2146,6 @@
                     "id": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
                   },
                   {
-                    "id": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
-                  },
-                  {
                     "id": "sha256:560f49382557eb971a482da7026e56a44149a8440ac887fd4fd4d778bb1ab196"
                   },
                   {
@@ -2646,9 +2643,6 @@
           },
           "sha256:03f00cc8815451bf931215a349677e4a0dba9092943a379ac77bc9ea986c779e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.4-20210921/Packages/rpm-plugin-selinux-4.14.3-13.el8.x86_64.rpm"
-          },
-          "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm"
           },
           "sha256:052251a8350237da90314221e6edad8de076c59165a563c141613214a9d73f23": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/el8-x86_64-google-compute-engine-20220227/Packages/052251a8350237da90314221e6edad8de076c59165a563c141613214a9d73f23-gce-disk-expand-20200716.00-g1.el8.x86_64.rpm"
@@ -10223,15 +10217,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64.rpm",
         "checksum": "sha256:9e70cafe666de95febf05bcee7d3be9a2c5cb9bb3d361d81b2d72bde8a5e20c7"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "48.module+el8.4.0+10368+630e803b",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/qemu-guest-agent-4.2.0-48.module+el8.4.0+10368+630e803b.x86_64.rpm",
-        "checksum": "sha256:03f578c782326e708d8f99645961ac10cabac98d951bee816de1508bac4cf4f4"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -2034,9 +2034,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893"
-                  },
-                  {
                     "id": "sha256:9de450d086f494ac3776444a8c325dd313eb63c2140cbe73d9d99e00dee46399"
                   },
                   {
@@ -2678,9 +2675,6 @@
           },
           "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/python3-gobject-base-3.28.3-2.el8.aarch64.rpm"
-          },
-          "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.aarch64.rpm"
           },
           "sha256:310d69dea3d9bb92e6e783f0458f8924431cb5703120a4730b0dcfaac4ecaaa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/libdnf-0.63.0-3.el8.aarch64.rpm"
@@ -9694,15 +9688,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.aarch64.rpm",
-        "checksum": "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -2043,9 +2043,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893"
-                  },
-                  {
                     "id": "sha256:9de450d086f494ac3776444a8c325dd313eb63c2140cbe73d9d99e00dee46399"
                   },
                   {
@@ -2717,9 +2714,6 @@
           },
           "sha256:31043a7324411dad6b84f6504a9e9cb7ece9f576acf091be522e484c8b82f469": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/python3-gobject-base-3.28.3-2.el8.aarch64.rpm"
-          },
-          "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.aarch64.rpm"
           },
           "sha256:310d69dea3d9bb92e6e783f0458f8924431cb5703120a4730b0dcfaac4ecaaa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-r8.5-20220504/Packages/libdnf-0.63.0-3.el8.aarch64.rpm"
@@ -9736,15 +9730,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.aarch64.rpm",
-        "checksum": "sha256:310c51e65da1036e1d07571b8f44a02aa9962c79743b20a834dbd1349ac41893"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -1971,9 +1971,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
-                  },
-                  {
                     "id": "sha256:dc874028a25d78374ffa470d7cba5f0eb89d543a486a645f51cde3aafb6efc93"
                   },
                   {
@@ -2861,9 +2858,6 @@
           },
           "sha256:6bde078378d758ca574298032ecbcbb98f80bc68df25273f98705bda74793ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/selinux-policy-3.14.3-80.el8.noarch.rpm"
-          },
-          "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm"
           },
           "sha256:6d136acc39e088ca8c8a51833fa0fc340cb4a5741fdce9b57a6ef3814b7bef89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64.rpm"
@@ -9301,15 +9295,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm",
-        "checksum": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -1981,9 +1981,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
-                  },
-                  {
                     "id": "sha256:dc874028a25d78374ffa470d7cba5f0eb89d543a486a645f51cde3aafb6efc93"
                   },
                   {
@@ -2904,9 +2901,6 @@
           },
           "sha256:6bde078378d758ca574298032ecbcbb98f80bc68df25273f98705bda74793ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/selinux-policy-3.14.3-80.el8.noarch.rpm"
-          },
-          "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm"
           },
           "sha256:6d136acc39e088ca8c8a51833fa0fc340cb4a5741fdce9b57a6ef3814b7bef89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64.rpm"
@@ -9344,15 +9338,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm",
-        "checksum": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -2413,9 +2413,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
-                  },
-                  {
                     "id": "sha256:dc874028a25d78374ffa470d7cba5f0eb89d543a486a645f51cde3aafb6efc93"
                   },
                   {
@@ -3640,9 +3637,6 @@
           },
           "sha256:6c9b434880278c220f3bd4c254c877593979ed453f52d8e6e51cf0fc898e9b85": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-ha-r8.5-20220504/Packages/libknet1-crypto-openssl-plugin-1.18-2.el8_4.x86_64.rpm"
-          },
-          "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm"
           },
           "sha256:6d136acc39e088ca8c8a51833fa0fc340cb4a5741fdce9b57a6ef3814b7bef89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64.rpm"
@@ -11640,15 +11634,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm",
-        "checksum": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
-                  },
-                  {
                     "id": "sha256:dc874028a25d78374ffa470d7cba5f0eb89d543a486a645f51cde3aafb6efc93"
                   },
                   {
@@ -3179,9 +3176,6 @@
           },
           "sha256:6bde078378d758ca574298032ecbcbb98f80bc68df25273f98705bda74793ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/selinux-policy-3.14.3-80.el8.noarch.rpm"
-          },
-          "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm"
           },
           "sha256:6d136acc39e088ca8c8a51833fa0fc340cb4a5741fdce9b57a6ef3814b7bef89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64.rpm"
@@ -10096,15 +10090,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm",
-        "checksum": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
-                  },
-                  {
                     "id": "sha256:dc874028a25d78374ffa470d7cba5f0eb89d543a486a645f51cde3aafb6efc93"
                   },
                   {
@@ -3190,9 +3187,6 @@
           },
           "sha256:6bde078378d758ca574298032ecbcbb98f80bc68df25273f98705bda74793ebf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/selinux-policy-3.14.3-80.el8.noarch.rpm"
-          },
-          "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm"
           },
           "sha256:6d136acc39e088ca8c8a51833fa0fc340cb4a5741fdce9b57a6ef3814b7bef89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-r8.5-20220504/Packages/python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64.rpm"
@@ -10110,15 +10104,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "4.2.0",
-        "release": "59.module+el8.5.0+12817+cb650d43",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/qemu-guest-agent-4.2.0-59.module+el8.5.0+12817+cb650d43.x86_64.rpm",
-        "checksum": "sha256:6cc76375b292cee17b3eb60c638a9b978a898e0cd57f7042bb19b954a0c095a8"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -2037,9 +2037,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
-                  },
-                  {
                     "id": "sha256:5f8a723a2d2eed7a553d9efa794e362811bf04b413c30054887bd2d56cef24e8"
                   },
                   {
@@ -3308,9 +3305,6 @@
           },
           "sha256:a93b90699f26009debf0ac7b6759daf23afa9f3c851ccd7c98e35d9a89824dcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sg3_utils-libs-1.44-5.el8.aarch64.rpm"
-          },
-          "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
           "sha256:aa4b8463be8bceddb296424e76ddecc80b72ffc8543b6746eadfc4972131b6e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/setup-2.12.2-6.el8.noarch.rpm"
@@ -9706,15 +9700,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm",
-        "checksum": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -2046,9 +2046,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
-                  },
-                  {
                     "id": "sha256:5f8a723a2d2eed7a553d9efa794e362811bf04b413c30054887bd2d56cef24e8"
                   },
                   {
@@ -3350,9 +3347,6 @@
           },
           "sha256:a93b90699f26009debf0ac7b6759daf23afa9f3c851ccd7c98e35d9a89824dcb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/sg3_utils-libs-1.44-5.el8.aarch64.rpm"
-          },
-          "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
           "sha256:aa4b8463be8bceddb296424e76ddecc80b72ffc8543b6746eadfc4972131b6e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/setup-2.12.2-6.el8.noarch.rpm"
@@ -9748,15 +9742,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm",
-        "checksum": "sha256:a992c740ae37f436e6abaf3c2f721d2a5de06a44297b5ad09a653fcf8a976d85"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -1980,9 +1980,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3113,9 +3110,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -9343,15 +9337,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -1991,9 +1991,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3157,9 +3154,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -9387,15 +9381,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -2424,9 +2424,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3999,9 +3996,6 @@
           },
           "sha256:9d44aa71f33960ce96e66ee5b42dc12a00edbdb9450e9c7787550a7facb96552": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-lxml-4.2.3-4.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
@@ -11684,15 +11678,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -3129,9 +3129,6 @@
                     "id": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:65f09851bd80394b34b388d3df5bc6955bfa7e5a9a525bebe915e5adf9052780"
                   },
                   {
@@ -5262,9 +5259,6 @@
           },
           "sha256:9d44aa71f33960ce96e66ee5b42dc12a00edbdb9450e9c7787550a7facb96552": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-lxml-4.2.3-4.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/perl-Digest-1.17-395.el8.noarch.rpm"
@@ -15284,15 +15278,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python38-six-1.12.0-10.module+el8.4.0+8888+89bc7e79.noarch.rpm",
         "checksum": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rest",

--- a/test/data/manifests/rhel_86-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3461,9 +3458,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -10090,15 +10084,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
@@ -2119,9 +2119,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
-                  },
-                  {
                     "id": "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870"
                   },
                   {
@@ -3475,9 +3472,6 @@
           },
           "sha256:9cf3aaab618686a40f62c6d9869161c216ea0c86d0f33544ba9dec3db55aa6fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libteam-1.31-2.el8.x86_64.rpm"
-          },
-          "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm"
           },
           "sha256:9f9feb77c731a460cba4720ca92e8cbc266c4c2c7ffa22a53b90c2d1ad23dc6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libsolv-0.7.20-1.el8.x86_64.rpm"
@@ -10104,15 +10098,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "5.module+el8.6.0+14025+ca131e0a",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/qemu-guest-agent-6.2.0-5.module+el8.6.0+14025+ca131e0a.x86_64.rpm",
-        "checksum": "sha256:9d491da84f286d7ae152fc33a0ef317328b0c85349706b4817a27181ecd59fb9"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ami-boot.json
@@ -2034,9 +2034,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881"
-                  },
-                  {
                     "id": "sha256:1f4f59cd7994d34e53c3b3e2abb39afede44c0c5688e9a2d954d226a79e5da32"
                   },
                   {
@@ -2675,9 +2672,6 @@
           },
           "sha256:2690e446abc26d0531173c071df0aa8ced5210bffee76b736ae223eebbc892eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/authselect-compat-1.2.2-3.el8.aarch64.rpm"
-          },
-          "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.aarch64.rpm"
           },
           "sha256:283e8c71f1880364f3e4eefc9876305303072f837fd2e4f891997f515c81dcf5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20220415/Packages/python3-dnf-4.7.0-8.el8.noarch.rpm"
@@ -9691,15 +9685,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.aarch64.rpm",
-        "checksum": "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ec2-boot.json
@@ -2043,9 +2043,6 @@
                     "id": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
                   },
                   {
-                    "id": "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881"
-                  },
-                  {
                     "id": "sha256:1f4f59cd7994d34e53c3b3e2abb39afede44c0c5688e9a2d954d226a79e5da32"
                   },
                   {
@@ -2714,9 +2711,6 @@
           },
           "sha256:2690e446abc26d0531173c071df0aa8ced5210bffee76b736ae223eebbc892eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/authselect-compat-1.2.2-3.el8.aarch64.rpm"
-          },
-          "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.aarch64.rpm"
           },
           "sha256:283e8c71f1880364f3e4eefc9876305303072f837fd2e4f891997f515c81dcf5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20220415/Packages/python3-dnf-4.7.0-8.el8.noarch.rpm"
@@ -9733,15 +9727,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/python3-unbound-1.7.3-17.el8.aarch64.rpm",
         "checksum": "sha256:8fc269f9b18e428f12c9afe7231e67edea41404ad47c7e87f104ec47312ee3fd"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.aarch64.rpm",
-        "checksum": "sha256:28269b3d1e0da34e8325953a09c2d0e8f36edb51bc1c80583e5e3987ee375881"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ami-boot.json
@@ -1980,9 +1980,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:788e1e3cafa686a2d7e25ae43deba7fda7226f2fe0795006474dfe518d5d522e"
                   },
                   {
@@ -3209,9 +3206,6 @@
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/file-5.33-20.el8.x86_64.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -9343,15 +9337,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2-boot.json
@@ -1991,9 +1991,6 @@
                     "id": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:788e1e3cafa686a2d7e25ae43deba7fda7226f2fe0795006474dfe518d5d522e"
                   },
                   {
@@ -3253,9 +3250,6 @@
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/file-5.33-20.el8.x86_64.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -9387,15 +9381,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm",
         "checksum": "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
@@ -2424,9 +2424,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:788e1e3cafa686a2d7e25ae43deba7fda7226f2fe0795006474dfe518d5d522e"
                   },
                   {
@@ -4137,9 +4134,6 @@
           },
           "sha256:bafc9ec3dd737b0dbdf179b9d9b4c8a9b5c1a92423eae1e4eb3047522107695e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/telnet-0.17-76.el8.x86_64.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -11684,15 +11678,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
@@ -3129,9 +3129,6 @@
                     "id": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:65f09851bd80394b34b388d3df5bc6955bfa7e5a9a525bebe915e5adf9052780"
                   },
                   {
@@ -5499,9 +5496,6 @@
           },
           "sha256:bb4b2ae2789e9295d835c3c48705f5bd7f6813613f91faab19d4bcb37300b1c2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -15284,15 +15278,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python38-six-1.12.0-10.module+el8.4.0+8888+89bc7e79.noarch.rpm",
         "checksum": "sha256:cbcd80197468aeae26500542100782eb9b4853d3b8db959ef647184c81a38fb6"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rest",

--- a/test/data/manifests/rhel_87-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce-boot.json
@@ -2113,9 +2113,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:788e1e3cafa686a2d7e25ae43deba7fda7226f2fe0795006474dfe518d5d522e"
                   },
                   {
@@ -3563,9 +3560,6 @@
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/file-5.33-20.el8.x86_64.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -10060,15 +10054,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
@@ -2113,9 +2113,6 @@
                     "id": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
                   },
                   {
-                    "id": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
-                  },
-                  {
                     "id": "sha256:788e1e3cafa686a2d7e25ae43deba7fda7226f2fe0795006474dfe518d5d522e"
                   },
                   {
@@ -3577,9 +3574,6 @@
           },
           "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/file-5.33-20.el8.x86_64.rpm"
-          },
-          "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm"
           },
           "sha256:bbbfb708ab2d3bf9b0d0db0c9a24022d28b0a48dfd626bfdd5ff152fccc5267f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20220415/Packages/cryptsetup-libs-2.3.7-2.el8.x86_64.rpm"
@@ -10074,15 +10068,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/python36-3.6.8-38.module+el8.5.0+12207+5c5719bc.x86_64.rpm",
         "checksum": "sha256:ee2ba576f07f5cdd9cf24e788d60071869107aa313addbba0a311448bb32a86c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 15,
-        "version": "6.2.0",
-        "release": "9.module+el8.7.0+14737+6552dcb8",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20220415/Packages/qemu-guest-agent-6.2.0-9.module+el8.7.0+14737+6552dcb8.x86_64.rpm",
-        "checksum": "sha256:bb5773ec3e68aadcf9f31e892e9bbaec9c059602e037db03d0fbecdbdda2186b"
       },
       {
         "name": "rhc",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -1921,9 +1921,6 @@
                     "id": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
                   },
                   {
-                    "id": "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b"
-                  },
-                  {
                     "id": "sha256:5750bb4b560044238b945166b92e99c62da5fd3b14faaba8757d78f1b242cf79"
                   },
                   {
@@ -2838,9 +2835,6 @@
           },
           "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
-          },
-          "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm"
           },
           "sha256:69b20a900c231a1a30629e42d1864aaf9a32ede4a7e8ad39c9d560201d5cf2ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-squash-055-10.git20210824.el9.aarch64.rpm"
@@ -9173,15 +9167,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm",
-        "checksum": "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -865,9 +865,6 @@
                     "id": "sha256:6d564871ff46b3e8a0fc5e78fc17a950af1d291397eca19ffe9beb1e97e29f70"
                   },
                   {
-                    "id": "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86"
-                  },
-                  {
                     "id": "sha256:e3d425107eef5b866e2f39a1e04e2bdddacad0def949017b89acff3a939a0bc7"
                   },
                   {
@@ -3144,9 +3141,6 @@
           },
           "sha256:a3701fe9260c9e076b6b408bd901951121d38e4c3d3c6c52dadea59a286d1e39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libbrotli-1.0.9-6.el9.aarch64.rpm"
-          },
-          "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm"
           },
           "sha256:a45df628baddcbc033ba3d55f319ce13f57a2ef615a2a9c9aa11217bf3b273d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/openssh-8.7p1-6.el9.aarch64.rpm"
@@ -6011,15 +6005,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.aarch64.rpm",
         "checksum": "sha256:6d564871ff46b3e8a0fc5e78fc17a950af1d291397eca19ffe9beb1e97e29f70"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm",
-        "checksum": "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -1933,9 +1933,6 @@
                     "id": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
                   },
                   {
-                    "id": "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b"
-                  },
-                  {
                     "id": "sha256:5750bb4b560044238b945166b92e99c62da5fd3b14faaba8757d78f1b242cf79"
                   },
                   {
@@ -2883,9 +2880,6 @@
           },
           "sha256:688bacfd60f31d9e7b1d295d8929d7f953ec789b86c475ef828c0b74d35d5ae4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/python3-pip-wheel-21.2.3-6.el9.noarch.rpm"
-          },
-          "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm"
           },
           "sha256:69b20a900c231a1a30629e42d1864aaf9a32ede4a7e8ad39c9d560201d5cf2ca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-squash-055-10.git20210824.el9.aarch64.rpm"
@@ -9230,15 +9224,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.aarch64.rpm",
-        "checksum": "sha256:6979fe9b8acfb7e3d4aebb551789e1258d7cc5109a4efb59898b9cb94e470a8b"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -877,9 +877,6 @@
                     "id": "sha256:6d564871ff46b3e8a0fc5e78fc17a950af1d291397eca19ffe9beb1e97e29f70"
                   },
                   {
-                    "id": "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86"
-                  },
-                  {
                     "id": "sha256:e3d425107eef5b866e2f39a1e04e2bdddacad0def949017b89acff3a939a0bc7"
                   },
                   {
@@ -3189,9 +3186,6 @@
           },
           "sha256:a3701fe9260c9e076b6b408bd901951121d38e4c3d3c6c52dadea59a286d1e39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libbrotli-1.0.9-6.el9.aarch64.rpm"
-          },
-          "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm"
           },
           "sha256:a45df628baddcbc033ba3d55f319ce13f57a2ef615a2a9c9aa11217bf3b273d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/openssh-8.7p1-6.el9.aarch64.rpm"
@@ -6068,15 +6062,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.aarch64.rpm",
         "checksum": "sha256:6d564871ff46b3e8a0fc5e78fc17a950af1d291397eca19ffe9beb1e97e29f70"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.aarch64.rpm",
-        "checksum": "sha256:a39000b7f3c60b35d32b1e57b29ad76cdafcf7e4a069b1fffed1ac670e4d6e86"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -901,9 +901,6 @@
                     "id": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
                   },
                   {
-                    "id": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
-                  },
-                  {
                     "id": "sha256:f5671dc12b61c49f59c21a989d5afba03f7414f65e40f4fdff9fe75381dda5dc"
                   },
                   {
@@ -2462,9 +2459,6 @@
           },
           "sha256:219825121d761bf163e746f0ca424e4dfe071aece87c22ccd632abcf78ab4920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-inotify-0.9.6-25.el9.noarch.rpm"
-          },
-          "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:2358982717e4c6df5e0dfc4ad906dade4ecf051cb7612b1aa087ab6c03f36da2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libuser-0.63-7.el9.x86_64.rpm"
@@ -6016,15 +6010,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.x86_64.rpm",
         "checksum": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm",
-        "checksum": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -1873,9 +1873,6 @@
                     "id": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:ad52ab3b4ddbc85a3f2e5535e5e111009f8b04f975bf4cb2c55d27c54d0d75cc"
                   },
                   {
@@ -3203,9 +3200,6 @@
           },
           "sha256:c09e8b2d377ada926a712fd051f37ad8d90aaf51e1dea42b92c9147122520139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pcre2-10.37-3.el9.1.x86_64.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
@@ -8926,15 +8920,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -1887,9 +1887,6 @@
                     "id": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:ad52ab3b4ddbc85a3f2e5535e5e111009f8b04f975bf4cb2c55d27c54d0d75cc"
                   },
                   {
@@ -3250,9 +3247,6 @@
           },
           "sha256:c09e8b2d377ada926a712fd051f37ad8d90aaf51e1dea42b92c9147122520139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pcre2-10.37-3.el9.1.x86_64.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
@@ -8985,15 +8979,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -915,9 +915,6 @@
                     "id": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
                   },
                   {
-                    "id": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
-                  },
-                  {
                     "id": "sha256:f5671dc12b61c49f59c21a989d5afba03f7414f65e40f4fdff9fe75381dda5dc"
                   },
                   {
@@ -2509,9 +2506,6 @@
           },
           "sha256:219825121d761bf163e746f0ca424e4dfe071aece87c22ccd632abcf78ab4920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-inotify-0.9.6-25.el9.noarch.rpm"
-          },
-          "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:2358982717e4c6df5e0dfc4ad906dade4ecf051cb7612b1aa087ab6c03f36da2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libuser-0.63-7.el9.x86_64.rpm"
@@ -6075,15 +6069,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.x86_64.rpm",
         "checksum": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm",
-        "checksum": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -2245,9 +2245,6 @@
                     "id": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:49191fa272d3c16c219f1b27fd86bd085fa1ae3bac38946de40926b35773c4c4"
                   },
                   {
@@ -4248,9 +4245,6 @@
           },
           "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm"
@@ -11144,15 +11138,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "redhat-logos",

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -952,9 +952,6 @@
                     "id": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
                   },
                   {
-                    "id": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
-                  },
-                  {
                     "id": "sha256:f5671dc12b61c49f59c21a989d5afba03f7414f65e40f4fdff9fe75381dda5dc"
                   },
                   {
@@ -3150,9 +3147,6 @@
           },
           "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm"
-          },
-          "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:2358982717e4c6df5e0dfc4ad906dade4ecf051cb7612b1aa087ab6c03f36da2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libuser-0.63-7.el9.x86_64.rpm"
@@ -7271,15 +7265,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.x86_64.rpm",
         "checksum": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm",
-        "checksum": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -3181,9 +3181,6 @@
                     "id": "sha256:132cf073ac655f8fcf6a22d0161578cb1a8a252002b2e11adeb0c84d7900ce4c"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:49191fa272d3c16c219f1b27fd86bd085fa1ae3bac38946de40926b35773c4c4"
                   },
                   {
@@ -5897,9 +5894,6 @@
           },
           "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c295f071518f6366131e7b143e6c37f30caf6fdb51a0aec8ba516364e6bbde91": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libXext-1.3.4-8.el9.x86_64.rpm"
@@ -15724,15 +15718,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-tracer-0.7.5-4.el9.noarch.rpm",
         "checksum": "sha256:132cf073ac655f8fcf6a22d0161578cb1a8a252002b2e11adeb0c84d7900ce4c"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "redhat-logos",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1024,9 +1024,6 @@
                     "id": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
                   },
                   {
-                    "id": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
-                  },
-                  {
                     "id": "sha256:f5671dc12b61c49f59c21a989d5afba03f7414f65e40f4fdff9fe75381dda5dc"
                   },
                   {
@@ -4271,9 +4268,6 @@
           },
           "sha256:22c9fb99038494ef3811f1536ead88125d1be28c3ac6f729b9888e4bcffb4026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/urw-base35-nimbus-mono-ps-fonts-20200910-6.el9.noarch.rpm"
-          },
-          "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm"
           },
           "sha256:2310e59546e927a3459e6a4a93bd843ad8a7fd41368e3ba2f5be926b0b9f5a33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/conmon-2.1.0-1.el9.x86_64.rpm"
@@ -9259,15 +9253,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-generic-055-10.git20210824.el9.x86_64.rpm",
         "checksum": "sha256:f00365d25649f658468a39755e0436ac8e7d6e5f033ffaff5251fe7bb7e5b95a"
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "10.git20210824.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dracut-config-rescue-055-10.git20210824.el9.x86_64.rpm",
-        "checksum": "sha256:22f900f590759293faf294d79cc7c21ea1d0090816c12d6142d418efbb6d42c7"
       },
       {
         "name": "dracut-network",

--- a/test/data/manifests/rhel_90-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce-boot.json
@@ -1970,9 +1970,6 @@
                     "id": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:ad52ab3b4ddbc85a3f2e5535e5e111009f8b04f975bf4cb2c55d27c54d0d75cc"
                   },
                   {
@@ -3418,9 +3415,6 @@
           },
           "sha256:c09e8b2d377ada926a712fd051f37ad8d90aaf51e1dea42b92c9147122520139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pcre2-10.37-3.el9.1.x86_64.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
@@ -9414,15 +9408,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
@@ -1970,9 +1970,6 @@
                     "id": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8"
                   },
                   {
-                    "id": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
-                  },
-                  {
                     "id": "sha256:ad52ab3b4ddbc85a3f2e5535e5e111009f8b04f975bf4cb2c55d27c54d0d75cc"
                   },
                   {
@@ -3427,9 +3424,6 @@
           },
           "sha256:c09e8b2d377ada926a712fd051f37ad8d90aaf51e1dea42b92c9147122520139": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/pcre2-10.37-3.el9.1.x86_64.rpm"
-          },
-          "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm"
           },
           "sha256:c432790f9b6cf33ef8c6e3618b209e8922b409de79f0519cc9679b1ad6cb20ed": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libini_config-1.3.1-51.el9.x86_64.rpm"
@@ -9423,15 +9417,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8"
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "5.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/qemu-guest-agent-6.2.0-5.el9.x86_64.rpm",
-        "checksum": "sha256:c24fef81612662dd27d8bc72f1e8dae00fff3ca1905c630f57e5362803e72f35"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -4987,14 +4987,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:59f7811976c37d5026057216e477abfe70ad2407e42cb2d3da0d4f7de8d53282",
                     "options": {
                       "metadata": {
@@ -6672,9 +6664,6 @@
           },
           "sha256:f821d67686ec0b3c07260bdc41dd9aa720e370c1f8e5b158691d7d182184c0da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/python3-netifaces-0.10.6-15.el9.aarch64.rpm"
-          },
-          "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.aarch64.rpm"
           },
           "sha256:f9fbfb9999fd64705dbaedb810a0a3b98011d5c8bcd062bb4b7d91ca3d7e34d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/sssd-common-2.6.2-2.el9.aarch64.rpm"
@@ -12861,16 +12850,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.aarch64.rpm",
-        "checksum": "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -2179,14 +2179,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d8d13dfdc6d4c6af623905c7f37ae4f07faf6c4eeb69546ba9c23fd92fefc883",
                     "options": {
                       "metadata": {
@@ -6489,9 +6481,6 @@
           "sha256:d62f0262248a7da16dc0e9431015f82e29e83e6a981dc969c527df738656abd9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libcollection-0.7.0-51.el9.aarch64.rpm"
           },
-          "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.aarch64.rpm"
-          },
           "sha256:d679dbc918fd999386ee5e83ecec55c7879499790598ba4731ca84506965f0a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/c-ares-1.17.1-5.el9.aarch64.rpm"
           },
@@ -9362,16 +9351,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.aarch64.rpm",
         "checksum": "sha256:4ef22e4502fdb4968cdeb73ba084b15d0764928aa5afc1daea7bd648e8a6d41e",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.aarch64.rpm",
-        "checksum": "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -2197,14 +2197,6 @@
                     }
                   },
                   {
-                    "id": "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d8d13dfdc6d4c6af623905c7f37ae4f07faf6c4eeb69546ba9c23fd92fefc883",
                     "options": {
                       "metadata": {
@@ -6545,9 +6537,6 @@
           "sha256:d62f0262248a7da16dc0e9431015f82e29e83e6a981dc969c527df738656abd9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libcollection-0.7.0-51.el9.aarch64.rpm"
           },
-          "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.aarch64.rpm"
-          },
           "sha256:d679dbc918fd999386ee5e83ecec55c7879499790598ba4731ca84506965f0a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/c-ares-1.17.1-5.el9.aarch64.rpm"
           },
@@ -9431,16 +9420,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.aarch64.rpm",
         "checksum": "sha256:4ef22e4502fdb4968cdeb73ba084b15d0764928aa5afc1daea7bd648e8a6d41e",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.aarch64.rpm",
-        "checksum": "sha256:d668e8e97309259b74740f4d430ad469a86c30993c745cc139f6eb0443f8ec69",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -5005,14 +5005,6 @@
                     }
                   },
                   {
-                    "id": "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:59f7811976c37d5026057216e477abfe70ad2407e42cb2d3da0d4f7de8d53282",
                     "options": {
                       "metadata": {
@@ -6731,9 +6723,6 @@
           },
           "sha256:f821d67686ec0b3c07260bdc41dd9aa720e370c1f8e5b158691d7d182184c0da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/python3-netifaces-0.10.6-15.el9.aarch64.rpm"
-          },
-          "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.aarch64.rpm"
           },
           "sha256:f9fbfb9999fd64705dbaedb810a0a3b98011d5c8bcd062bb4b7d91ca3d7e34d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/sssd-common-2.6.2-2.el9.aarch64.rpm"
@@ -12930,16 +12919,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.aarch64.rpm",
-        "checksum": "sha256:f9d0df54678c83fa12d439673c437578af9f7cb09804dec3bb33c006f43f77e4",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -4859,14 +4859,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9d517c86aa21c27dbd1896a79942e11e44e5e0f140185280024df99086cc1793",
                     "options": {
                       "metadata": {
@@ -5804,9 +5796,6 @@
           },
           "sha256:6afc8c020a9b22c187edeb118a96627e849297a3f237022025088af8fb42eb1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/policycoreutils-3.3-6.el9_0.x86_64.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c285a1b8cf7b6eb99db4d558f3d6b036a6397c79f496d32da7b6f475145d2a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-img-6.2.0-11.el9_0.1.x86_64.rpm"
@@ -12508,16 +12497,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -2275,14 +2275,6 @@
                     }
                   },
                   {
-                    "id": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd5b20a42eca11f206109f1ca6d6121e8c43585dda6c0a7546e96fd070051a20",
                     "options": {
                       "metadata": {
@@ -5686,9 +5678,6 @@
           },
           "sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
-          },
-          "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm"
           },
           "sha256:54c8ff0d9acb9043c68780e2566ee1a83bf881b236ae7131c5ecaf7b40665c9e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/libbasicobjects-0.1.1-51.el9.x86_64.rpm"
@@ -9289,16 +9278,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.x86_64.rpm",
         "checksum": "sha256:b20143ec0439f888980055d084eb222d933b58c4bef87dc1e20e0e5b1b8be13a",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm",
-        "checksum": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -2295,14 +2295,6 @@
                     }
                   },
                   {
-                    "id": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd5b20a42eca11f206109f1ca6d6121e8c43585dda6c0a7546e96fd070051a20",
                     "options": {
                       "metadata": {
@@ -5744,9 +5736,6 @@
           },
           "sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
-          },
-          "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm"
           },
           "sha256:54c8ff0d9acb9043c68780e2566ee1a83bf881b236ae7131c5ecaf7b40665c9e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/libbasicobjects-0.1.1-51.el9.x86_64.rpm"
@@ -9360,16 +9349,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.x86_64.rpm",
         "checksum": "sha256:b20143ec0439f888980055d084eb222d933b58c4bef87dc1e20e0e5b1b8be13a",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm",
-        "checksum": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -4879,14 +4879,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9d517c86aa21c27dbd1896a79942e11e44e5e0f140185280024df99086cc1793",
                     "options": {
                       "metadata": {
@@ -5862,9 +5854,6 @@
           },
           "sha256:6afc8c020a9b22c187edeb118a96627e849297a3f237022025088af8fb42eb1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/policycoreutils-3.3-6.el9_0.x86_64.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c285a1b8cf7b6eb99db4d558f3d6b036a6397c79f496d32da7b6f475145d2a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-img-6.2.0-11.el9_0.1.x86_64.rpm"
@@ -12579,16 +12568,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -2378,14 +2378,6 @@
                     }
                   },
                   {
-                    "id": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd5b20a42eca11f206109f1ca6d6121e8c43585dda6c0a7546e96fd070051a20",
                     "options": {
                       "metadata": {
@@ -7451,9 +7443,6 @@
           "sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
           },
-          "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm"
-          },
           "sha256:54c8ff0d9acb9043c68780e2566ee1a83bf881b236ae7131c5ecaf7b40665c9e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/libbasicobjects-0.1.1-51.el9.x86_64.rpm"
           },
@@ -11501,16 +11490,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.x86_64.rpm",
         "checksum": "sha256:b20143ec0439f888980055d084eb222d933b58c4bef87dc1e20e0e5b1b8be13a",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm",
-        "checksum": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -5818,14 +5818,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393",
                     "options": {
                       "metadata": {
@@ -7601,9 +7593,6 @@
           },
           "sha256:6afc8c020a9b22c187edeb118a96627e849297a3f237022025088af8fb42eb1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/policycoreutils-3.3-6.el9_0.x86_64.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c1cfe8c3a9f5cb43b285d8a78e5eb75ac5609fc021eb94e03b68f0f0d89697d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-ha-n9.1-20220324/Packages/pacemaker-cli-2.1.2-4.el9.x86_64.rpm"
@@ -15790,16 +15779,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
         "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -8318,14 +8318,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393",
                     "options": {
                       "metadata": {
@@ -10411,9 +10403,6 @@
           },
           "sha256:6b0419dade394fbfa8b1f67cfb6e7a7a180db6a2eb583b9fa369e447d1936997": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/git-core-doc-2.31.1-2.el9.2.noarch.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c285a1b8cf7b6eb99db4d558f3d6b036a6397c79f496d32da7b6f475145d2a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-img-6.2.0-11.el9_0.1.x86_64.rpm"
@@ -22183,16 +22172,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-tracer-0.7.5-4.el9.noarch.rpm",
         "checksum": "sha256:132cf073ac655f8fcf6a22d0161578cb1a8a252002b2e11adeb0c84d7900ce4c",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -2550,14 +2550,6 @@
                     }
                   },
                   {
-                    "id": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:cd5b20a42eca11f206109f1ca6d6121e8c43585dda6c0a7546e96fd070051a20",
                     "options": {
                       "metadata": {
@@ -10165,9 +10157,6 @@
           "sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
           },
-          "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm"
-          },
           "sha256:54c8ff0d9acb9043c68780e2566ee1a83bf881b236ae7131c5ecaf7b40665c9e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/libbasicobjects-0.1.1-51.el9.x86_64.rpm"
           },
@@ -14984,16 +14973,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-generic-055-30.git20220216.el9.x86_64.rpm",
         "checksum": "sha256:b20143ec0439f888980055d084eb222d933b58c4bef87dc1e20e0e5b1b8be13a",
-        "check_gpg": true
-      },
-      {
-        "name": "dracut-config-rescue",
-        "epoch": 0,
-        "version": "055",
-        "release": "30.git20220216.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/dracut-config-rescue-055-30.git20220216.el9.x86_64.rpm",
-        "checksum": "sha256:54c30b33c21d48d125e132bac9cb41e2d6231fbcd6d5e358c7796c552cc11ac5",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce-boot.json
@@ -5095,14 +5095,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9d517c86aa21c27dbd1896a79942e11e44e5e0f140185280024df99086cc1793",
                     "options": {
                       "metadata": {
@@ -6147,9 +6139,6 @@
           },
           "sha256:6afc8c020a9b22c187edeb118a96627e849297a3f237022025088af8fb42eb1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/policycoreutils-3.3-6.el9_0.x86_64.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c285a1b8cf7b6eb99db4d558f3d6b036a6397c79f496d32da7b6f475145d2a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-img-6.2.0-11.el9_0.1.x86_64.rpm"
@@ -13184,16 +13173,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
@@ -5095,14 +5095,6 @@
                     }
                   },
                   {
-                    "id": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9d517c86aa21c27dbd1896a79942e11e44e5e0f140185280024df99086cc1793",
                     "options": {
                       "metadata": {
@@ -6153,9 +6145,6 @@
           },
           "sha256:6afc8c020a9b22c187edeb118a96627e849297a3f237022025088af8fb42eb1e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/policycoreutils-3.3-6.el9_0.x86_64.rpm"
-          },
-          "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm"
           },
           "sha256:6c285a1b8cf7b6eb99db4d558f3d6b036a6397c79f496d32da7b6f475145d2a5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-img-6.2.0-11.el9_0.1.x86_64.rpm"
@@ -13193,16 +13182,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 17,
-        "version": "6.2.0",
-        "release": "11.el9_0.1",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/qemu-guest-agent-6.2.0-11.el9_0.1.x86_64.rpm",
-        "checksum": "sha256:6b9f6e054cbdc420ce86df00b60596d07c10bc35dc4c31c0458917819fc55cf0",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
