### PR TITLE
Support hybrid boot for edge installers

### DIFF
--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -266,7 +266,7 @@ func edgeInstallerPipelines(t *imageType, customizations *blueprint.Customizatio
 	pipelines = append(pipelines, *anacondaTreePipeline(repos, installerPackages, kernelVer, archName, d.product, d.osVersion, "edge", ksUsers))
 	isolabel := fmt.Sprintf(d.isolabelTmpl, archName)
 	pipelines = append(pipelines, *bootISOTreePipeline(kernelVer, archName, d.vendor, d.product, d.osVersion, isolabel, kickstartOptions, payloadStages))
-	pipelines = append(pipelines, *bootISOPipeline(t.Filename(), d.isolabelTmpl, archName, false))
+	pipelines = append(pipelines, *bootISOPipeline(t.Filename(), d.isolabelTmpl, archName, t.Arch().Name() == "x86_64"))
 	return pipelines, nil
 }
 

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -258,7 +258,7 @@ func edgeInstallerPipelines(t *imageType, customizations *blueprint.Customizatio
 	pipelines = append(pipelines, *anacondaTreePipeline(repos, installerPackages, kernelVer, archName, d.product, d.osVersion, "edge", ksUsers))
 	isolabel := fmt.Sprintf(d.isolabelTmpl, archName)
 	pipelines = append(pipelines, *bootISOTreePipeline(kernelVer, archName, d.vendor, d.product, d.osVersion, isolabel, kickstartOptions, payloadStages))
-	pipelines = append(pipelines, *bootISOPipeline(t.Filename(), d.isolabelTmpl, archName, false))
+	pipelines = append(pipelines, *bootISOPipeline(t.Filename(), d.isolabelTmpl, archName, t.Arch().Name() == "x86_64"))
 	return pipelines, nil
 }
 

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -73,6 +73,7 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline)
 	isoPipeline.Filename = img.Filename
+	isoPipeline.ISOLinux = true
 	artifact := isoPipeline.Export()
 
 	return artifact, nil

--- a/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
@@ -9139,7 +9139,12 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-8-x86_64-dvd",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_8-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_installer_with_users-boot.json
@@ -9191,7 +9191,12 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-8-x86_64-dvd",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -9392,7 +9392,12 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -9444,7 +9444,12 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_installer-boot.json
@@ -10104,7 +10104,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_installer_with_users-boot.json
@@ -10156,7 +10156,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_installer-boot.json
@@ -10297,7 +10297,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_installer_with_users-boot.json
@@ -10349,7 +10349,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_installer-boot.json
@@ -10624,7 +10624,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-fedora_iot_installer_with_users-boot.json
@@ -10676,7 +10676,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_installer-boot.json
@@ -10809,7 +10809,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-x86_64-fedora_iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-fedora_iot_installer_with_users-boot.json
@@ -10861,7 +10861,12 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_8-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_installer-boot.json
@@ -3673,7 +3673,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-6-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_8-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_installer_with_users-boot.json
@@ -3725,7 +3725,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-6-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_84-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_installer-boot.json
@@ -3715,7 +3715,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-4-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_84-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_installer_with_users-boot.json
@@ -3767,7 +3767,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-4-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_85-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_installer-boot.json
@@ -3679,7 +3679,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-5-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_85-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_installer_with_users-boot.json
@@ -3679,7 +3679,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-5-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
@@ -3673,7 +3673,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-6-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_86-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_installer_with_users-boot.json
@@ -3725,7 +3725,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-6-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_87-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_installer-boot.json
@@ -3736,7 +3736,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-7-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_87-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_installer_with_users-boot.json
@@ -3788,7 +3788,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-7-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -3765,7 +3765,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -3817,7 +3817,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -9568,7 +9568,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -9620,7 +9620,12 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-x86_64",
               "sysid": "LINUX",
+              "boot": {
+                "image": "isolinux/isolinux.bin",
+                "catalog": "isolinux/boot.cat"
+              },
               "efi": "images/efiboot.img",
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },


### PR DESCRIPTION
We supported hybrid boot for edge installers in RHEL 9.0 but we regressed when unifying the distro definitions.
From the history it seems we never supported BIOS on RHEL 8.x, but we can add it there as well.

Fixes [RHBZ#2110864](https://bugzilla.redhat.com/show_bug.cgi?id=2110864)