### PR TITLE
weldr: Preload metadata at startup

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -123,6 +123,8 @@ func (c *Composer) InitWeldr(repoPaths []string, weldrListener net.Listener,
 	}
 	c.weldrListener = weldrListener
 
+	// Preload the Metadata for all the supported distros
+	c.weldr.PreloadMetadata()
 	return nil
 }
 


### PR DESCRIPTION
For each of the supported distros start a goroutine to depsolve
'filesystem' which will preload the metadata making subsequent responses
faster.

This is safe to do without limits because we only supposed a limited
number of distros, and without additional locking because this is the
the same as hitting the API with multiple depsolve requests at the same
time.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

I didn't add testing for this because I'm not sure it can be tested. Ideas are welcome :)