### PR TITLE
worker: fix crash if no autoscale instance is defined

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -128,6 +128,10 @@ func setProtection(protected bool) {
 		}
 		return
 	}
+	if len(asInstanceOutput.AutoScalingInstances) == 0 {
+		logrus.Info("No Autoscaling instace is defined")
+		return
+	}
 
 	// make the request to protect (or unprotect) the instance
 	input := &autoscaling.SetInstanceProtectionInput{


### PR DESCRIPTION
The worker assumes that when running on AWS an autoscale is defined. If not defined, the worker crashes.

This crash occurred when triggering a build via the Weldr API while running a local installation of osbuild-composer and osbuild-worker on an EC2 instance 

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
