### PR TITLE
templates/packer: Append distro and architecture to the ami name

### DIFF
--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -38,7 +38,7 @@ build {
     }
 
     # Set a name for the resulting AMI.
-    ami_name = "${var.image_name}"
+    ami_name = "${var.image_name}-rhel-8-x86_64"
 
     # Apply tags to the resulting AMI/EBS snapshot.
     tags = {
@@ -72,7 +72,7 @@ build {
     }
 
     # Set a name for the resulting AMI.
-    ami_name = "${var.image_name}"
+    ami_name = "${var.image_name}-rhel-8-aarch64"
 
     # Apply tags to the resulting AMI/EBS snapshot.
     tags = {


### PR DESCRIPTION
Because the rhel-8 images share the same name, and `force_deregister` is true, packer will always deregister one of them.

---

These still conform to the ` '^osbuild-composer-worker.*'` sharing regex