### PR TITLE
test/aws.sh: use bigger instance for `cloud-image-val-test`

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -229,7 +229,7 @@ tee "${TEMPDIR}/resource-file.json" <<EOF
         {
             "ami": "$AMI_IMAGE_ID",
             "region": "us-east-1",
-            "instance_type": "t3a.micro",
+            "instance_type": "t3.medium",
             "username": "$SSH_USER",
             "name": "civ-testing-image"
         }


### PR DESCRIPTION
For some tests, using a micro instance type is not enough. Changing to t3.medium will solve these issues.

The PR also includes conversation around CIV release process.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/