### PR TITLE
Cache the results of dnf-json dump and search commands

### DIFF
--- a/internal/dnfjson/dnfjson_test.go
+++ b/internal/dnfjson/dnfjson_test.go
@@ -548,3 +548,39 @@ func TestErrorRepoInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoConfigHash(t *testing.T) {
+	rc := repoConfig{
+		ID:        "repoid-1",
+		Name:      "A test repository",
+		BaseURL:   "https://arepourl/",
+		IgnoreSSL: false,
+	}
+
+	hash := rc.Hash()
+	assert.Equal(t, 64, len(hash))
+
+	rc.BaseURL = "https://adifferenturl/"
+	assert.NotEqual(t, hash, rc.Hash())
+}
+
+func TestRequestHash(t *testing.T) {
+	solver := NewSolver("f36", "36", "x86_64", "/tmp/cache")
+	repos := []rpmmd.RepoConfig{
+		rpmmd.RepoConfig{
+			Name:      "A test repository",
+			BaseURL:   "https://arepourl/",
+			IgnoreSSL: false,
+		},
+	}
+
+	req, err := solver.makeDumpRequest(repos)
+	assert.Nil(t, err)
+	hash := req.Hash()
+	assert.Equal(t, 64, len(hash))
+
+	req, err = solver.makeSearchRequest(repos, []string{"package0*"})
+	assert.Nil(t, err)
+	assert.Equal(t, 64, len(req.Hash()))
+	assert.NotEqual(t, hash, req.Hash())
+}


### PR DESCRIPTION
This is a proposed change, so I'm making it a Draft for now. Discussion will be in #2887

This caches the results of dnf-json for 60s, the cache is based on the Request made, so different distros, repos, search terms are considered different. It returns the results for 60s and then makes a new request to dnf-json, and it cleans up the map when CleanCache() is called so that memory use doesn't go crazy.

The result of this is that when using cockpit-composer to page through lists of packages, or explore package dependencies, it speeds things up 'a whole bunch'. The only possible drawback I see is that every 60s it takes a bit longer to get results.

This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

- [X] PR contains automated tests for new functionality and