### PR TITLE
in edge simplified test, replace containerized fdo server with fdo-aio service

### DIFF
--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -25,6 +25,11 @@ function get_build_info() {
 # Start firewalld
 sudo systemctl enable --now firewalld
 
+# Install fdo packages (This cannot be done in the spec file because Fedora repo does not have this package yet)
+greenprint "Install and start fdo-aio service"
+sudo dnf install -y fdo-admin-cli
+sudo systemctl enable --now fdo-aio
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd
@@ -87,13 +92,9 @@ PROD_REPO_URL=http://192.168.100.1/repo
 PROD_REPO=/var/www/html/repo
 STAGE_REPO_ADDRESS=192.168.200.1
 STAGE_REPO_URL="http://${STAGE_REPO_ADDRESS}:8080/repo/"
-# FDO server repo commit to checkout
-FDO_SERVER_REPO_COMMIT=c2bab2c3cda954087fe66b683d31bffeac0c7189
-FDO_SERVER_ADDRESS=192.168.200.2
-# FDO admin CLI image version
-FDO_ADMIN_CLI_VERSION=0.4.0
-# FDO Manualfacture server image version
-FDO_MF_SERVER_VERSION=0.4.0
+FDO_SERVER_ADDRESS=192.168.100.1
+DIUN_PUB_KEY_HASH=sha256:$(openssl x509 -fingerprint -sha256 -noout -in /etc/fdo/aio/keys/diun_cert.pem | cut -d"=" -f2 | sed 's/://g')
+DIUN_PUB_KEY_ROOT_CERTS=$(cat /etc/fdo/aio/keys/diun_cert.pem)
 ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
@@ -293,28 +294,6 @@ sudo podman rmi -f -a
 # Prepare stage repo network
 greenprint "🔧 Prepare stage repo network"
 sudo podman network inspect edge >/dev/null 2>&1 || sudo podman network create --driver=bridge --subnet=192.168.200.0/24 --gateway=192.168.200.254 edge
-
-###########################################################
-##
-## Prepare fdo server
-##
-###########################################################
-greenprint "🔧 Prepare fdo manufacturing server"
-sudo git clone https://github.com/runcom/fdo-containers
-pushd fdo-containers
-sudo git checkout "$FDO_SERVER_REPO_COMMIT"
-sudo CONTAINER_IMAGE="quay.io/fido-fdo/fdo-admin-cli:$FDO_ADMIN_CLI_VERSION" ./create-keys.sh
-DIUN_PUB_KEY_HASH=$(cat keys/diun_pub_key_hash)
-DIUN_PUB_KEY_ROOT_CERTS=$(cat keys/diun_cert.pem)
-sudo podman run -d \
-  -v "$PWD"/ownership_vouchers:/etc/fdo/ownership_vouchers:z \
-  -v "$PWD"/config/manufacturing-server.yml:/etc/fdo/manufacturing-server.conf.d/00-default.yml:z \
-  -v "$PWD"/keys:/etc/fdo/keys:z \
-  --ip "$FDO_SERVER_ADDRESS" \
-  --name fdo-manufacturing-server \
-  --network edge \
-  "quay.io/fido-fdo/fdo-manufacturing-server:$FDO_MF_SERVER_VERSION"
-popd
 
 # Wait for fdo server to be running
 until [ "$(curl -X POST http://${FDO_SERVER_ADDRESS}:8080/ping)" == "pong" ]; do

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -46,20 +46,13 @@
     - set_fact:
         checking_stage: "{{ result_stage.stdout }}"
 
-    # case: check /boot/device-credentials exists
-    # simplified installer installed Edge system ONLY
-    - name: check /boot/device-credentials exists
-      stat:
-        path: /boot/device-credentials
-      register: stat_result
-
-    - name: check commit deployed and built
+    # case: check fdo onboarding status
+    # after fdo onboarding finished, /boot/device-credentials will be moved to /etc/device-credentials
+    - name: check if fdo onboarding completed successfully
       block:
-        - assert:
-            that:
-              - stat_result.stat.exists
-            fail_msg: "/boot/device-credentials does not exist"
-            success_msg: "/boot/device-credentials exists"
+        - name: wait until the file /etc/device-credentials is present before continuing
+          wait_for:
+            path: /etc/device-credentials
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
