### PR TITLE
Enable testing for Fedora ISOs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -749,6 +749,7 @@ Installer:
           - rhos-01/rhel-8.7-nightly-x86_64
           - rhos-01/rhel-9.1-nightly-x86_64
           - rhos-01/centos-stream-9-x86_64
+          - rhos-01/fedora-37-x86_64
 
 Manifest-diff:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,8 +376,8 @@ New OSTree:
     matrix:
       - RUNNER:
           - rhos-01/fedora-35-x86_64
-          # - rhos-01/fedora-36-x86_64
-          # - rhos-01/fedora-37-x86_64
+          - rhos-01/fedora-36-x86_64
+          - rhos-01/fedora-37-x86_64
           - rhos-01/rhel-8.7-nightly-x86_64
           - rhos-01/rhel-9.1-nightly-x86_64
           - rhos-01/centos-stream-8-x86_64

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -129,6 +129,9 @@ case "${ID}-${VERSION_ID}" in
     centos-9)
         OS_VARIANT="centos-stream9"
         ;;
+    "fedora-"*)
+        OS_VARIANT="fedora-unknown"
+        ;;
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;


### PR DESCRIPTION
For now, this is expected to fail because of https://github.com/osbuild/osbuild/issues/1115.
Letting it run to see if any other issues arise with the test scripts before hitting the bug.