### PR TITLE
test: User in commit will not be supported after osbuild-composer 64

### DIFF
--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -297,6 +297,27 @@ name = "kernel-rt"
 EOF
 fi
 
+# User in raw image blueprint is not for RHEL 9.1 and 8.7
+# Workaround for RHEL 9.1 and 8.7 nightly test
+# Check osbuild-composer version first
+if ! nvrGreaterOrEqual "osbuild-composer" "64"; then
+    USER_IN_RAW="false"
+else
+    USER_IN_RAW="true"
+fi
+
+if [[ "$USER_IN_RAW" == "false" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.user]]
+name = "admin"
+description = "Administrator account"
+password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
+key = "${SSH_KEY_PUB}"
+home = "/home/admin/"
+groups = ["wheel"]
+EOF
+fi
+
 greenprint "📄 container blueprint"
 cat "$BLUEPRINT_FILE"
 
@@ -359,7 +380,12 @@ description = "A rhel-edge raw image"
 version = "0.0.1"
 modules = []
 groups = []
+EOF
 
+# User in raw image blueprint is not for RHEL 9.1 and 8.7
+# Workaround for RHEL 9.1 and 8.7 nightly test
+if [[ "$USER_IN_RAW" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [[customizations.user]]
 name = "admin"
 description = "Administrator account"
@@ -368,6 +394,7 @@ key = "${SSH_KEY_PUB}"
 home = "/home/admin/"
 groups = ["wheel"]
 EOF
+fi
 
 greenprint "📄 raw image blueprint"
 cat "$BLUEPRINT_FILE"
@@ -585,6 +612,19 @@ if [[ "$ID" != "fedora" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [customizations.kernel]
 name = "kernel-rt"
+EOF
+fi
+
+# User in raw image blueprint is not for RHEL 9.1 and 8.7
+# Workaround for RHEL 9.1 and 8.7 nightly test
+if [[ "$USER_IN_RAW" == "false" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.user]]
+name = "admin"
+description = "Administrator account"
+password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
+home = "/home/admin/"
+groups = ["wheel"]
 EOF
 fi
 


### PR DESCRIPTION
After osbuild-composer 64, user should be configured in raw-image blueprint. But the old versions do not support user in raw-image blueprint. This PR is to keep them both.