### PR TITLE
appsre: disable aarch64 AMI creation temporarily

### DIFF
--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -55,39 +55,39 @@ build {
     }
   }
 
-  source "amazon-ebs.image_builder" {
-    name = "rhel-8-aarch64"
+  // source "amazon-ebs.image_builder" {
+  //   name = "rhel-8-aarch64"
 
-    # Use a static RHEL 8.6 Cloud Access Image.
-    source_ami = "ami-0c84d76d81209a0e2"
-    ssh_username = "ec2-user"
-    instance_type = "c6g.large"
-    aws_polling {
-      delay_seconds = 10
-      max_attempts  = 50
-    }
+  //   # Use a static RHEL 8.6 Cloud Access Image.
+  //   source_ami = "ami-0c84d76d81209a0e2"
+  //   ssh_username = "ec2-user"
+  //   instance_type = "c6g.large"
+  //   aws_polling {
+  //     delay_seconds = 10
+  //     max_attempts  = 50
+  //   }
 
-    # Set a name for the resulting AMI.
-    ami_name = "${var.image_name}"
+  //   # Set a name for the resulting AMI.
+  //   ami_name = "${var.image_name}"
 
-    # Apply tags to the resulting AMI/EBS snapshot.
-    tags = {
-      AppCode = "IMGB-001"
-      Name = "${var.image_name}"
-      composer_commit = "${var.composer_commit}"
-      os = "rhel"
-      os_version = "8"
-      arch = "aarch64"
-    }
+  //   # Apply tags to the resulting AMI/EBS snapshot.
+  //   tags = {
+  //     AppCode = "IMGB-001"
+  //     Name = "${var.image_name}"
+  //     composer_commit = "${var.composer_commit}"
+  //     os = "rhel"
+  //     os_version = "8"
+  //     arch = "aarch64"
+  //   }
 
-    # Ensure that the EBS snapshot used for the AMI meets our requirements.
-    launch_block_device_mappings {
-      delete_on_termination = "true"
-      device_name           = "/dev/sda1"
-      volume_size           = 10
-      volume_type           = "gp2"
-    }
-  }
+  //   # Ensure that the EBS snapshot used for the AMI meets our requirements.
+  //   launch_block_device_mappings {
+  //     delete_on_termination = "true"
+  //     device_name           = "/dev/sda1"
+  //     volume_size           = 10
+  //     volume_type           = "gp2"
+  //   }
+  // }
 
   source "amazon-ebs.image_builder"  {
     name = "fedora-35-x86_64"


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
