### PR TITLE
Enable integration testing on aarch64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -516,11 +516,13 @@ aws.sh:
   extends: .integration
   variables:
     SCRIPT: aws.sh
-    
+
 azure.sh:
   extends: .integration
   variables:
     SCRIPT: azure.sh
+  rules:
+    - if: '$RUNNER =~ /[\S]+x86_64[\S]+/'
 
 # The required GCE image type is not supported on Fedora
 gcp.sh:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,7 +445,9 @@ Rebase OSTree UEFI:
       - aws/rhel-8.6-ga-x86_64
       - aws/rhel-9.0-ga-x86_64
       - aws/rhel-8.7-nightly-x86_64
+      - aws/rhel-8.7-nightly-aarch64
       - aws/rhel-9.1-nightly-x86_64
+      - aws/rhel-9.1-nightly-aarch64
       - aws/centos-stream-9-x86_64
     INTERNAL_NETWORK: ["true"]
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -536,9 +536,9 @@ gcp.sh:
 
 vmware.sh:
   extends: .integration
-  rules: 
+  rules:
     # WHITELIST
-    - if: $RUNNER =~ "/^.*(rhel).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    - if: $RUNNER =~ "/^.*(rhel).*$/" && $RUNNER =~ "/^.*(x86_64).*$/" && $CI_PIPELINE_SOURCE != "schedule"
     - !reference [.nightly_rules, rules]
   variables:
     SCRIPT: vmware.sh

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -245,6 +245,10 @@ tee "${TEMPDIR}/resource-file.json" <<EOF
 }
 EOF
 
+if [ "$ARCH" == "aarch64" ]; then
+    sed -i s/t3.medium/a1.large/ "${TEMPDIR}/resource-file.json"
+fi
+
 sudo ${CONTAINER_RUNTIME} run \
     -a stdout -a stderr \
     -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
