### PR TITLE
Add the `rhsm.facts` stage.

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-35": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [
@@ -156,21 +156,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [
@@ -216,14 +216,14 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [
@@ -269,21 +269,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [
@@ -329,7 +329,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "376cbffd136bc4ba86fc7c63697fa5b88fe3acef"
+        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
       }
     },
     "repos": [

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -269,6 +269,10 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 		}
 
 		imageOptions := distro.ImageOptions{Size: imageType.Size(0)}
+		imageOptions.Facts = &distro.FactsImageOptions{
+			ApiType: "cloudapi-v2",
+		}
+
 		if request.Customizations != nil && request.Customizations.Subscription != nil {
 			imageOptions.Subscription = &distro.SubscriptionImageOptions{
 				Organization:  request.Customizations.Subscription.Organization,

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -129,6 +129,7 @@ type ImageOptions struct {
 	OSTree       ostree.RequestParams
 	Size         uint64
 	Subscription *SubscriptionImageOptions
+	Facts        *FactsImageOptions
 }
 
 // The SubscriptionImageOptions specify subscription-specific image options
@@ -140,6 +141,12 @@ type SubscriptionImageOptions struct {
 	ServerUrl     string
 	BaseUrl       string
 	Insights      bool
+}
+
+// The FactsImageOptions specify things to be stored into the Insights facts
+// storage. This mostly relates to how the build of the image was performed.
+type FactsImageOptions struct {
+	ApiType string
 }
 
 type BasePartitionTableMap map[string]disk.PartitionTable

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -690,6 +690,14 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	}
 
+	if options.Facts != nil {
+		p.AddStage(osbuild.NewRHSMFactsStage(&osbuild.RHSMFactsStageOptions{
+			Facts: osbuild.RHSMFacts{
+				ApiType: options.Facts.ApiType,
+			},
+		}))
+	}
+
 	if t.rpmOstree {
 		p.AddStage(osbuild.NewOSTreePrepTreeStage(&osbuild.OSTreePrepTreeStageOptions{
 			EtcGroupMembers: []string{

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -688,6 +688,14 @@ func osPipeline(t *imageType,
 		p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	}
 
+	if options.Facts != nil {
+		p.AddStage(osbuild.NewRHSMFactsStage(&osbuild.RHSMFactsStageOptions{
+			Facts: osbuild.RHSMFacts{
+				ApiType: options.Facts.ApiType,
+			},
+		}))
+	}
+
 	if t.rpmOstree {
 		p.AddStage(osbuild.NewOSTreePrepTreeStage(&osbuild.OSTreePrepTreeStageOptions{
 			EtcGroupMembers: []string{

--- a/internal/osbuild/rhsm_facts_stage.go
+++ b/internal/osbuild/rhsm_facts_stage.go
@@ -1,0 +1,19 @@
+package osbuild
+
+type RHSMFactsStageOptions struct {
+	Facts RHSMFacts `json:"facts"`
+}
+
+type RHSMFacts struct {
+	ApiType string `json:"image-builder.osbuild-composer.api-type"`
+}
+
+func (RHSMFactsStageOptions) isStageOptions() {}
+
+// NewRHSMFactsStage creates a new RHSM stage
+func NewRHSMFactsStage(options *RHSMFactsStageOptions) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.rhsm.facts",
+		Options: options,
+	}
+}

--- a/internal/osbuild/rhsm_facts_stage_test.go
+++ b/internal/osbuild/rhsm_facts_stage_test.go
@@ -1,0 +1,46 @@
+package osbuild
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRHSMFactsStage(t *testing.T) {
+	expectedStage := &Stage{
+		Type:    "org.osbuild.rhsm.facts",
+		Options: &RHSMFactsStageOptions{},
+	}
+	actualStage := NewRHSMFactsStage(&RHSMFactsStageOptions{})
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestRHSMFactsStageJson(t *testing.T) {
+	tests := []struct {
+		Options    RHSMFactsStageOptions
+		JsonString string
+	}{
+		{
+			Options: RHSMFactsStageOptions{
+				Facts: RHSMFacts{
+					ApiType: "test-api",
+				},
+			},
+			JsonString: fmt.Sprintf(`{"facts":{"image-builder.osbuild-composer.api-type":"%s"}}`, "test-api"),
+		},
+	}
+	for _, test := range tests {
+		marshaledJson, err := json.Marshal(test.Options)
+		require.NoError(t, err, "failed to marshal JSON")
+		require.Equal(t, test.JsonString, string(marshaledJson))
+
+		var jsonOptions RHSMFactsStageOptions
+		err = json.Unmarshal([]byte(test.JsonString), &jsonOptions)
+		require.NoError(t, err, "failed to parse JSON")
+		require.True(t, reflect.DeepEqual(test.Options, jsonOptions))
+	}
+}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2351,6 +2351,9 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			URL:    cr.OSTree.URL,
 		},
 	}
+	options.Facts = &distro.FactsImageOptions{
+		ApiType: "weldr",
+	}
 
 	packageSets, err := api.depsolveBlueprintForImageType(*bp, options, imageType)
 	if err != nil {

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -309,10 +309,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 62
-Requires:   osbuild-ostree >= 62
-Requires:   osbuild-lvm2 >= 62
-Requires:   osbuild-luks2 >= 62
+Requires:   osbuild >= 63
+Requires:   osbuild-ostree >= 63
+Requires:   osbuild-lvm2 >= 63
+Requires:   osbuild-luks2 >= 63
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker


### PR DESCRIPTION
Work has been ongoing to store RHSM facts into built images. This PR is part of the `osbuild-composer` side of things but has some problems to solve and/or discuss.

In this initial pull request only the `ApiType` used to request the compose is stored in the `rhsm.facts` file eventually created by `osbuild`.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
