### PR TITLE
rhel9: explicitly add containernetworking-plugins to edge

### DIFF
--- a/internal/distro/rhel9/package_sets.go
+++ b/internal/distro/rhel9/package_sets.go
@@ -946,6 +946,7 @@ func edgeCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"ima-evm-utils",
 			"audit",
 			"podman",
+			"containernetworking-plugins", // required for cni networks but not a hard dependency of podman >= 4.2.0 (rhbz#2123210)
 			"container-selinux",
 			"skopeo",
 			"criu",


### PR DESCRIPTION
In podman v4.0.0 the default network backend was switched from cni to netavark.  However, podman will choose cni if there are already containers, images, or cni networks preset on a system [1].

Starting with podman v4.2.0, containernetworking-plugins is no longer a hard requirement for podman.  So when an edge commit is built with an embedded container, podman v4.2.0+ will choose the cni network and fail with an error because the plugin isn't installed.

Adding the package explicitly alongside podman to avoid this issue with future RHEL 9.1 edge builds when they include containers.

This change does not affect test manifests.  The package is already included in manifests as a dependency of podman < v4.2.0.

See rhbz#2123210

[1] https://github.com/containers/common/blob/a083f790abf21048518f2d66b7e01370cc055790/pkg/config/containers.conf#L275-L278


----

Regarding all other image types:
We don't include podman in other image types by default.  It's up to the user to install their container runtime if and when they choose to include a container in their build.  We might change this in the future with a default runtime and an associated option, but I'd like to isolate this change to fix the issue in the edge commit before making bigger changes to image types and options.