### PR TITLE
osbuild-mock-openid-provider: support `client_credentials` grant type

### DIFF
--- a/cmd/osbuild-mock-openid-provider/main.go
+++ b/cmd/osbuild-mock-openid-provider/main.go
@@ -90,13 +90,29 @@ func main() {
 			panic(err)
 		}
 
-		cc := customClaims{
-			Type:      "Bearer",
-			ExpiresAt: 0,
-			IssuedAt:  time.Now().Unix(),
-			// Use refresh_token as rh-org-id
-			RHOrgID: r.Form.Get("refresh_token"),
+		var cc customClaims
+		switch r.Form.Get("grant_type") {
+		case "refresh_token":
+			cc = customClaims{
+				Type:      "Bearer",
+				ExpiresAt: 0,
+				IssuedAt:  time.Now().Unix(),
+				// Use refresh_token as rh-org-id
+				RHOrgID: r.Form.Get("refresh_token"),
+			}
+		case "client_credentials":
+			cc = customClaims{
+				Type:      "Bearer",
+				ExpiresAt: 0,
+				IssuedAt:  time.Now().Unix(),
+				// Use client_secret as rh-org-id
+				RHOrgID: r.Form.Get("client_secret"),
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
+
 		token := jwt.NewWithClaims(jwt.SigningMethodRS256, cc)
 		token.Header["kid"] = "key-id"
 

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -528,11 +528,12 @@ KILL_PIDS+=("$!")
 
 sudo systemctl restart osbuild-composer
 
-until curl --output /dev/null --silent --fail localhost:8081/token; do
+until curl --data "grant_type=refresh_token" --output /dev/null --silent --fail localhost:8081/token; do
     sleep 0.5
 done
 
 TOKEN="$(curl --request POST \
+        --data "grant_type=refresh_token" \
         --data "refresh_token=$REFRESH_TOKEN" \
         --header "Content-Type: application/x-www-form-urlencoded" \
         --silent \

--- a/test/cases/api/common/common.sh
+++ b/test/cases/api/common/common.sh
@@ -60,6 +60,7 @@ function access_token {
 function access_token_with_org_id {
   local refresh_token="$1"
   curl --request POST \
+    --data "grant_type=refresh_token" \
     --data "refresh_token=$refresh_token" \
     --header "Content-Type: application/x-www-form-urlencoded" \
     --silent \

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
 
 # Provision the software under test.
-/usr/libexec/osbuild-composer-test/provision.sh
+/usr/libexec/osbuild-composer-test/provision.sh none
 
 # Get OS data.
 source /etc/os-release

--- a/tools/koji-compose.py
+++ b/tools/koji-compose.py
@@ -127,7 +127,10 @@ class ComposerAPIClient:
         self.auth_server = auth_server
 
     def access_token(self):
-        resp = requests.post(self.auth_server + "/token", data={"refresh_token": self.refresh_token})
+        resp = requests.post(self.auth_server + "/token", data={
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+        })
         if resp.status_code != 200:
             raise RuntimeError(f"failed to refresh token: {resp.text}")
         return resp.json()["access_token"]


### PR DESCRIPTION
Extend the implementation of mock openid server to take the `grant_type`
into consideration for the `/token` endpoint.

In addition to the previously supported `refresh_topen`, the
implementation now supports also `client_credentials`.

This is necessary to make it possible to use the mock server in
the `koji-osbuild` CI, because the builder plugin uses
`client_credentials` to get access token.

The implementation behaves in the following way:
 - For `refresh_token` grant type, it takes the `refresh_token` value
   from the request and adds it to the `rh-org-id` field in the custom
   claim, which is part of the returned token.
 - For `client_credentials` grant type, it takes the `client_secret`
   value from the request and adds it to the `rh-org-id` field in the
   custom claim, which is part of the returned token.

Requests without the supported `grant_type` set are rejected.

Modify affected test cases to specify `grant_type` when fetching a new
access token.

Related to https://github.com/osbuild/koji-osbuild/pull/104

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
