### PR TITLE
tests/upgrade: copy shared_lib.sh to the test vm

### DIFF
--- a/test/cases/upgrade8to9.sh
+++ b/test/cases/upgrade8to9.sh
@@ -118,6 +118,7 @@ sudo pkill -P "$CONSOLE_PID"
 
 # copy over next phases of the test and run the first one
 sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" /usr/share/tests/osbuild-composer/upgrade8to9/*.sh root@"$INSTANCE_ADDRESS":
+sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" /usr/libexec/tests/osbuild-composer/shared_lib.sh root@"$INSTANCE_ADDRESS":
 # Put comment in sshd_config to keep root login after upgrade
 sudo ssh "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS" 'sed -i "s/PermitRootLogin yes/PermitRootLogin yes #for sure/" /etc/ssh/sshd_config'
 set +e

--- a/test/data/upgrade8to9/upgrade_prepare.sh
+++ b/test/data/upgrade8to9/upgrade_prepare.sh
@@ -12,7 +12,8 @@ dnf install -y osbuild-composer composer-cli
 
 # Prepare the upgrade
 curl -k -o /etc/yum.repos.d/oam-group-leapp-rhel-8.repo https://gitlab.cee.redhat.com/leapp/oamg-rhel8-vagrant/-/raw/master/roles/init/files/leapp-copr.repo
-dnf install -y leapp-upgrade-el8toel9 vdo
+# install the leapp upgrade tool + other dependencies
+dnf install -y leapp-upgrade-el8toel9 vdo jq rpmdevtools
 curl -kLO https://gitlab.cee.redhat.com/leapp/oamg-rhel7-vagrant/raw/master/roles/init/files/prepare_test_env.sh
 source /root/prepare_test_env.sh
 get_data_files

--- a/test/data/upgrade8to9/upgrade_verify.sh
+++ b/test/data/upgrade8to9/upgrade_verify.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+source shared_lib.sh
 
 WORKSPACE=$(mktemp -d)
 function cleanup() {
@@ -43,9 +43,6 @@ COMPOSE_INFO=${WORKSPACE}/compose-info-${IMAGE_KEY}.json
 
 # check installed osbuild-composer version
 rpm -qi osbuild-composer
-
-# install jq in case it's not present
-dnf install -y jq
 
 # Prepare repository override
 mkdir -p /etc/osbuild-composer/repositories


### PR DESCRIPTION
shared_lib.sh now contains some more helper functions and the verification script uses them. Copy it over so that we can source it. Also install all other dependencies before the actual upgrade.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
