### PR TITLE
Add timeouts to http.Server APIs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,9 +101,8 @@ jobs:
 
   lint:
     name: "⌨ Lint"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-
       - name: Set up Go 1.16
         uses: actions/setup-go@v3
         with:
@@ -115,10 +114,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.30.0
-
-        # This is needed to lint internal/upload/koji package
+      # This is needed to lint internal/upload/koji package
       - name: Install kerberos devel package
         run: sudo apt-get install -y libkrb5-dev
 
@@ -127,7 +123,10 @@ jobs:
         run: sudo apt-get install -y libgpgme-dev
 
       - name: Run golangci-lint
-        run: $(go env GOPATH)/bin/golangci-lint run --timeout 5m0s
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --verbose --timeout 5m0s
 
   prepare:
     name: "🔍 Check source preparation"

--- a/cmd/osbuild-auth-tests/certificates.go
+++ b/cmd/osbuild-auth-tests/certificates.go
@@ -44,6 +44,7 @@ func newSelfSignedCertificateKeyPair(subj string) (*certificateKeyPair, error) {
 
 	ckp := certificateKeyPair{baseDir: dir}
 
+	//nolint:gosec
 	cmd := exec.Command(
 		"openssl", "req", "-nodes", "-x509",
 		"-subj", subj,
@@ -115,6 +116,7 @@ func newCA(subj string) (*ca, error) {
 		BaseDir: baseDir,
 	}
 
+	//nolint:gosec
 	cmd := exec.Command(
 		"openssl", "req",
 		"-config", opensslConfig,

--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -221,7 +221,7 @@ func (c *Composer) Start() error {
 	if c.localWorkerListener != nil {
 		localWorkerAPI = &http.Server{
 			ErrorLog:          c.logger,
-			Handler:           c.workers.Handler(),
+			Handler:           http.TimeoutHandler(c.workers.Handler(), 60*time.Second, `{"href":"/api/worker/v1/errors/1008","code":"IMAGE-BUILDER-LOCAL-WORKER-1008","id":"1008","kind":"Error","reason":"Timeout exceeded"}`),
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 
@@ -253,7 +253,7 @@ func (c *Composer) Start() error {
 		}
 		remoteWorkerAPI = &http.Server{
 			ErrorLog:          c.logger,
-			Handler:           handler,
+			Handler:           http.TimeoutHandler(handler, 60*time.Second, `{"href":"/api/worker/v1/errors/1008","code":"IMAGE-BUILDER-REMOTE-WORKER-1008","id":"1008","kind":"Error","reason":"Timeout exceeded"}`),
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 
@@ -299,7 +299,7 @@ func (c *Composer) Start() error {
 
 		composerAPI = &http.Server{
 			ErrorLog:          c.logger,
-			Handler:           handler,
+			Handler:           http.TimeoutHandler(handler, 60*time.Second, `{"href":"/api/image-builder-composer/v2/errors/1020","code":"IMAGE-BUILDER-COMPOSER-1020","id":"1020","kind":"Error","reason":"Timeout exceeded"}`),
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 

--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -220,8 +220,9 @@ func (c *Composer) Start() error {
 
 	if c.localWorkerListener != nil {
 		localWorkerAPI = &http.Server{
-			ErrorLog: c.logger,
-			Handler:  c.workers.Handler(),
+			ErrorLog:          c.logger,
+			Handler:           c.workers.Handler(),
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 
 		go func() {
@@ -251,8 +252,9 @@ func (c *Composer) Start() error {
 			}
 		}
 		remoteWorkerAPI = &http.Server{
-			ErrorLog: c.logger,
-			Handler:  handler,
+			ErrorLog:          c.logger,
+			Handler:           handler,
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 
 		go func() {
@@ -296,8 +298,9 @@ func (c *Composer) Start() error {
 		}
 
 		composerAPI = &http.Server{
-			ErrorLog: c.logger,
-			Handler:  handler,
+			ErrorLog:          c.logger,
+			Handler:           handler,
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 
 		go func() {

--- a/cmd/osbuild-mock-openid-provider/main.go
+++ b/cmd/osbuild-mock-openid-provider/main.go
@@ -149,6 +149,7 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 	})
 
+	//nolint:gosec
 	if tlsCert != "" && tlsKey != "" {
 		log.Fatal(http.ListenAndServeTLS(addr, tlsCert, tlsKey, mux))
 	} else {

--- a/internal/boot/azuretest/azure.go
+++ b/internal/boot/azuretest/azure.go
@@ -11,8 +11,12 @@ import (
 	"net/url"
 	"os"
 
+	// NOTE these are deprecated and will need replacement, see issue #2977
+	//nolint:staticcheck
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	//nolint:staticcheck
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"

--- a/internal/boot/context-managers.go
+++ b/internal/boot/context-managers.go
@@ -180,6 +180,7 @@ func WithBootedQemuImage(image string, ns NetNS, f func() error) error {
 // WithBootedNspawnImage boots the specified image in the specified namespace
 // using nspawn. The VM is killed immediately after function returns.
 func WithBootedNspawnImage(image string, ns NetNS, f func() error) error {
+	//nolint:gosec
 	cmd := exec.Command(
 		"systemd-nspawn",
 		"--boot", "--register=no",
@@ -205,6 +206,7 @@ func WithBootedNspawnImage(image string, ns NetNS, f func() error) error {
 // WithBootedNspawnImage boots the specified directory in the specified namespace
 // using nspawn. The VM is killed immediately after function returns.
 func WithBootedNspawnDirectory(dir string, ns NetNS, f func() error) error {
+	//nolint:gosec
 	cmd := exec.Command(
 		"systemd-nspawn",
 		"--boot", "--register=no",

--- a/internal/cloud/gcp/gcp.go
+++ b/internal/cloud/gcp/gcp.go
@@ -14,6 +14,7 @@ import (
 // GCPCredentialsEnvName contains name of the environment variable used
 // to specify the path to file with CGP service account credentials
 const (
+	//nolint:gosec
 	GCPCredentialsEnvName string = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 

--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -70,6 +70,7 @@ const (
 	ErrorGettingOSBuildJobStatus                  ServiceErrorCode = 1017
 	ErrorGettingAWSEC2JobStatus                   ServiceErrorCode = 1018
 	ErrorGettingJobType                           ServiceErrorCode = 1019
+	ErrorTimeoutExceeded                          ServiceErrorCode = 1020
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -144,6 +145,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorGettingOSBuildJobStatus, http.StatusInternalServerError, "Unable to get osbuild job status"},
 		serviceError{ErrorGettingAWSEC2JobStatus, http.StatusInternalServerError, "Unable to get ec2 job status"},
 		serviceError{ErrorGettingJobType, http.StatusInternalServerError, "Unable to get job type of existing job"},
+		serviceError{ErrorTimeoutExceeded, http.StatusInternalServerError, "Timeout exceeded"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -281,7 +281,7 @@ func imageInstallerPipelines(t *imageType, customizations *blueprint.Customizati
 	}
 	pipelines = append(pipelines, *treePipeline)
 
-	kernelPkg := new(rpmmd.PackageSpec)
+	var kernelPkg *rpmmd.PackageSpec
 	installerPackages := packageSetSpecs[installerPkgsKey]
 	for _, pkg := range installerPackages {
 		if pkg.Name == "kernel" {

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -273,7 +273,7 @@ func imageInstallerPipelines(t *imageType, customizations *blueprint.Customizati
 	}
 	pipelines = append(pipelines, *treePipeline)
 
-	kernelPkg := new(rpmmd.PackageSpec)
+	var kernelPkg *rpmmd.PackageSpec
 	installerPackages := packageSetSpecs[installerPkgsKey]
 	for _, pkg := range installerPackages {
 		if pkg.Name == "kernel" {

--- a/internal/upload/azure/azurestorage.go
+++ b/internal/upload/azure/azurestorage.go
@@ -186,7 +186,7 @@ func (c StorageClient) CreateStorageContainerIfNotExist(ctx context.Context, sto
 
 	_, err := containerURL.Create(ctx, azblob.Metadata{}, azblob.PublicAccessNone)
 	if err != nil {
-		if storageErr, ok := err.(azblob.StorageError); ok && storageErr.(azblob.StorageError).ServiceCode() == azblob.ServiceCodeContainerAlreadyExists {
+		if storageErr, ok := err.(azblob.StorageError); ok && storageErr.ServiceCode() == azblob.ServiceCodeContainerAlreadyExists {
 			return nil
 		}
 		return fmt.Errorf("cannot create a storage container: %v", err)

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -277,7 +277,8 @@ func setupRouter(api *API) *API {
 
 func (api *API) Serve(listener net.Listener) error {
 	api.server = http.Server{
-		Handler:           api,
+		// The timeout here is so long because downloading metadata can take several minutes
+		Handler:           http.TimeoutHandler(api, 10*time.Minute, `{"errors":[{"code":500,"id":"HTTPTimeoutError","msg":"Timeout exceeded"}],"status":false}`),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -276,7 +276,10 @@ func setupRouter(api *API) *API {
 }
 
 func (api *API) Serve(listener net.Listener) error {
-	api.server = http.Server{Handler: api}
+	api.server = http.Server{
+		Handler:           api,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 
 	err := api.server.Serve(listener)
 	if err != nil && err != http.ErrServerClosed {

--- a/internal/worker/api/errors.go
+++ b/internal/worker/api/errors.go
@@ -34,6 +34,7 @@ const (
 	ErrorRetrievingJobStatus      ServiceErrorCode = 1005
 	ErrorRequestingJob            ServiceErrorCode = 1006
 	ErrorFailedLoadingOpenAPISpec ServiceErrorCode = 1007
+	ErrorTimeoutExceeded          ServiceErrorCode = 1008
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -70,6 +71,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorRequestingJob, http.StatusInternalServerError, "Error requesting job"},
 		serviceError{ErrorInvalidErrorId, http.StatusBadRequest, "Invalid format for error id, it should be an integer as a string"},
 		serviceError{ErrorFailedLoadingOpenAPISpec, http.StatusInternalServerError, "Unable to load openapi spec"},
+		serviceError{ErrorTimeoutExceeded, http.StatusInternalServerError, "Timeout exceeded"},
 		serviceError{ErrorResourceNotFound, http.StatusNotFound, "Requested resource doesn't exist"},
 		serviceError{ErrorMethodNotAllowed, http.StatusMethodNotAllowed, "Requested method isn't supported for resource"},
 		serviceError{ErrorNotAcceptable, http.StatusNotAcceptable, "Only 'application/json' content is supported"},


### PR DESCRIPTION
While fixing the linting for #2973 I noticed there were no timeouts, so I tried adding them.
I'm actually unsure if they are really needed since none of these endpoints are exposed directly, right?

I'm also seeing some odd log entries. It looks like it is constantly trying to make requests for the local worker. I see these:

```
Sep 13 10:44:00 fedora osbuild-worker[666]: time="2022-09-13T10:44:00-07:00" level=error msg="Requesting job failed: error requesting job: 503 — Timeout exceeded (IMAGE-BUILDER-LOCAL-WORKER-1008)"
Sep 13 10:44:00 fedora osbuild-worker[666]: time="2022-09-13T10:44:00-07:00" level=warning msg="Received error from RequestAndRunJob, backing off"
Sep 13 10:44:41 fedora osbuild-worker[666]: time="2022-09-13T10:44:41-07:00" level=error msg="Requesting job failed: error requesting job: 503 — Timeout exceeded (IMAGE-BUILDER-LOCAL-WORKER-1008)"
Sep 13 10:44:41 fedora osbuild-worker[666]: time="2022-09-13T10:44:41-07:00" level=warning msg="Received error from RequestAndRunJob, backing off"
```

every minute (the timeout is 60 seconds for the workers).

So basically, this PR is for discussion only right now :)

P.S. This is based on #2973, so that's why so many commits.
