### PR TITLE
test: change CIV tag

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -216,7 +216,15 @@ fi
 
 greenprint "Pulling cloud-image-val container"
 
-CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:latest"
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+else
+  # If not, get prod container
+  TAG="prod"
+fi
+
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
 
 sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_CLOUD_IMAGE_VAL}
 


### PR DESCRIPTION
We were using `latest` as tag, this can be dangerous as it's the default
tag, an anyone can accidentally update it. Using `prod` is safer.

Also use dev container image if the test script is running in CIV CI.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/