### PR TITLE
templates/composer: Remove non-existent secret

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -150,9 +150,6 @@ objects:
         - name: composer-config
           configMap:
             name: composer-config
-        - name: db-secrets
-          secret:
-            secretName: db
         - name: state-directory
           emptyDir: {}
         - name: cache-directory


### PR DESCRIPTION
This causes the deployment to fail.

