### PR TITLE
distro: use storage capacity multiple constants in partition tables

### DIFF
--- a/internal/distro/fedora/partition_tables.go
+++ b/internal/distro/fedora/partition_tables.go
@@ -1,6 +1,7 @@
 package fedora
 
 import (
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 )
@@ -11,13 +12,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * common.MebiByte, // 200 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -31,7 +32,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -44,7 +45,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -63,7 +64,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * common.MebiByte, // 200 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -77,7 +78,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -90,7 +91,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -112,13 +113,13 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 525336576, // 500 MiB
+				Size: 501 * common.MebiByte, // 501 MiB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -132,7 +133,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1073741824, // 1 GiB
+				Size: 1 * common.GibiByte, // 1 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -145,7 +146,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2693791744, // 2.5 GiB
+				Size: 2569 * common.MebiByte, // 2.5 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -164,13 +165,13 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 525336576, // 500 MiB
+				Size: 501 * common.MebiByte, // 501 MiB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -184,7 +185,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 1073741824, // 1 GiB
+				Size: 1 * common.GibiByte, // 1 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -197,7 +198,7 @@ var iotBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2693791744, // 2.5 GiB
+				Size: 2569 * common.MebiByte, // 2.5 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{

--- a/internal/distro/rhel7/azure.go
+++ b/internal/distro/rhel7/azure.go
@@ -59,10 +59,10 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 	distro.X86_64ArchName: disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
-		Size: 68719476736,
+		Size: 64 * common.GibiByte,
 		Partitions: []disk.Partition{
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -75,7 +75,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -87,7 +87,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2097152,
+				Size:     2 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
@@ -100,7 +100,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 					Description: "built with lvm2 and osbuild",
 					LogicalVolumes: []disk.LVMLogicalVolume{
 						{
-							Size: 1 * 1024 * 1024 * 1024,
+							Size: 1 * common.GibiByte,
 							Name: "homelv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -112,7 +112,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "rootlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -124,7 +124,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "tmplv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -136,7 +136,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024,
+							Size: 10 * common.GibiByte,
 							Name: "usrlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -148,7 +148,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024, // firedrill: 8 GB
+							Size: 10 * common.GibiByte, // firedrill: 8 GB
 							Name: "varlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",

--- a/internal/distro/rhel7/partition_tables.go
+++ b/internal/distro/rhel7/partition_tables.go
@@ -1,6 +1,7 @@
 package rhel7
 
 import (
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 )
@@ -13,13 +14,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * common.MebiByte, // 200 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -33,7 +34,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -46,7 +47,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{

--- a/internal/distro/rhel8/azure.go
+++ b/internal/distro/rhel8/azure.go
@@ -128,10 +128,10 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 	distro.X86_64ArchName: disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
-		Size: 68719476736,
+		Size: 64 * common.GibiByte,
 		Partitions: []disk.Partition{
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -144,7 +144,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -156,7 +156,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2097152,
+				Size:     2 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
@@ -169,7 +169,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 					Description: "built with lvm2 and osbuild",
 					LogicalVolumes: []disk.LVMLogicalVolume{
 						{
-							Size: 1 * 1024 * 1024 * 1024,
+							Size: 1 * common.GibiByte,
 							Name: "homelv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -181,7 +181,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "rootlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -193,7 +193,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "tmplv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -205,7 +205,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024,
+							Size: 10 * common.GibiByte,
 							Name: "usrlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -217,7 +217,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024,
+							Size: 10 * common.GibiByte,
 							Name: "varlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",

--- a/internal/distro/rhel8/partition_tables.go
+++ b/internal/distro/rhel8/partition_tables.go
@@ -1,6 +1,7 @@
 package rhel8
 
 import (
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 )
@@ -11,13 +12,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576,
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 104857600,
+				Size: 100 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -30,7 +31,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -49,7 +50,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 104857600,
+				Size: 100 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -62,7 +63,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -81,12 +82,12 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     4194304,
+				Size:     4 * common.MebiByte,
 				Type:     "41",
 				Bootable: true,
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -102,7 +103,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     2 * 1024 * 1024 * 1024, // 2 GiB
+				Size:     2 * common.GibiByte, // 2 GiB
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
@@ -122,13 +123,13 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576,
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -147,7 +148,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 209715200,
+				Size: 200 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -160,7 +161,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 536870912,
+				Size: 512 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -172,7 +173,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -194,13 +195,13 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576,
+				Size:     1 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 133169152, // 127 MB
+				Size: 127 * common.MebiByte, // 127 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -214,7 +215,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 402653184, // 384 MB
+				Size: 384 * common.MebiByte, // 384 MB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -227,7 +228,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{
@@ -261,7 +262,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 133169152, // 127 MB
+				Size: 127 * common.MebiByte, // 127 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -275,7 +276,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 402653184, // 384 MB
+				Size: 384 * common.MebiByte, // 384 MB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -288,7 +289,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
+				Size: 2 * common.GibiByte, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.LUKSContainer{

--- a/internal/distro/rhel9/azure.go
+++ b/internal/distro/rhel9/azure.go
@@ -125,10 +125,10 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 	distro.X86_64ArchName: disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
-		Size: 68719476736,
+		Size: 64 * common.GibiByte,
 		Partitions: []disk.Partition{
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -141,7 +141,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000,
+				Size: 500 * common.MebiByte,
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -153,7 +153,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2097152,
+				Size:     2 * common.MebiByte,
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
@@ -166,7 +166,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 					Description: "built with lvm2 and osbuild",
 					LogicalVolumes: []disk.LVMLogicalVolume{
 						{
-							Size: 1 * 1024 * 1024 * 1024,
+							Size: 1 * common.GibiByte,
 							Name: "homelv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -178,7 +178,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "rootlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -190,7 +190,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 2 * 1024 * 1024 * 1024,
+							Size: 2 * common.GibiByte,
 							Name: "tmplv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -202,7 +202,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024,
+							Size: 10 * common.GibiByte,
 							Name: "usrlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",
@@ -214,7 +214,7 @@ var azureRhuiBasePartitionTables = distro.BasePartitionTableMap{
 							},
 						},
 						{
-							Size: 10 * 1024 * 1024 * 1024,
+							Size: 10 * common.GibiByte,
 							Name: "varlv",
 							Payload: &disk.Filesystem{
 								Type:         "xfs",

--- a/internal/distro/rhel9/partition_tables.go
+++ b/internal/distro/rhel9/partition_tables.go
@@ -1,6 +1,7 @@
 package rhel9
 
 import (
+	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 )
@@ -11,13 +12,13 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * common.MebiByte, // 200 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -31,7 +32,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -44,7 +45,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -63,7 +64,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * common.MebiByte, // 200 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -77,7 +78,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -90,7 +91,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -109,12 +110,12 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size:     4194304,
+				Size:     4 * common.MebiByte,
 				Type:     "41",
 				Bootable: true,
 			},
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/boot",
@@ -125,7 +126,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 2147483648, // 2GiB
+				Size: 2 * common.GibiByte, // 2GiB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -141,7 +142,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
-				Size: 524288000, // 500 MB
+				Size: 500 * common.MebiByte, // 500 MB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/boot",
@@ -152,7 +153,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size:     2147483648, // 2GiB
+				Size:     2 * common.GibiByte, // 2GiB
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
@@ -172,13 +173,13 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * common.MebiByte, // 1MB
 				Bootable: true,
 				Type:     disk.BIOSBootPartitionGUID,
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
-				Size: 133169152, // 127 MB
+				Size: 127 * common.MebiByte, // 127 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -192,7 +193,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 402653184, // 384 MB
+				Size: 384 * common.MebiByte, // 384 MB
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{
@@ -238,7 +239,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size: 133169152, // 127 MB
+				Size: 127 * common.MebiByte, // 127 MB
 				Type: disk.EFISystemPartitionGUID,
 				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -252,7 +253,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
-				Size: 402653184, // 384 MB
+				Size: 384 * common.MebiByte, // 384 MB
 				Type: disk.XBootLDRPartitionGUID,
 				UUID: disk.FilesystemDataUUID,
 				Payload: &disk.Filesystem{


### PR DESCRIPTION
Use storage capacity multiple constants in partition tables of all distro definitions.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
