### PR TITLE
distro: add oscap packages to image

### DIFF
--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -450,13 +450,11 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(extraPkgs)
 	}
 
-	// if oscap customizations are enabled we need to add `openscap-scanner`
-	// and `scap-security-guides` packages to build root
+	// if oscap customizations are enabled we need to add
+	// `openscap-scanner` & `scap-security-guide` packages
+	// to build root
 	if bp.Customizations.GetOpenSCAP() != nil {
-		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(rpmmd.PackageSet{Include: []string{
-			"openscap-scanner",
-			"scap-security-guide",
-		}})
+		bpPackages = append(bpPackages, "openscap-scanner", "scap-security-guide")
 	}
 
 	// depsolve bp packages separately

--- a/internal/distro/rhel9/distro.go
+++ b/internal/distro/rhel9/distro.go
@@ -386,13 +386,11 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(extraPkgs)
 	}
 
-	// if oscap customizations are enabled we need to add `openscap-scanner`
-	// and `scap-security-guides` packages to build root
+	// if oscap customizations are enabled we need to add
+	// `openscap-scanner` & `scap-security-guide` packages
+	// to build root
 	if bp.Customizations.GetOpenSCAP() != nil {
-		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(rpmmd.PackageSet{Include: []string{
-			"openscap-scanner",
-			"scap-security-guide",
-		}})
+		bpPackages = append(bpPackages, "openscap-scanner", "scap-security-guide")
 	}
 
 	// depsolve bp packages separately

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -155,6 +155,10 @@ func (p *OS) getPackageSetChain() []rpmmd.PackageSet {
 		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
 	}
 
+	if p.OpenSCAPConfig != nil {
+		packages = append(packages, "openscap-scanner", "scap-security-guide")
+	}
+
 	chain := []rpmmd.PackageSet{
 		{
 			Include:      append(packages, p.ExtraBasePackages...),
@@ -185,9 +189,6 @@ func (p *OS) getBuildPackages() []string {
 	if p.SElinux != "" {
 		packages = append(packages, "policycoreutils")
 		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
-	}
-	if p.OpenSCAPConfig != nil {
-		packages = append(packages, "openscap-scanner", "scap-security-guide")
 	}
 	return packages
 }

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -373,14 +373,6 @@ version = "0.0.1"
 modules = []
 groups = []
 
-[[ packages ]]
-name = "openscap-scanner"
-version = "*"
-
-[[ packages ]]
-name = "scap-security-guide"
-version = "*"
-
 [customizations.openscap]
 profile_id = "${PROFILE}"
 datastream = "${DATASTREAM}"


### PR DESCRIPTION
Since the oscap remediation stage in osbuild runs the oscap pacakge in `chroot`, it is not possible to have
the packages in the build root. The packages are needed in the image itself.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
