### PR TITLE
distro/image-installer: remove nvmf dracut module for RHEL-9.1

### DIFF
--- a/internal/distro/rhel9/package_sets.go
+++ b/internal/distro/rhel9/package_sets.go
@@ -1223,7 +1223,6 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 			"nmap-ncat",
 			"nm-connection-editor",
 			"nss-tools",
-			"nvme-cli", // for nvmf dracut module
 			"openssh-clients",
 			"openssh-server",
 			"oscap-anaconda-addon",

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -1067,7 +1067,6 @@ func anacondaTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.PackageSpec
 		"multipath",
 		"nfs",
 		"nvdimm", // non-volatile DIMM firmware (provides nfit, cuse, and nd_e820)
-		"nvmf",
 		"rdma",
 		"rngd",
 	})

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -8129,14 +8129,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -9111,7 +9103,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -10776,9 +10767,6 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
-          },
-          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -22101,16 +22089,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
-        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -8158,14 +8158,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -9141,7 +9133,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -10828,9 +10819,6 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
-          },
-          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -22153,16 +22141,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
-        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -11822,14 +11822,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -12805,7 +12797,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -14459,9 +14450,6 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
-          },
-          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -25745,16 +25733,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
-        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -11851,14 +11851,6 @@
                     }
                   },
                   {
-                    "id": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:9130a491601594bf3791ee1fafd81840e9b9e66f111b2002236d144c7b65c081",
                     "options": {
                       "metadata": {
@@ -12834,7 +12826,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -14510,9 +14501,6 @@
           },
           "sha256:8a7da28db1c8dea227e2e3bf45e22d6f3920b44466d82392db10bc5a202ffcce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/fwupd-1.5.9-3.el9.aarch64.rpm"
-          },
-          "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm"
           },
           "sha256:8abb0ab85d37efc7a8a6132e3f9398f0179fa791bf118fd9f87119adaec621e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220208/Packages/perl-B-1.80-479.el9.aarch64.rpm"
@@ -25796,16 +25784,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:95bd797672d70a8752fb881c4ff04ccc14234842dfd9de6bc48373dd96c1ec81",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.aarch64.rpm",
-        "checksum": "sha256:8aa984accb80c96a9e7569feef196c19408e063b3c40b6f55b60473ae10e9cbb",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -8272,14 +8272,6 @@
                     }
                   },
                   {
-                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -9272,7 +9264,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -10907,9 +10898,6 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
-          },
-          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -22471,16 +22459,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
-        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -8301,14 +8301,6 @@
                     }
                   },
                   {
-                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -9302,7 +9294,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -10959,9 +10950,6 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
-          },
-          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -22523,16 +22511,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
-        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -12030,14 +12030,6 @@
                     }
                   },
                   {
-                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -13031,7 +13023,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -14657,9 +14648,6 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
-          },
-          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -26185,16 +26173,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
-        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
@@ -12059,14 +12059,6 @@
                     }
                   },
                   {
-                    "id": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0",
                     "options": {
                       "metadata": {
@@ -13060,7 +13052,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -14708,9 +14699,6 @@
           },
           "sha256:88bbb9c78ed4935955e5768f30829922cdbdd288917a32bcaf645868c9bb5026": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/crypto-policies-scripts-20220203-1.gitf03e75e.el9.noarch.rpm"
-          },
-          "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm"
           },
           "sha256:89728c73d1ba9818e95789a5b862ff9649cb934884e2733fca628277c5ef2d49": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/protobuf-c-1.3.3-9.el9.x86_64.rpm"
@@ -26236,16 +26224,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:a7da4ef003bc60045bc60dae299b703e7f1db326f25208fb922ce1b79e2882da",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.14",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/nvme-cli-1.14-3.el9.x86_64.rpm",
-        "checksum": "sha256:89233769b317900c1d20f6d05cc88f936438e820c74de209f0efec2dca4cc22e",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -1724,9 +1724,6 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
-                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -3576,7 +3573,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -4581,9 +4577,6 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
-          },
-          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -11486,15 +11479,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
-        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -1753,9 +1753,6 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
-                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -3606,7 +3603,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -4633,9 +4629,6 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
-          },
-          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -11538,15 +11531,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
-        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -3178,9 +3178,6 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
-                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -5031,7 +5028,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -6046,9 +6042,6 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
-          },
-          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -12900,15 +12893,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
-        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -3207,9 +3207,6 @@
                     "id": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
                   },
                   {
-                    "id": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac"
                   },
                   {
@@ -5060,7 +5057,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -6097,9 +6093,6 @@
           },
           "sha256:4f1f5c0c2f4e131af3839456a1e191da440b62559b289820f942edaa2a2ca354": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.aarch64.rpm"
-          },
-          "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm"
           },
           "sha256:4f52b48ea331a31c91582de5377507caf3400970ff40b7f242e0ad5b93d5b9ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/gstreamer1-plugins-good-1.18.4-5.el9.aarch64.rpm"
@@ -12951,15 +12944,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.aarch64.rpm",
-        "checksum": "sha256:4f2960344a8f7098953438409500ee9661b50f1fd1e6e5b1b32df317c0aabdba"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -1763,9 +1763,6 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
-                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -3640,7 +3637,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -5596,9 +5592,6 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
-          },
-          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -11712,15 +11705,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
-        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -1792,9 +1792,6 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
-                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -3670,7 +3667,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -5648,9 +5644,6 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
-          },
-          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -11764,15 +11757,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
-        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -3244,9 +3244,6 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
-                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -5122,7 +5119,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -7093,9 +7089,6 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
-          },
-          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -13155,15 +13148,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
-        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
@@ -3273,9 +3273,6 @@
                     "id": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
                   },
                   {
-                    "id": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575"
                   },
                   {
@@ -5151,7 +5148,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -7144,9 +7140,6 @@
           },
           "sha256:a362e6e28a10e0214b16d03edd7f125015f95a611e03b7ee3b51ad8b3cc3ace6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geoclue2-2.5.7-5.el9.x86_64.rpm"
-          },
-          "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm"
           },
           "sha256:a3aa10107f6fa6c6c2e5e0f134d137c7c5b0b77d118fb0f8cdf1e23167616e25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/p11-kit-0.24.1-2.el9.x86_64.rpm"
@@ -13206,15 +13199,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6"
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/nvme-cli-1.16-2.el9.x86_64.rpm",
-        "checksum": "sha256:a3880caf866f28104c364359b644abafc77095ca6e4402c74db91557f5519a03"
       },
       {
         "name": "openldap",

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -4489,14 +4489,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -9271,7 +9263,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -11383,9 +11374,6 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
-          },
-          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -17765,16 +17753,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
-        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -4518,14 +4518,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -9301,7 +9293,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -11435,9 +11426,6 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
-          },
-          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -17817,16 +17805,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
-        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -8302,14 +8302,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -13085,7 +13077,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -15207,9 +15198,6 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
-          },
-          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -21529,16 +21517,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
-        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -8331,14 +8331,6 @@
                     }
                   },
                   {
-                    "id": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:f08900533af1aa558b9ab4f64bfc17691fcddf1196b1585765a9997953e9aaac",
                     "options": {
                       "metadata": {
@@ -13114,7 +13106,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -15258,9 +15249,6 @@
           },
           "sha256:b66b63dc25e7eb3bba8af2ad2488b0920edc934a58ce9e5ba27f2a6905d9da5f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20220324/Packages/google-noto-cjk-fonts-common-20201206-4.el9.noarch.rpm"
-          },
-          "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm"
           },
           "sha256:b6a73c9da522df55690b886c0a9af39338571d34ee6f0d4d9b994c8289df3412": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/libattr-2.5.1-3.el9.aarch64.rpm"
@@ -21580,16 +21568,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.aarch64.rpm",
         "checksum": "sha256:6fb2eb0e66f94ce62b1f14f00704de0800664da8429df1df244ad7d9ee2c0b7b",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.aarch64.rpm",
-        "checksum": "sha256:b6782ec48ed2eeb43385cd526ba42626b4ab6ab508297353da905f51736a3298",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -4593,14 +4593,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -9448,7 +9440,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -11917,9 +11908,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -18120,16 +18108,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
-        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -4622,14 +4622,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -9478,7 +9470,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -11969,9 +11960,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -18172,16 +18160,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
-        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
@@ -8478,14 +8478,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -13334,7 +13326,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -15827,9 +15818,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -21958,16 +21946,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
-        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
@@ -8507,14 +8507,6 @@
                     }
                   },
                   {
-                    "id": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:8caf70f76bc314ccb0cfd75377f561f12289a8e5ffcf537df1fab1c0e9bb8575",
                     "options": {
                       "metadata": {
@@ -13363,7 +13355,6 @@
                 "multipath",
                 "nfs",
                 "nvdimm",
-                "nvmf",
                 "rdma",
                 "rngd"
               ],
@@ -15878,9 +15869,6 @@
           },
           "sha256:ce6dcb35f56a067393e94e5d49299a9ab256ad4949e6f86ac27e6b58516b18a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/kmod-libs-28-7.el9.x86_64.rpm"
-          },
-          "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm"
           },
           "sha256:cee202f1330ee17cfc3d5db3cd841594896cfda34b275da9bed1f5e6ccfaf644": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20220324/Packages/libwayland-client-1.19.0-4.el9.x86_64.rpm"
@@ -22009,16 +21997,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/npth-1.6-8.el9.x86_64.rpm",
         "checksum": "sha256:3e044d8534970034063e6445a142780bbe9d37f5e75b98f8788ade5470a32ab6",
-        "check_gpg": true
-      },
-      {
-        "name": "nvme-cli",
-        "epoch": 0,
-        "version": "1.16",
-        "release": "3.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20220324/Packages/nvme-cli-1.16-3.el9.x86_64.rpm",
-        "checksum": "sha256:ce7f8f58e8e40f59b659f0ba36670cba570d9527e4330299399d8adaf6d19edf",
         "check_gpg": true
       },
       {


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
