### PR TITLE
spec: bump osbuild dep to >= 65

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-35": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -156,7 +156,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "4bc6e226ea4196b702841add42fe0e0a793c2998"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -233,21 +233,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -293,14 +293,14 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -346,21 +346,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [
@@ -406,7 +406,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "ba218f781d4c7455cd995eea55be09e902370905"
+        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
       }
     },
     "repos": [

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -306,10 +306,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 64
-Requires:   osbuild-ostree >= 63
-Requires:   osbuild-lvm2 >= 63
-Requires:   osbuild-luks2 >= 63
+Requires:   osbuild >= 65
+Requires:   osbuild-ostree >= 65
+Requires:   osbuild-lvm2 >= 65
+Requires:   osbuild-luks2 >= 65
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker


### PR DESCRIPTION
osbuild 65 got support for gpgkeypaths in the ostree.remotes stage that we need for iot-raw-image implemented recently.

See
https://github.com/osbuild/osbuild/commit/2bff83364b69f974b697e56b7094a24eeb83b37b

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
