### PR TITLE
gen-manifests: don't fail on invalid distro-arch-image combos

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -379,7 +379,8 @@ func main() {
 	for _, distroName := range distros {
 		distribution := distroReg.GetDistro(distroName)
 		if distribution == nil {
-			panic(fmt.Sprintf("invalid distro name %q\n", distroName))
+			fmt.Fprintf(os.Stderr, "invalid distro name %q\n", distroName)
+			continue
 		}
 
 		distroArches := arches
@@ -389,7 +390,8 @@ func main() {
 		for _, archName := range distroArches {
 			arch, err := distribution.GetArch(archName)
 			if err != nil {
-				panic(fmt.Sprintf("invalid arch name %q for distro %q: %s", archName, distroName, err.Error()))
+				fmt.Fprintf(os.Stderr, "invalid arch name %q for distro %q: %s\n", archName, distroName, err.Error())
+				continue
 			}
 
 			daImgTypes := imgTypes
@@ -399,7 +401,8 @@ func main() {
 			for _, imgTypeName := range daImgTypes {
 				imgType, err := arch.GetImageType(imgTypeName)
 				if err != nil {
-					panic(fmt.Sprintf("invalid image type %q for distro %q and arch %q: %s", imgTypeName, distroName, archName, err.Error()))
+					fmt.Fprintf(os.Stderr, "invalid image type %q for distro %q and arch %q: %s\n", imgTypeName, distroName, archName, err.Error())
+					continue
 				}
 
 				// get repositories


### PR DESCRIPTION
When the user specifies any of the distro, arch, or image type values to filter generation, invalid combinations would cause a panic, which made it hard to filter requests based just on an image type.
Instead of failing, print an error message to inform the user, but continue with the rest of the jobs.
This way, a user is informed that a certain combination is invalid if they make a mistake, but can also filter on a single image type and only get valid manifests out of the run.


This change enables running (for example):
```
go run ./cmd/gen-manifests -images edge-installer,installer
```
without worrying about distros or architectures that don't support those image types.

The error message is printed to avoid situations where typos create only invalid requests that are silently skipped.