### PR TITLE
Add GCP guest agent config stage

### DIFF
--- a/internal/distro/image_config.go
+++ b/internal/distro/image_config.go
@@ -31,29 +31,30 @@ type ImageConfig struct {
 
 	// for RHSM configuration, we need to potentially distinguish the case
 	// when the user want the image to be subscribed on first boot and when not
-	RHSMConfig         map[RHSMSubscriptionStatus]*osbuild.RHSMStageOptions
-	SystemdLogind      []*osbuild.SystemdLogindStageOptions
-	CloudInit          []*osbuild.CloudInitStageOptions
-	Modprobe           []*osbuild.ModprobeStageOptions
-	DracutConf         []*osbuild.DracutConfStageOptions
-	SystemdUnit        []*osbuild.SystemdUnitStageOptions
-	Authselect         *osbuild.AuthselectStageOptions
-	SELinuxConfig      *osbuild.SELinuxConfigStageOptions
-	Tuned              *osbuild.TunedStageOptions
-	Tmpfilesd          []*osbuild.TmpfilesdStageOptions
-	PamLimitsConf      []*osbuild.PamLimitsConfStageOptions
-	Sysctld            []*osbuild.SysctldStageOptions
-	DNFConfig          []*osbuild.DNFConfigStageOptions
-	SshdConfig         *osbuild.SshdConfigStageOptions
-	Authconfig         *osbuild.AuthconfigStageOptions
-	PwQuality          *osbuild.PwqualityConfStageOptions
-	WAAgentConfig      *osbuild.WAAgentConfStageOptions
-	Grub2Config        *osbuild.GRUB2Config
-	DNFAutomaticConfig *osbuild.DNFAutomaticConfigStageOptions
-	YumConfig          *osbuild.YumConfigStageOptions
-	YUMRepos           []*osbuild.YumReposStageOptions
-	Firewall           *osbuild.FirewallStageOptions
-	UdevRules          *osbuild.UdevRulesStageOptions
+	RHSMConfig          map[RHSMSubscriptionStatus]*osbuild.RHSMStageOptions
+	SystemdLogind       []*osbuild.SystemdLogindStageOptions
+	CloudInit           []*osbuild.CloudInitStageOptions
+	Modprobe            []*osbuild.ModprobeStageOptions
+	DracutConf          []*osbuild.DracutConfStageOptions
+	SystemdUnit         []*osbuild.SystemdUnitStageOptions
+	Authselect          *osbuild.AuthselectStageOptions
+	SELinuxConfig       *osbuild.SELinuxConfigStageOptions
+	Tuned               *osbuild.TunedStageOptions
+	Tmpfilesd           []*osbuild.TmpfilesdStageOptions
+	PamLimitsConf       []*osbuild.PamLimitsConfStageOptions
+	Sysctld             []*osbuild.SysctldStageOptions
+	DNFConfig           []*osbuild.DNFConfigStageOptions
+	SshdConfig          *osbuild.SshdConfigStageOptions
+	Authconfig          *osbuild.AuthconfigStageOptions
+	PwQuality           *osbuild.PwqualityConfStageOptions
+	WAAgentConfig       *osbuild.WAAgentConfStageOptions
+	Grub2Config         *osbuild.GRUB2Config
+	DNFAutomaticConfig  *osbuild.DNFAutomaticConfigStageOptions
+	YumConfig           *osbuild.YumConfigStageOptions
+	YUMRepos            []*osbuild.YumReposStageOptions
+	Firewall            *osbuild.FirewallStageOptions
+	UdevRules           *osbuild.UdevRulesStageOptions
+	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and
@@ -150,6 +151,9 @@ func (c *ImageConfig) InheritFrom(parentConfig *ImageConfig) *ImageConfig {
 		}
 		if finalConfig.UdevRules == nil {
 			finalConfig.UdevRules = parentConfig.UdevRules
+		}
+		if finalConfig.GCPGuestAgentConfig == nil {
+			finalConfig.GCPGuestAgentConfig = parentConfig.GCPGuestAgentConfig
 		}
 	}
 	return &finalConfig

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -1778,6 +1778,14 @@ func newDistro(distroName string) distro.Distro {
 				},
 			},
 		},
+		GCPGuestAgentConfig: &osbuild.GcpGuestAgentConfigOptions{
+			ConfigScope: osbuild.GcpGuestAgentConfigScopeDistro,
+			Config: &osbuild.GcpGuestAgentConfig{
+				InstanceSetup: &osbuild.GcpGuestAgentConfigInstanceSetup{
+					SetBotoConfig: common.BoolToPtr(false),
+				},
+			},
+		},
 	}
 
 	if rd.osVersion == "8.4" {

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -647,6 +647,10 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewYumReposStage(yumRepo))
 	}
 
+	if gcpGuestAgentConfig := imageConfig.GCPGuestAgentConfig; gcpGuestAgentConfig != nil {
+		p.AddStage(osbuild.NewGcpGuestAgentConfigStage(gcpGuestAgentConfig))
+	}
+
 	if udevRules := imageConfig.UdevRules; udevRules != nil {
 		p.AddStage(osbuild.NewUdevRulesStage(udevRules))
 	}

--- a/internal/distro/rhel9/distro.go
+++ b/internal/distro/rhel9/distro.go
@@ -1666,6 +1666,14 @@ func newDistro(distroName string) distro.Distro {
 				},
 			},
 		},
+		GCPGuestAgentConfig: &osbuild.GcpGuestAgentConfigOptions{
+			ConfigScope: osbuild.GcpGuestAgentConfigScopeDistro,
+			Config: &osbuild.GcpGuestAgentConfig{
+				InstanceSetup: &osbuild.GcpGuestAgentConfigInstanceSetup{
+					SetBotoConfig: common.BoolToPtr(false),
+				},
+			},
+		},
 	}
 
 	gceImgType := imageType{

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -639,6 +639,10 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewYumReposStage(yumRepo))
 	}
 
+	if gcpGuestAgentConfig := imageConfig.GCPGuestAgentConfig; gcpGuestAgentConfig != nil {
+		p.AddStage(osbuild.NewGcpGuestAgentConfigStage(gcpGuestAgentConfig))
+	}
+
 	if udevRules := imageConfig.UdevRules; udevRules != nil {
 		p.AddStage(osbuild.NewUdevRulesStage(udevRules))
 	}

--- a/internal/osbuild/gcp_guest_agent_conf_stage.go
+++ b/internal/osbuild/gcp_guest_agent_conf_stage.go
@@ -1,0 +1,118 @@
+package osbuild
+
+import (
+	"fmt"
+)
+
+type GcpGuestAgentConfigScopeValue string
+
+const (
+	GcpGuestAgentConfigScopeDistro   GcpGuestAgentConfigScopeValue = "distro"
+	GcpGuestAgentConfigScopeInstance GcpGuestAgentConfigScopeValue = "instance"
+)
+
+type GcpGuestAgentConfigAccounts struct {
+	DeprovisionRemove *bool    `json:"deprovision_remove,omitempty"`
+	Groups            []string `json:"groups,omitempty"`
+	UseraddCmd        string   `json:"useradd_cmd,omitempty"`
+	UserdelCmd        string   `json:"userdel_cmd,omitempty"`
+	UsermodCmd        string   `json:"usermod_cmd,omitempty"`
+	GpasswdAddCmd     string   `json:"gpasswd_add_cmd,omitempty"`
+	GpasswdRemoveCmd  string   `json:"gpasswd_remove_cmd,omitempty"`
+	GroupaddCmd       string   `json:"groupadd_cmd,omitempty"`
+}
+
+type GcpGuestAgentConfigDaemons struct {
+	AccountsDaemon  *bool `json:"accounts_daemon,omitempty"`
+	ClockSkewDaemon *bool `json:"clock_skew_daemon,omitempty"`
+	NetworkDaemon   *bool `json:"network_daemon,omitempty"`
+}
+
+type GcpGuestAgentConfigInstanceSetup struct {
+	HostKeyTypes     []string `json:"host_key_types,omitempty"`
+	OptimizeLocalSsd *bool    `json:"optimize_local_ssd,omitempty"`
+	NetworkEnabled   *bool    `json:"network_enabled,omitempty"`
+	SetBotoConfig    *bool    `json:"set_boto_config,omitempty"`
+	SetHostKeys      *bool    `json:"set_host_keys,omitempty"`
+	SetMultiqueue    *bool    `json:"set_multiqueue,omitempty"`
+}
+
+type GcpGuestAgentConfigIpForwarding struct {
+	EthernetProtoId   string `json:"ethernet_proto_id,omitempty"`
+	IpAliases         *bool  `json:"ip_aliases,omitempty"`
+	TargetInstanceIps *bool  `json:"target_instance_ips,omitempty"`
+}
+
+type GcpGuestAgentConfigMetadataScripts struct {
+	DefaultShell string `json:"default_shell,omitempty"`
+	RunDir       string `json:"run_dir,omitempty"`
+	Startup      *bool  `json:"startup,omitempty"`
+	Shutdown     *bool  `json:"shutdown,omitempty"`
+}
+
+type GcpGuestAgentConfigNetworkInterfaces struct {
+	Setup        *bool  `json:"setup,omitempty"`
+	IpForwarding *bool  `json:"ip_forwarding,omitempty"`
+	DhcpCommand  string `json:"dhcp_command,omitempty"`
+}
+
+type GcpGuestAgentConfig struct {
+	Accounts          *GcpGuestAgentConfigAccounts          `json:"Accounts,omitempty"`
+	Daemons           *GcpGuestAgentConfigDaemons           `json:"Daemons,omitempty"`
+	InstanceSetup     *GcpGuestAgentConfigInstanceSetup     `json:"InstanceSetup,omitempty"`
+	IpForwarding      *GcpGuestAgentConfigIpForwarding      `json:"IpForwarding,omitempty"`
+	MetadataScripts   *GcpGuestAgentConfigMetadataScripts   `json:"MetadataScripts,omitempty"`
+	NetworkInterfaces *GcpGuestAgentConfigNetworkInterfaces `json:"NetworkInterfaces,omitempty"`
+}
+
+type GcpGuestAgentConfigOptions struct {
+	ConfigScope GcpGuestAgentConfigScopeValue `json:"config_scope,omitempty"`
+	Config      *GcpGuestAgentConfig          `json:"config"`
+}
+
+func (GcpGuestAgentConfigOptions) isStageOptions() {}
+
+func (o GcpGuestAgentConfigOptions) validate() error {
+	allowedScopeValues := []GcpGuestAgentConfigScopeValue{
+		GcpGuestAgentConfigScopeDistro,
+		GcpGuestAgentConfigScopeInstance,
+		"", // default empty value when the option is not set
+	}
+
+	valid := false
+	for _, value := range allowedScopeValues {
+		if o.ConfigScope == value {
+			valid = true
+			break
+		}
+	}
+
+	if !valid {
+		return fmt.Errorf(
+			"scope %q doesn't conform to schema (%s). Must be one of [distro, instance]",
+			o.ConfigScope,
+			repoFilenameRegex,
+		)
+	}
+
+	if o.Config == nil {
+		return fmt.Errorf("config property is required")
+	}
+
+	if (GcpGuestAgentConfig{}) == *o.Config {
+		return fmt.Errorf("at least one config section must be defined")
+	}
+
+	return nil
+}
+
+func NewGcpGuestAgentConfigStage(options *GcpGuestAgentConfigOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.gcp.guest-agent.conf",
+		Options: options,
+	}
+}

--- a/internal/osbuild/gcp_guest_agent_conf_stage_test.go
+++ b/internal/osbuild/gcp_guest_agent_conf_stage_test.go
@@ -1,0 +1,84 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGcpGuestAgentConfigOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options GcpGuestAgentConfigOptions
+		err     bool
+	}{
+		{
+			name:    "empty-config",
+			options: GcpGuestAgentConfigOptions{},
+			err:     true,
+		},
+		{
+			name: "empty-config",
+			options: GcpGuestAgentConfigOptions{
+				ConfigScope: GcpGuestAgentConfigScopeDistro,
+				Config:      &GcpGuestAgentConfig{},
+			},
+			err: true,
+		},
+		{
+			name: "invalid-ConfigScope",
+			options: GcpGuestAgentConfigOptions{
+				ConfigScope: "incorrect",
+				Config: &GcpGuestAgentConfig{
+					Accounts: &GcpGuestAgentConfigAccounts{
+						Groups: []string{"group1", "group2"},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "valid-data",
+			options: GcpGuestAgentConfigOptions{
+				ConfigScope: GcpGuestAgentConfigScopeDistro,
+				Config: &GcpGuestAgentConfig{
+					Accounts: &GcpGuestAgentConfigAccounts{
+						Groups: []string{"group1", "group2"},
+					},
+				},
+			},
+			err: false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewGcpGuestAgentConfigStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewGcpGuestAgentConfigStage(&tt.options) })
+			}
+		})
+	}
+}
+func TestNewGcpGuestAgentConfigStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type: "org.osbuild.gcp.guest-agent.conf",
+		Options: &GcpGuestAgentConfigOptions{
+			Config: &GcpGuestAgentConfig{
+				Accounts: &GcpGuestAgentConfigAccounts{
+					Groups: []string{"group1", "group2"},
+				},
+			},
+		},
+	}
+	actualStage := NewGcpGuestAgentConfigStage(&GcpGuestAgentConfigOptions{
+		Config: &GcpGuestAgentConfig{
+			Accounts: &GcpGuestAgentConfigAccounts{
+				Groups: []string{"group1", "group2"},
+			},
+		},
+	})
+	assert.Equal(t, expectedStage, actualStage)
+}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -309,7 +309,7 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 63
+Requires:   osbuild >= 64
 Requires:   osbuild-ostree >= 63
 Requires:   osbuild-lvm2 >= 63
 Requires:   osbuild-luks2 >= 63

--- a/test/data/manifests/centos_8-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_8-x86_64-gce-boot.json
@@ -5529,6 +5529,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/centos_9-x86_64-gce-boot.json
+++ b/test/data/manifests/centos_9-x86_64-gce-boot.json
@@ -5123,6 +5123,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_8-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce-boot.json
@@ -2333,6 +2333,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
@@ -2344,6 +2344,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_84-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce-boot.json
@@ -2365,6 +2365,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
@@ -2376,6 +2376,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_85-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce-boot.json
@@ -2333,6 +2333,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
@@ -2344,6 +2344,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce-boot.json
@@ -2333,6 +2333,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
@@ -2344,6 +2344,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_87-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce-boot.json
@@ -2327,6 +2327,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
@@ -2338,6 +2338,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce-boot.json
@@ -2155,6 +2155,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
@@ -2161,6 +2161,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_91-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce-boot.json
@@ -5317,6 +5317,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [

--- a/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
@@ -5323,6 +5323,17 @@
             }
           },
           {
+            "type": "org.osbuild.gcp.guest-agent.conf",
+            "options": {
+              "config_scope": "distro",
+              "config": {
+                "InstanceSetup": {
+                  "set_boto_config": false
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.fstab",
             "options": {
               "filesystems": [


### PR DESCRIPTION
- Add new GCP guest-agent config stage
- Add stage to RHEL8 and RHEL90 distro definitions
- Add GCPGuestAgentConf to ImageConfig
- Regenerate test cases for RHEL8 and RHEL90
- osbuild-composer.spec version bump for osbuild dependency
- Schutzfile osbuild commit hash update to include new GCP guest-agent config