### PR TITLE
test: Add Fedora 36 and 37 and remove 35 test for ostree.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -355,9 +355,8 @@ OSTree:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/fedora-35-x86_64
-          # - rhos-01/fedora-36-x86_64
-          # - rhos-01/fedora-37-x86_64
+          - rhos-01/fedora-36-x86_64
+          - rhos-01/fedora-37-x86_64
           - rhos-01/rhel-8.4-ga-x86_64
           - rhos-01/rhel-8.6-ga-x86_64
           - rhos-01/rhel-9.0-ga-x86_64
@@ -375,7 +374,6 @@ New OSTree:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/fedora-35-x86_64
           - rhos-01/fedora-36-x86_64
           - rhos-01/fedora-37-x86_64
           - rhos-01/rhel-8.7-nightly-x86_64

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -15,14 +15,6 @@ fi
 
 # Set os-variant and boot location used by virt-install.
 case "${ID}-${VERSION_ID}" in
-    "fedora-35")
-        IMAGE_TYPE=iot-commit
-        OSTREE_REF="fedora/35/${ARCH}/iot"
-        OS_VARIANT="fedora35"
-        USER_IN_COMMIT="false"
-        BOOT_LOCATION="https://mirrors.rit.edu/fedora/fedora/linux/releases/35/Everything/x86_64/os/"
-        EMBEDED_CONTAINER="false"
-        ;;
     "fedora-36")
         IMAGE_TYPE=iot-commit
         OSTREE_REF="fedora/36/${ARCH}/iot"


### PR DESCRIPTION
1. Fedora 35 will be EOL, it's removed from `ostree.sh` and enable __Fedora 36__ and __37__ instead.
2. Fedora 35 is removed from `ostree-ng.sh` as well.